### PR TITLE
Add other return FillTypes to serial algorithm

### DIFF
--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -1,9 +1,11 @@
-from ._contourpy import Mpl2014ContourGenerator, SerialContourGenerator
+from ._contourpy import (
+    FillType, Mpl2014ContourGenerator, SerialContourGenerator)
 from ._mpl2005 import Cntr as Mpl2005ContourGenerator
 import numpy as np
 
 
-def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=0):
+def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=0,
+                      fill_type=None):
     x = np.asarray(x, dtype=np.float64)
     y = np.asarray(y, dtype=np.float64)
     z = np.ma.asarray(z, dtype=np.float64)  # Preserve mask if present.
@@ -35,6 +37,12 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=0):
         if corner_mask:
             raise ValueError('serial contour generator does not support corner_mask=True')
 
+        if fill_type is None:
+            fill_type = SerialContourGenerator.default_fill_type
+
+        if not SerialContourGenerator.supports_fill_type(fill_type):
+            raise ValueError(f'serial contour generator does not support fill_type of {fill_type}')
+
         if isinstance(chunk_size, tuple) and len(chunk_size) == 2:
             y_chunk_size, x_chunk_size = chunk_size
         else:
@@ -44,10 +52,14 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=0):
             raise ValueError('chunk_size cannot be negative')
 
         cont_gen = SerialContourGenerator(
-            x, y, z, mask, x_chunk_size=x_chunk_size, y_chunk_size=y_chunk_size)
+            x, y, z, mask, fill_type, x_chunk_size=x_chunk_size,
+            y_chunk_size=y_chunk_size)
     else:
         if chunk_size < 0:
             raise ValueError('chunk_size cannot be negative')
+
+        if fill_type not in (None, FillType.OuterCodes):
+            raise ValueError(f'{name} contour generator does not support fill_type {fill_type}')
 
         if name == 'mpl2014':
             if corner_mask is None:

--- a/lib/contourpy/util/mpl_util.py
+++ b/lib/contourpy/util/mpl_util.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+
+def mpl_codes_to_offsets(codes):
+    offsets = np.nonzero(codes == 1)[0]
+    offsets = np.append(offsets, len(codes))
+    return offsets
+
+
+def offsets_to_mpl_codes(offsets):
+    codes = np.full(offsets[-1]-offsets[0], 2, dtype=np.uint8)  # LINETO = 2
+    codes[offsets[:-1]] = 1  # MOVETO = 1
+    codes[offsets[1:]-1] = 79  # CLOSEPOLY 79
+    return codes

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ _contourpy = Pybind11Extension(
     'contourpy._contourpy',
     sources=[
         'src/chunk_local.cpp',
+        'src/fill_type.cpp',
         'src/mpl2014.cpp',
         'src/outer_or_hole.cpp',
         'src/serial.cpp',

--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,13 @@
 
 namespace py = pybind11;
 
+// Input numpy array classes.
 typedef py::array_t<double, py::array::c_style | py::array::forcecast> CoordinateArray;
 typedef py::array_t<bool,   py::array::c_style | py::array::forcecast> MaskArray;
+
+// Output numpy array classes.
+typedef py::array_t<double>  PointArray;
+typedef py::array_t<uint8_t> CodeArray;
+typedef py::array_t<int32_t> OffsetArray;
 
 #endif // CONTOURPY_COMMON_H

--- a/src/fill_type.cpp
+++ b/src/fill_type.cpp
@@ -1,0 +1,27 @@
+#include "fill_type.h"
+#include <iostream>
+
+std::ostream &operator<<(std::ostream &os, const FillType& fill_type)
+{
+    switch (fill_type) {
+        case FillType::OuterCodes:
+            os << "OuterCodes";
+            break;
+        case FillType::OuterOffsets:
+            os << "OuterOffsets";
+            break;
+        case FillType::CombinedCodes:
+            os << "CombinedCodes";
+            break;
+        case FillType::CombinedOffsets:
+            os << "CombinedOffsets";
+            break;
+        case FillType::CombinedCodesOffsets:
+            os << "CombinedCodesOffsets";
+            break;
+        case FillType::CombinedOffsets2:
+            os << "CombinedOffsets2";
+            break;
+    }
+    return os;
+}

--- a/src/fill_type.h
+++ b/src/fill_type.h
@@ -1,0 +1,19 @@
+#ifndef CONTOURPY_FILL_TYPE_H
+#define CONTOURPY_FILL_TYPE_H
+
+#include <iosfwd>
+
+// C++11 scoped enum, must be fully qualified to use.
+enum class FillType
+{
+    OuterCodes = 1,
+    OuterOffsets = 2,
+    CombinedCodes = 3,
+    CombinedOffsets = 4,
+    CombinedCodesOffsets = 5,
+    CombinedOffsets2 = 6,
+};
+
+std::ostream &operator<<(std::ostream &os, const FillType& fill_type);
+
+#endif // CONTOURPY_FILL_TYPE_H

--- a/src/mpl2014.cpp
+++ b/src/mpl2014.cpp
@@ -389,7 +389,7 @@ void Mpl2014ContourGenerator::append_contour_line_to_vertices(
 {
     // Convert ContourLine to python equivalent, and clear it.
     py::ssize_t dims[2] = {static_cast<py::ssize_t>(contour_line.size()), 2};
-    py::array_t<double> line(dims);
+    PointArray line(dims);
 
     double* ptr = line.mutable_data();
     for (ContourLine::const_iterator point = contour_line.begin();
@@ -433,11 +433,11 @@ void Mpl2014ContourGenerator::append_contour_to_vertices_and_codes(
                  npoints += static_cast<py::ssize_t>((*children_it)->size() + 1);
 
             py::ssize_t vertices_dims[2] = {npoints, 2};
-            py::array_t<double> vertices(vertices_dims);
+            PointArray vertices(vertices_dims);
             double* vertices_ptr = vertices.mutable_data();
 
             py::ssize_t codes_dims[1] = {npoints};
-            py::array_t<unsigned char> codes(codes_dims);
+            CodeArray codes(codes_dims);
             unsigned char* codes_ptr = codes.mutable_data();
 
             for (point = line.begin(); point != line.end(); ++point) {

--- a/src/serial.h
+++ b/src/serial.h
@@ -2,7 +2,9 @@
 #define CONTOURPY_SERIAL_H
 
 #include "common.h"
+#include "fill_type.h"
 #include "outer_or_hole.h"
+#include <vector>
 
 // Forward declarations.
 class ChunkLocal;
@@ -12,19 +14,25 @@ class SerialContourGenerator
 public:
     SerialContourGenerator(
         const CoordinateArray& x, const CoordinateArray& y,
-        const CoordinateArray& z, const MaskArray& mask, long x_chunk_size,
-        long y_chunk_size);
+        const CoordinateArray& z, const MaskArray& mask, FillType fill_type,
+        long x_chunk_size, long y_chunk_size);
 
     ~SerialContourGenerator();
 
     py::tuple contour_filled(
         const double& lower_level, const double& upper_level);
 
+    static FillType default_fill_type();
+
     py::tuple get_chunk_count() const;
 
     py::tuple get_chunk_size() const;
 
     bool get_corner_mask() const;
+
+    FillType get_fill_type() const;
+
+    static bool supports_fill_type(FillType fill_type);
 
     void write_cache() const;  // For debug purposes only.
 
@@ -97,8 +105,7 @@ private:
     void set_look_flags(long hole_start_quad);
 
     void single_chunk_filled(
-        long chunk, ChunkLocal& local, py::list& vertices_list,
-        py::list& codes_list);
+        long chunk, ChunkLocal& local, std::vector<py::list>& return_lists);
 
     void write_cache_quad(long quad) const;
 
@@ -110,12 +117,17 @@ private:
     const long _nx_chunks, _ny_chunks;  // Number of chunks in each direction.
     const long _n_chunks;               // Total number of chunks.
     const long _x_chunk_size, _y_chunk_size;
+    const FillType _fill_type;
 
     CacheItem* _cache;
 
     // Current contouring operation.
     bool _filled;
     double _lower_level, _upper_level;
+
+    // Current contouring operation, based on return type and filled or lines.
+    bool _identify_holes;
+    unsigned int _return_list_count;
 };
 
 #endif // CONTOURPY_SERIAL_H

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -1,6 +1,7 @@
 #include "common.h"
 #include "mpl2014.h"
 #include "serial.h"
+#include "fill_type.h"
 
 PYBIND11_MODULE(_contourpy, m) {
     m.doc() = "doc notes";
@@ -21,29 +22,49 @@ PYBIND11_MODULE(_contourpy, m) {
              py::arg("chunk_size") = 0)
         .def("contour_filled",
              &mpl2014::Mpl2014ContourGenerator::contour_filled)
-        .def("contour_lines",
-             &mpl2014::Mpl2014ContourGenerator::contour_lines);
+        .def("contour_lines", &mpl2014::Mpl2014ContourGenerator::contour_lines)
+        .def_property_readonly_static(
+            "fill_type",
+            [](py::object /* self */) {return FillType::OuterCodes;});
 
     py::class_<SerialContourGenerator>(m, "SerialContourGenerator")
         .def(py::init<const CoordinateArray&,
                       const CoordinateArray&,
                       const CoordinateArray&,
                       const MaskArray&,
+                      FillType,
                       long,
                       long>(),
              py::arg("x"),
              py::arg("y"),
              py::arg("z"),
              py::arg("mask"),
+             py::arg("fill_type"),
              py::kw_only(),
              py::arg("x_chunk_size") = 0,
              py::arg("y_chunk_size") = 0)
         .def("contour_filled", &SerialContourGenerator::contour_filled)
         .def("write_cache", &SerialContourGenerator::write_cache)
-        .def_property_readonly("chunk_count",
-                               &SerialContourGenerator::get_chunk_count)
-        .def_property_readonly("chunk_size",
-                               &SerialContourGenerator::get_chunk_size)
-        .def_property_readonly("corner_mask",
-                               &SerialContourGenerator::get_corner_mask);
+        .def_property_readonly(
+            "chunk_count", &SerialContourGenerator::get_chunk_count)
+        .def_property_readonly(
+            "chunk_size", &SerialContourGenerator::get_chunk_size)
+        .def_property_readonly(
+            "fill_type", &SerialContourGenerator::get_fill_type)
+        .def_property_readonly_static(
+            "default_fill_type",
+            [](py::object /* self */) {
+                return SerialContourGenerator::default_fill_type();
+            })
+        .def_static(
+            "supports_fill_type", &SerialContourGenerator::supports_fill_type);
+
+    py::enum_<FillType>(m, "FillType")
+        .value("OuterCodes", FillType::OuterCodes)
+        .value("OuterOffsets", FillType::OuterOffsets)
+        .value("CombinedCodes", FillType::CombinedCodes)
+        .value("CombinedOffsets", FillType::CombinedOffsets)
+        .value("CombinedCodesOffsets", FillType::CombinedCodesOffsets)
+        .value("CombinedOffsets2", FillType::CombinedOffsets2)
+        .export_values();
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-import contourpy
 from image_comparison import compare_images
 import pytest
 import util_config

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,18 @@
+from contourpy import FillType
+import pytest
+import util_test
+
+
+@pytest.mark.parametrize('name, value', util_test.all_fill_types_str_value())
+def test_fill_type(name, value):
+    t = FillType.__members__[name]
+    assert t.name == name
+    assert t.value == value
+
+
+def test_all_fill_types():
+    # Check that all_fill_types() matches FillType.__members__
+    fill_types = dict(util_test.all_fill_types_str_value())
+    for name, enum in dict(FillType.__members__).items():
+        assert(name in fill_types)
+        assert(fill_types[name] == enum.value)

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -1,21 +1,33 @@
-from contourpy import contour_generator
+from contourpy import contour_generator, FillType
 from contourpy.util import random_uniform, MplTestRenderer
 from image_comparison import compare_images
 import numpy as np
+from numpy.testing import assert_array_equal
 import pytest
 import util_test
 
 
-@pytest.mark.parametrize('name', util_test.all_names())
-def test_filled_random_uniform_no_corner_mask(name):
+@pytest.fixture
+def two_outers_one_hole():
+    x, y = np.meshgrid([0., 1., 2., 3.], [0., 1., 2.])
+    z = np.array([[1.5, 1.5, 0.9, 0.0],
+                  [1.5, 2.8, 0.4, 0.8],
+                  [0.0, 0.0, 0.8, 1.9]])
+    return x, y, z
+
+
+@pytest.mark.parametrize(
+    'name, fill_type', util_test.all_names_and_fill_types())
+def test_filled_random_uniform_no_corner_mask(name, fill_type):
     x, y, z = random_uniform((30, 40), mask_fraction=0.05)
-    cont_gen = contour_generator(x, y, z, name=name, corner_mask=False)
+    cont_gen = contour_generator(
+        x, y, z, name=name, fill_type=fill_type, corner_mask=False)
     levels = np.arange(0.0, 1.01, 0.2)
 
     renderer = MplTestRenderer(x, y)
     for i in range(len(levels)-1):
         renderer.filled(cont_gen.contour_filled(levels[i], levels[i+1]),
-                        color=f'C{i}')
+                        fill_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, 'filled_random_uniform_no_corner_mask.png',
@@ -28,10 +40,96 @@ def test_filled_random_uniform_corner_mask(name):
     cont_gen = contour_generator(x, y, z, name=name, corner_mask=True)
     levels = np.arange(0.0, 1.01, 0.2)
 
+    fill_type = \
+        cont_gen.fill_type if name != 'mpl2005' else FillType.OuterCodes
+
     renderer = MplTestRenderer(x, y)
     for i in range(len(levels)-1):
         renderer.filled(cont_gen.contour_filled(levels[i], levels[i+1]),
-                        color=f'C{i}')
+                        fill_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, 'filled_random_uniform_corner_mask.png', name)
+
+
+@pytest.mark.parametrize('fill_type', FillType.__members__.values())
+@pytest.mark.parametrize('name', ['serial'])
+def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
+    x, y, z = two_outers_one_hole
+    cont_gen = contour_generator(x, y, z, name, fill_type=fill_type)
+    assert cont_gen.fill_type == fill_type
+    filled = cont_gen.contour_filled(1.0, 2.0)
+    if fill_type in (FillType.OuterCodes, FillType.OuterOffsets):
+        assert isinstance(filled, tuple) and len(filled) == 2
+        points = filled[0]
+        assert isinstance(points, list) and len(points) == 2
+        for p in points:
+            assert isinstance(p, np.ndarray)
+            assert p.dtype == np.float64
+        assert points[0].shape == (13, 2)
+        assert points[1].shape == (4, 2)
+        assert_array_equal(points[0][0], points[0][7])
+        assert_array_equal(points[0][8], points[0][12])
+        assert_array_equal(points[1][0], points[1][3])
+        if fill_type == FillType.OuterCodes:
+            codes = filled[1]
+            assert isinstance(codes, list) and len(codes) == 2
+            for c in codes:
+                assert isinstance(c, np.ndarray)
+                assert c.dtype == np.uint8
+            assert_array_equal(codes[0], [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79])
+            assert_array_equal(codes[1], [1, 2, 2, 79])
+        else:  # FillType.OuterOffsets.
+            offsets = filled[1]
+            assert isinstance(offsets, list) and len(offsets) == 2
+            for o in offsets:
+                assert isinstance(o, np.ndarray)
+                assert o.dtype == np.int32
+            assert_array_equal(offsets[0], [0, 8, 13])
+            assert_array_equal(offsets[1], [0, 4])
+    elif fill_type in (FillType.CombinedCodes, FillType.CombinedOffsets,
+                       FillType.CombinedCodesOffsets,
+                       FillType.CombinedOffsets2):
+        if fill_type in (FillType.CombinedCodes, FillType.CombinedOffsets):
+            assert isinstance(filled, tuple) and len(filled) == 2
+        else:
+            assert isinstance(filled, tuple) and len(filled) == 3
+        points = filled[0]
+        assert isinstance(points, list) and len(points) == 1
+        points = points[0]
+        assert isinstance(points, np.ndarray)
+        assert points.dtype == np.float64
+        assert points.shape == (17, 2)
+        assert_array_equal(points[0], points[7])
+        assert_array_equal(points[8], points[12])
+        assert_array_equal(points[13], points[16])
+        if fill_type in (FillType.CombinedCodes,
+                         FillType.CombinedCodesOffsets):
+            codes = filled[1]
+            assert isinstance(codes, list) and len(codes) == 1
+            codes = codes[0]
+            assert isinstance(codes, np.ndarray)
+            assert codes.dtype == np.uint8
+            assert_array_equal(
+                codes, [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79, 1, 2, 2, 79])
+        else:
+            offsets = filled[1]
+            assert isinstance(offsets, list) and len(offsets) == 1
+            offsets = offsets[0]
+            assert isinstance(offsets, np.ndarray)
+            assert offsets.dtype == np.int32
+            assert_array_equal(offsets, [0, 8, 13, 17])
+
+        if fill_type in (FillType.CombinedCodesOffsets,
+                         FillType.CombinedOffsets2):
+            outer_offsets = filled[2]
+            assert isinstance(outer_offsets, list) and len(outer_offsets) == 1
+            outer_offsets = outer_offsets[0]
+            assert isinstance(outer_offsets, np.ndarray)
+            assert outer_offsets.dtype == np.int32
+            if fill_type == FillType.CombinedCodesOffsets:
+                assert_array_equal(outer_offsets, [0, 13, 17])
+            else:
+                assert_array_equal(outer_offsets, [0, 2, 3])
+    else:
+        raise RuntimeError(f'Unexpected fill_type {fill_type}')

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,8 +1,33 @@
+from contourpy import FillType
 
 
 def all_names():
     return ['mpl2014', 'mpl2005', 'serial']
 
 
+def all_names_and_fill_types():
+    return [
+        ('mpl2014', FillType.OuterCodes),
+        ('mpl2005', FillType.OuterCodes),
+        ('serial', FillType.OuterCodes),
+        ('serial', FillType.OuterOffsets),
+        ('serial', FillType.CombinedCodes),
+        ('serial', FillType.CombinedOffsets),
+        ('serial', FillType.CombinedCodesOffsets),
+        ('serial', FillType.CombinedOffsets2),
+    ]
+
+
 def corner_mask_names():
     return ['mpl2014']
+
+
+def all_fill_types_str_value():
+    return [
+        ('OuterCodes', 1),
+        ('OuterOffsets', 2),
+        ('CombinedCodes', 3),
+        ('CombinedOffsets', 4),
+        ('CombinedCodesOffsets', 5),
+        ('CombinedOffsets2', 6),
+    ]


### PR DESCRIPTION
Added FillType C++ enum for returned fill type, and wrapped this using pybind11 so can be used in Python.

Implemented 6 different fill types: using mpl codes or offsets, and either combined together (single numpy array of points per chunk) or combined via outer lines.