### PR TITLE
Contour lines in serial algorithm, no corner mask

### DIFF
--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -1,11 +1,11 @@
 from ._contourpy import (
-    FillType, Mpl2014ContourGenerator, SerialContourGenerator)
+    FillType, LineType, Mpl2014ContourGenerator, SerialContourGenerator)
 from ._mpl2005 import Cntr as Mpl2005ContourGenerator
 import numpy as np
 
 
 def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=0,
-                      fill_type=None):
+                      fill_type=None, line_type=None):
     x = np.asarray(x, dtype=np.float64)
     y = np.asarray(y, dtype=np.float64)
     z = np.ma.asarray(z, dtype=np.float64)  # Preserve mask if present.
@@ -37,11 +37,15 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=0,
         if corner_mask:
             raise ValueError('serial contour generator does not support corner_mask=True')
 
+        if line_type is None:
+            line_type = SerialContourGenerator.default_line_type
+        if not SerialContourGenerator.supports_line_type(line_type):
+            raise ValueError(f'serial contour generator does not support line_type {line_type}')
+
         if fill_type is None:
             fill_type = SerialContourGenerator.default_fill_type
-
         if not SerialContourGenerator.supports_fill_type(fill_type):
-            raise ValueError(f'serial contour generator does not support fill_type of {fill_type}')
+            raise ValueError(f'serial contour generator does not support fill_type {fill_type}')
 
         if isinstance(chunk_size, tuple) and len(chunk_size) == 2:
             y_chunk_size, x_chunk_size = chunk_size
@@ -52,11 +56,14 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=0,
             raise ValueError('chunk_size cannot be negative')
 
         cont_gen = SerialContourGenerator(
-            x, y, z, mask, fill_type, x_chunk_size=x_chunk_size,
+            x, y, z, mask, line_type, fill_type, x_chunk_size=x_chunk_size,
             y_chunk_size=y_chunk_size)
     else:
         if chunk_size < 0:
             raise ValueError('chunk_size cannot be negative')
+
+        if line_type not in (None, LineType.Separate):
+            raise ValueError(f'{name} contour generator does not support line_type {line_type}')
 
         if fill_type not in (None, FillType.OuterCodes):
             raise ValueError(f'{name} contour generator does not support fill_type {fill_type}')

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -6,7 +6,7 @@ import matplotlib
 _default_backend = matplotlib.get_backend()
 matplotlib.use('Agg')
 
-from contourpy import FillType
+from contourpy import FillType, LineType
 from .mpl_util import mpl_codes_to_offsets, offsets_to_mpl_codes
 import io
 import matplotlib.pyplot as plt
@@ -62,15 +62,20 @@ class MplRenderer:
         ax = self._get_ax(ax)
         ax.plot(x, y, x.T, y.T, color=color, alpha=alpha)
 
-    def lines(self, lines, ax=0, color='C0', alpha=1.0):
+    def lines(self, lines, line_type, ax=0, color='C0', alpha=1.0,
+              linewidth=1):
         ax = self._get_ax(ax)
-        paths = []
-        for line in lines:
-            # Drawing as Paths so that they can be closed correctly.
-            closed = line[0, 0] == line[-1, 0] and line[0, 1] == line[-1, 1]
-            paths.append(mpath.Path(line, closed=closed))
+        if line_type == LineType.Separate:
+            paths = []
+            for line in lines:
+                # Drawing as Paths so that they can be closed correctly.
+                closed = line[0, 0] == line[-1, 0] and line[0, 1] == line[-1, 1]
+                paths.append(mpath.Path(line, closed=closed))
+        else:
+            raise RuntimeError(f'Rendering LineType {line_type} not implemented')
         collection = mcollections.PathCollection(
-            paths, facecolors='none', edgecolors=color, lw=1, alpha=alpha)
+            paths, facecolors='none', edgecolors=color, lw=linewidth,
+            alpha=alpha)
         ax.add_collection(collection)
 
     def save_to_buffer(self):
@@ -78,6 +83,9 @@ class MplRenderer:
         self.fig.savefig(buf, format='png')
         buf.seek(0)
         return buf
+
+    def save(self, filename):
+        self.fig.savefig(filename)
 
     def show(self):
         plt.show()
@@ -184,6 +192,33 @@ class MplDebugRenderer(MplRenderer):
                             points[:, 1][start_indices], 'o',
                             c=start_point_color, alpha=alpha)
 
+    def lines(self, lines, line_type, ax=0, color='C0', alpha=1.0, linewidth=1,
+              point_color='C0', start_point_color='red', arrow_size=0.1):
+        super().lines(lines, line_type, ax, color, alpha, linewidth)
+
+        ax = self._get_ax(ax)
+
+        if arrow_size > 0.0:
+            # LineType.Separate
+            for line in lines:
+                for i in range(len(line)-1):
+                    self._arrow(ax, line[i], line[i+1], color, alpha,
+                                arrow_size)
+
+        if point_color is not None:
+            for line in lines:
+                start_index = 0
+                end_index = len(line)
+                if start_point_color is not None:
+                    ax.plot(line[0, 0], line[0, 1], 'o', c=start_point_color,
+                            alpha=alpha)
+                    start_index = 1
+                    if line[0][0] == line[-1][0] and line[-1][0] == line[-1][1]:
+                        end_index -= 1
+                ax.plot(line[start_index:end_index, 0],
+                        line[start_index:end_index, 1], 'o', c=color,
+                        alpha=alpha)
+
     def point_numbers(self, x, y, z, ax=0, color='red'):
         ax = self._get_ax(ax)
         ny, nx = z.shape
@@ -204,13 +239,14 @@ class MplDebugRenderer(MplRenderer):
                 ax.text(xmid, ymid, str(quad), ha='center', va='center',
                         color=color, clip_on=True)
 
-    def z_levels(self, x, y, z, lower_level, upper_level, ax=0, color='green'):
+    def z_levels(self, x, y, z, lower_level, upper_level=None, ax=0,
+                 color='green'):
         ax = self._get_ax(ax)
         ny, nx = z.shape
         for j in range(ny):
             for i in range(nx):
                 zz = z[j,i]
-                if zz > upper_level:
+                if upper_level is not None and zz > upper_level:
                     z_level = 2
                 elif zz > lower_level:
                     z_level = 1

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ _contourpy = Pybind11Extension(
     sources=[
         'src/chunk_local.cpp',
         'src/fill_type.cpp',
+        'src/line_type.cpp',
         'src/mpl2014.cpp',
         'src/outer_or_hole.cpp',
         'src/serial.cpp',

--- a/src/line_type.cpp
+++ b/src/line_type.cpp
@@ -1,0 +1,12 @@
+#include "line_type.h"
+#include <iostream>
+
+std::ostream &operator<<(std::ostream &os, const LineType& line_type)
+{
+    switch (line_type) {
+        case LineType::Separate:
+            os << "Separate";
+            break;
+    }
+    return os;
+}

--- a/src/line_type.h
+++ b/src/line_type.h
@@ -1,0 +1,14 @@
+#ifndef CONTOURPY_LINE_TYPE_H
+#define CONTOURPY_LINE_TYPE_H
+
+#include <iosfwd>
+
+// C++11 scoped enum, must be fully qualified to use.
+enum class LineType
+{
+    Separate = 0,
+};
+
+std::ostream &operator<<(std::ostream &os, const LineType& line_type);
+
+#endif // CONTOURPY_LINE_TYPE_H

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -13,54 +13,62 @@
 
 // CacheItem masks, only accessed directly to set.  To read, use accessors
 // detailed below.  1 and 2 refer to level indices (lower and upper).
-#define MASK_Z_LEVEL            0x0003 // Combines the following two.
-#define MASK_Z_LEVEL_1          0x0001 // z > lower_level.
-#define MASK_Z_LEVEL_2          0x0002 // z > upper_level.
-#define MASK_SADDLE             0x000c // Combining the following two
-#define MASK_SADDLE_Z_LEVEL_1   0x0004 // saddle z > lower_level
-#define MASK_SADDLE_Z_LEVEL_2   0x0008 // saddle z > upper_level
-#define MASK_BOUNDARY_N         0x0010 // N edge of quad is a boundary.
-#define MASK_BOUNDARY_E         0x0020 // E edge of quad is a boundary.
-#define MASK_EXISTS_QUAD        0x0040 // All of quad exists (is not masked).
-#define MASK_EXISTS             0x0040 // copy of above
-#define MASK_START_N            0x0080 // N to E
-#define MASK_START_E            0x0100 // E to N
-#define MASK_START_BOUNDARY_W   0x0400
-#define MASK_START_BOUNDARY_S   0x0800
-#define MASK_START_HOLE_N       0x0200 // N boundary of EXISTS, E to W.
-#define MASK_ANY_START          0x0f80 // Combines all the above starts.
-#define MASK_LOOK_N             0x1000
-#define MASK_LOOK_S             0x2000
-#define MASK_NO_STARTS_IN_ROW   0x4000
-#define MASK_NO_MORE_STARTS     0x8000
+#define MASK_Z_LEVEL_1        0x0001 // z > lower_level.
+#define MASK_Z_LEVEL_2        0x0002 // z > upper_level.
+#define MASK_Z_LEVEL          (MASK_Z_LEVEL_1 | MASK_Z_LEVEL_2)
+#define MASK_SADDLE_Z_LEVEL_1 0x0004 // saddle z > lower_level
+#define MASK_SADDLE_Z_LEVEL_2 0x0008 // saddle z > upper_level
+#define MASK_SADDLE           (MASK_SADDLE_Z_LEVEL_1 | MASK_SADDLE_Z_LEVEL_2)
+#define MASK_BOUNDARY_N       0x0010 // N edge of quad is a boundary.
+#define MASK_BOUNDARY_E       0x0020 // E edge of quad is a boundary.
+#define MASK_EXISTS_QUAD      0x0040 // All of quad exists (is not masked).
+#define MASK_EXISTS           MASK_EXISTS_QUAD
+#define MASK_START_N          0x0080 // N to E
+#define MASK_START_E          0x0100 // E to N
+#define MASK_START_BOUNDARY_E 0x0200 // Filled and lines.
+#define MASK_START_BOUNDARY_N 0x0400 // Filled and lines.
+#define MASK_START_BOUNDARY_S 0x0800 // Filled only.
+#define MASK_START_BOUNDARY_W 0x1000 // Filled only.
+#define MASK_START_HOLE_N     0x2000 // N boundary of EXISTS, E to W, filled only.
+#define MASK_ANY_START_FILLED (MASK_START_N | MASK_START_E | MASK_START_BOUNDARY_W | MASK_START_BOUNDARY_S | MASK_START_HOLE_N)
+#define MASK_ANY_START_LINES  (MASK_START_N | MASK_START_E | MASK_START_BOUNDARY_W | MASK_START_BOUNDARY_S | MASK_START_BOUNDARY_N | MASK_START_BOUNDARY_E)
+#define MASK_LOOK_N           0x4000
+#define MASK_LOOK_S           0x8000
+#define MASK_NO_STARTS_IN_ROW 0x10000
+#define MASK_NO_MORE_STARTS   0x20000
 
 // Accessors for various CacheItem masks.
-#define Z_LEVEL(quad)           (_cache[quad] & MASK_Z_LEVEL)
-#define Z_NE                    Z_LEVEL(POINT_NE)
-#define Z_NW                    Z_LEVEL(POINT_NW)
-#define Z_SE                    Z_LEVEL(POINT_SE)
-#define Z_SW                    Z_LEVEL(POINT_SW)
-#define SADDLE_SET(quad)        ((_cache[quad] & MASK_SADDLE) != MASK_SADDLE)
-#define SADDLE_Z_LEVEL(quad)    (SADDLE_SET(quad) ? ((_cache[quad] & MASK_SADDLE) >> 2) : calc_z_level_mid(quad))
-#define BOUNDARY_N(quad)        (_cache[quad] & MASK_BOUNDARY_N)
-#define BOUNDARY_E(quad)        (_cache[quad] & MASK_BOUNDARY_E)
-#define EXISTS_QUAD(quad)       ((_cache[quad] & MASK_EXISTS) == MASK_EXISTS_QUAD)
-#define START_N(quad)           (_cache[quad] & MASK_START_N)
-#define START_E(quad)           (_cache[quad] & MASK_START_E)
-#define START_BOUNDARY_W(quad)  (_cache[quad] & MASK_START_BOUNDARY_W)
-#define START_BOUNDARY_S(quad)  (_cache[quad] & MASK_START_BOUNDARY_S)
-#define START_HOLE_N(quad)      (_cache[quad] & MASK_START_HOLE_N)
-#define ANY_START(quad)         (_cache[quad] & MASK_ANY_START)
-#define LOOK_N(quad)            (_cache[quad] & MASK_LOOK_N)
-#define LOOK_S(quad)            (_cache[quad] & MASK_LOOK_S)
-#define NO_STARTS_IN_ROW(quad)  (_cache[quad] & MASK_NO_STARTS_IN_ROW)
-#define NO_MORE_STARTS(quad)    (_cache[quad] & MASK_NO_MORE_STARTS)
+#define Z_LEVEL(quad)          (_cache[quad] & MASK_Z_LEVEL)
+#define Z_NE                   Z_LEVEL(POINT_NE)
+#define Z_NW                   Z_LEVEL(POINT_NW)
+#define Z_SE                   Z_LEVEL(POINT_SE)
+#define Z_SW                   Z_LEVEL(POINT_SW)
+#define SADDLE_SET(quad)       ((_cache[quad] & MASK_SADDLE) != MASK_SADDLE)
+#define SADDLE_Z_LEVEL(quad)   (SADDLE_SET(quad) ? ((_cache[quad] & MASK_SADDLE) >> 2) : calc_z_level_mid(quad))
+#define BOUNDARY_N(quad)       (_cache[quad] & MASK_BOUNDARY_N)
+#define BOUNDARY_E(quad)       (_cache[quad] & MASK_BOUNDARY_E)
+#define BOUNDARY_S(quad)       (_cache[quad-_nx] & MASK_BOUNDARY_N)
+#define BOUNDARY_W(quad)       (_cache[quad-1] & MASK_BOUNDARY_E)
+#define EXISTS_QUAD(quad)      ((_cache[quad] & MASK_EXISTS) == MASK_EXISTS_QUAD)
+#define START_N(quad)          (_cache[quad] & MASK_START_N)
+#define START_E(quad)          (_cache[quad] & MASK_START_E)
+#define START_BOUNDARY_E(quad) (_cache[quad] & MASK_START_BOUNDARY_E)
+#define START_BOUNDARY_N(quad) (_cache[quad] & MASK_START_BOUNDARY_N)
+#define START_BOUNDARY_S(quad) (_cache[quad] & MASK_START_BOUNDARY_S)
+#define START_BOUNDARY_W(quad) (_cache[quad] & MASK_START_BOUNDARY_W)
+#define START_HOLE_N(quad)     (_cache[quad] & MASK_START_HOLE_N)
+#define ANY_START_FILLED(quad) (_cache[quad] & MASK_ANY_START_FILLED)
+#define ANY_START_LINES(quad)  (_cache[quad] & MASK_ANY_START_LINES)
+#define LOOK_N(quad)           (_cache[quad] & MASK_LOOK_N)
+#define LOOK_S(quad)           (_cache[quad] & MASK_LOOK_S)
+#define NO_STARTS_IN_ROW(quad) (_cache[quad] & MASK_NO_STARTS_IN_ROW)
+#define NO_MORE_STARTS(quad)   (_cache[quad] & MASK_NO_MORE_STARTS)
 
 
 SerialContourGenerator::SerialContourGenerator(
     const CoordinateArray& x, const CoordinateArray& y,
-    const CoordinateArray& z, const MaskArray& mask, FillType fill_type,
-    long x_chunk_size, long y_chunk_size)
+    const CoordinateArray& z, const MaskArray& mask, LineType line_type,
+    FillType fill_type, long x_chunk_size, long y_chunk_size)
     : _x(x),
       _y(y),
       _z(z),
@@ -74,6 +82,7 @@ SerialContourGenerator::SerialContourGenerator(
       _n_chunks(_nx_chunks*_ny_chunks),
       _x_chunk_size(std::ceil((_nx-1.0) / _nx_chunks)),
       _y_chunk_size(std::ceil((_ny-1.0) / _ny_chunks)),
+      _line_type(line_type),
       _fill_type(fill_type),
       _cache(new CacheItem[_n]),
       _filled(false),
@@ -240,11 +249,40 @@ py::tuple SerialContourGenerator::contour_filled(
     return tuple;
 }
 
+py::list SerialContourGenerator::contour_lines(const double& level)
+{
+    _filled = false;
+    _lower_level = _upper_level = level;
+    _identify_holes = false;
+    _return_list_count = 1;
+
+    init_cache_levels_and_starts();
+
+    //std::vector<py::list> return_lists(_return_list_count);
+    py::list return_list;
+
+    ChunkLocal local;
+    for (long chunk = 0; chunk < _n_chunks; ++chunk) {
+        get_chunk_limits(chunk, local);
+        single_chunk_lines(chunk, local, return_list);
+        local.clear();
+    }
+
+    return return_list;
+}
+
 FillType SerialContourGenerator::default_fill_type()
 {
     FillType fill_type = FillType::OuterCodes;
     assert(supports_fill_type(fill_type));
     return fill_type;
+}
+
+LineType SerialContourGenerator::default_line_type()
+{
+    LineType line_type = LineType::Separate;
+    assert(supports_line_type(line_type));
+    return line_type;
 }
 
 long SerialContourGenerator::find_look_S(long look_N_quad) const
@@ -390,6 +428,8 @@ bool SerialContourGenerator::follow_interior(
                                    : (forward == -1 ? quad-_nx : quad));
     long right_point = left_point - left;
 
+    bool want_look_N = _identify_holes && pass > 0;
+
     bool abort = false;     // Whether to about the loop.
     bool finished = false;  // Whether finished line, i.e. returned to start.
     while (!abort) {
@@ -427,11 +467,21 @@ bool SerialContourGenerator::follow_interior(
         // Clear unwanted start locations.
         if (pass == 0 && !(quad == start_quad && forward == start_forward)) {
             if (START_E(quad) && forward == -1 && turn_left == -1 &&
-                ((is_upper && Z_NE > 0) || (!is_upper && Z_NE < 2)))
+                (is_upper ? Z_NE > 0 : Z_NE < 2)) {
                 _cache[quad] &= ~MASK_START_E;  // E high if is_upper else low.
+
+                if (!_filled && quad < start_location.quad)
+                    // Already counted points from here onwards.
+                    break;
+            }
             else if (START_N(quad) && forward < -1 && turn_left == 1 &&
-                     ((is_upper && Z_NW > 0) || (!is_upper && Z_NW < 2)))
+                     (is_upper ? Z_NW > 0 : Z_NW < 2)) {
                 _cache[quad] &= ~MASK_START_N;  // E high if is_upper else low.
+
+                if (!_filled && quad < start_location.quad)
+                    // Already counted points from here onwards.
+                    break;
+            }
         }
 
         // Determine entry edge and left and right points of next quad.
@@ -456,33 +506,42 @@ bool SerialContourGenerator::follow_interior(
             // Edge stays the same.
         }
 
-        if (LOOK_N(quad) && pass > 0 && forward == 1 && _identify_holes) {
+        if (want_look_N && LOOK_N(quad) && forward == 1) {
             // Only consider look_N if pass across E edge of this quad.
             // Care needed if both look_N and look_S set in quad because this
             // line corresponds to only one of them, so want to ignore the
             // look_N if it is the other line otherwise it will be double
             // counted.
-            if (!LOOK_S(quad) ||
-                (is_upper && Z_NE < 2) || (!is_upper && Z_NE > 0))
+            if (!LOOK_S(quad) || (is_upper ? Z_NE < 2 : Z_NE > 0))
                 local.look_up_quads.push_back(quad);
         }
 
         // If reached a boundary, return.
         // quad is always unchanged here.
+        bool reached_boundary = false;
         if (forward == 1 && BOUNDARY_E(quad)) {
             forward = _nx;  // Moving N.
-            break;
+            reached_boundary = true;
         }
         else if (forward > 1 && BOUNDARY_N(quad)) {
             forward = -1;  // Moving W.
-            break;
+            reached_boundary = true;
         }
-        else if (forward == -1 && BOUNDARY_E(quad-1)) {  // BOUNDARY_W(quad)
+        else if (forward == -1 && BOUNDARY_W(quad)) {
             forward = -_nx;  // Moving S.
-            break;
+            reached_boundary = true;
         }
-        else if (forward < -1 && BOUNDARY_N(quad-_nx)) {  // BOUNDARY_S(quad)
+        else if (forward < -1 && BOUNDARY_S(quad)) {
             forward = 1;  // Moving E.
+            reached_boundary = true;
+        }
+
+        if (reached_boundary) {
+            if (!_filled) {
+                point_count++;
+                if (pass > 0)
+                    interp(left_point, right_point, false, local);
+            }
             break;
         }
 
@@ -535,6 +594,11 @@ bool SerialContourGenerator::get_corner_mask() const
 FillType SerialContourGenerator::get_fill_type() const
 {
     return _fill_type;
+}
+
+LineType SerialContourGenerator::get_line_type() const
+{
+    return _line_type;
 }
 
 void SerialContourGenerator::get_point_xy(long point, double*& points) const
@@ -678,14 +742,14 @@ void SerialContourGenerator::init_cache_levels_and_starts()
                         start_in_row = true;
                     }
 
-                    if (BOUNDARY_N(quad-_nx) &&
+                    if (BOUNDARY_S(quad) &&
                         ((z_sw == 2 && z_se < 2) || (z_sw == 0 && z_se > 0) ||
                          z_sw == 1)) {
                         _cache[quad] |= MASK_START_BOUNDARY_S;
                         start_in_row = true;
                     }
 
-                    if (BOUNDARY_E(quad-1) &&
+                    if (BOUNDARY_W(quad) &&
                         ((z_nw == 2 && z_sw < 2) || (z_nw == 0 && z_sw > 0) ||
                          (z_nw == 1 && z_sw != 1))) {
                         _cache[quad] |= MASK_START_BOUNDARY_W;
@@ -719,9 +783,73 @@ void SerialContourGenerator::init_cache_levels_and_starts()
             _cache[1 + (j_final_start+1)*_nx] |= MASK_NO_MORE_STARTS;
     }
     else {
-        assert(0 && "not implemented");
+        long quad = 0;
+        long j_final_start = 0;
+        for (long j = 0; j < _ny; ++j) {
+            ZLevel z_nw = 0, z_sw = 0;
+            bool start_in_row = false;
+            for (long i = 0; i < _nx; ++i, ++quad, ++z_ptr) {
+                _cache[quad] &= keep_mask;
+                _cache[quad] |= MASK_SADDLE;
 
+                // Cache z-level of NE point.
+                ZLevel z_ne = 0;
+                if (*z_ptr > _lower_level) {
+                    _cache[quad] |= MASK_Z_LEVEL_1;
+                    z_ne = 1;
+                }
 
+                // z-level of SE point already calculated if j > 0; not needed
+                // if j == 0.
+                ZLevel z_se = (j > 0 ? Z_SE : 0);
+
+                if (EXISTS_QUAD(quad)) {
+                    if (BOUNDARY_S(quad) && z_sw == 1 && z_se == 0) {
+                        _cache[quad] |= MASK_START_BOUNDARY_S;
+                        start_in_row = true;
+                    }
+
+                    if (BOUNDARY_W(quad) && z_nw == 1 && z_sw == 0) {
+                        _cache[quad] |= MASK_START_BOUNDARY_W;
+                        start_in_row = true;
+                    }
+
+                    if (BOUNDARY_E(quad) && z_se == 1 && z_ne == 0) {
+                        _cache[quad] |= MASK_START_BOUNDARY_E;
+                        start_in_row = true;
+                    }
+
+                    if (BOUNDARY_N(quad) && z_ne == 1 && z_nw == 0) {
+                        _cache[quad] |= MASK_START_BOUNDARY_N;
+                        start_in_row = true;
+                    }
+
+                    if (!BOUNDARY_N(quad) && !BOUNDARY_E(quad)) {
+                        if (z_ne == 0 && z_nw > 0 && z_se > 0 &&
+                            (z_sw > 0 || SADDLE_Z_LEVEL(quad) > 0)) {
+                            _cache[quad] |= MASK_START_E;  // E to N low.
+                            start_in_row = true;
+                        }
+                        else if (z_nw == 0 && z_se == 0 && z_ne > 0 &&
+                                 (z_sw == 0 || SADDLE_Z_LEVEL(quad) == 0)) {
+                            _cache[quad] |= MASK_START_N;  // N to E low.
+                            start_in_row = true;
+                        }
+                    }
+                }
+
+                z_nw = z_ne;
+                z_sw = z_se;
+            } // i-loop.
+
+            if (start_in_row)
+                j_final_start = j;
+            else
+                _cache[1 + j*_nx] |= MASK_NO_STARTS_IN_ROW;
+        } // j-loop.
+
+        if (j_final_start < _ny-1)
+            _cache[1 + (j_final_start+1)*_nx] |= MASK_NO_MORE_STARTS;
     }
 }
 
@@ -762,6 +890,35 @@ bool SerialContourGenerator::is_quad_in_chunk(
 {
     return is_quad_in_bounds(
         quad, local.istart, local.iend, local.jstart, local.jend);
+}
+
+void SerialContourGenerator::line(
+    const Location& start_location, ChunkLocal& local)
+{
+    // start_location.on_boundary indicates starts (and therefore also finishes)
+
+    assert(is_quad_in_chunk(start_location.quad, local));
+
+    Location location = start_location;
+    unsigned long point_count = 0;
+
+    // finished indicates closed line loop.
+    bool finished = follow_interior(
+        location, start_location, local, point_count);
+
+    if (local.pass > 0)
+        local.line_offsets[local.line_count] = local.total_point_count;
+
+    if (local.pass == 0 && !start_location.on_boundary && !finished)
+        // An internal start that isn't a line loop is part of a line strip that
+        // starts on a boundary and will be traced later.  Do not count it as a
+        // valid start in pass 0 and remove the first point or it will be
+        // duplicated by the correct boundary-started line later.
+        point_count--;
+    else
+        local.line_count++;
+
+    local.total_point_count += point_count;
 }
 
 void SerialContourGenerator::move_to_next_boundary_edge(
@@ -867,11 +1024,10 @@ void SerialContourGenerator::set_look_flags(long hole_start_quad)
 void SerialContourGenerator::single_chunk_filled(
     long chunk, ChunkLocal& local, std::vector<py::list>& return_lists)
 {
-    // Allocated at start of pass 1, depending on _fill_type.
+    // Allocated at end of pass 0, depending on _fill_type.
     std::vector<double> all_points;
 
     for (local.pass = 0; local.pass < 2; ++local.pass) {
-
         bool ignore_holes = (_identify_holes && local.pass == 1);
 
         long j_final_start = local.jstart;
@@ -891,7 +1047,7 @@ void SerialContourGenerator::single_chunk_filled(
                                  : local.line_count);
 
             for (long i = local.istart; i <= local.iend; ++i, ++quad) {
-                if (!ANY_START(quad))
+                if (!ANY_START_FILLED(quad))
                     continue;
 
                 if (EXISTS_QUAD(quad)) {
@@ -1104,6 +1260,107 @@ void SerialContourGenerator::single_chunk_filled(
     }
 }
 
+void SerialContourGenerator::single_chunk_lines(
+    long chunk, ChunkLocal& local, py::list& return_list)
+{
+    // Allocated at end of pass 0, depending on _line_type.
+    std::vector<double> all_points;
+
+    for (local.pass = 0; local.pass < 2; ++local.pass) {
+        long j_final_start = local.jstart;
+        for (long j = local.jstart; j <= local.jend; ++j) {
+            long quad = local.istart + j*_nx;
+
+            if (NO_MORE_STARTS(quad))
+                break;
+
+            if (NO_STARTS_IN_ROW(quad))
+                continue;
+
+            // Want to count number of starts in this row, so store how many
+            // starts at start of row.
+            unsigned long prev_start_count = local.line_count;
+
+            for (long i = local.istart; i <= local.iend; ++i, ++quad) {
+                if (!ANY_START_LINES(quad))
+                    continue;
+
+                if (EXISTS_QUAD(quad)) {
+                    if (START_BOUNDARY_S(quad)) {
+                        Location location(quad, _nx, false, true);
+                        line(location, local);
+                    }
+
+                    if (START_BOUNDARY_W(quad)) {
+                        Location location(quad, 1, false, true);
+                        line(location, local);
+                    }
+
+                    if (START_BOUNDARY_E(quad)) {
+                        Location location(quad, -1, false, true);
+                        line(location, local);
+                    }
+
+                    if (START_BOUNDARY_N(quad)) {
+                        Location location(quad, -_nx, false, true);
+                        line(location, local);
+                    }
+
+                    if (START_E(quad)) {
+                        Location location(quad, -1, false, false);
+                        line(location, local);
+                    }
+
+                    if (START_N(quad)) {
+                        Location location(quad, -_nx, false, false);
+                        line(location, local);
+                    }
+                }
+            } // i
+
+            // Number of starts at end of row.
+            if (local.line_count - prev_start_count)
+                j_final_start = j;
+            else
+                _cache[local.istart + j*_nx] |= MASK_NO_STARTS_IN_ROW;
+        } // j
+
+        if (j_final_start < local.jend)
+            _cache[local.istart + (j_final_start+1)*_nx] |= MASK_NO_MORE_STARTS;
+
+        if (local.pass == 0) {
+            all_points.resize(2*local.total_point_count);
+            local.points = all_points.data();
+
+            // Allocate space for line_offsets, and set final offsets.
+            local.line_offsets.resize(local.line_count + 1);
+            local.line_offsets.back() = local.total_point_count;
+
+            local.total_point_count = 0;
+            local.line_count = 0;
+        }
+    } // pass
+
+    // Check both passes returned same number of points, lines, etc.
+    assert(local.line_offsets.size() == local.line_count + 1);
+    assert(local.line_offsets.back() == local.total_point_count);
+
+    for (unsigned long i = 0; i < local.line_count; ++i) {
+        // Copy points to new numpy array.
+        auto point_start = local.line_offsets[i];
+        auto point_end = local.line_offsets[i+1];
+        auto point_count = point_end - point_start;
+        assert(point_count > 1);
+        py::size_t points_shape[2] = {point_count, 2};
+        PointArray py_points(points_shape);
+        std::copy(all_points.data() + 2*point_start,
+                  all_points.data() + 2*point_end,
+                  py_points.mutable_data());
+
+        return_list.append(py_points);
+    }
+}
+
 bool SerialContourGenerator::supports_fill_type(FillType fill_type)
 {
     switch (fill_type) {
@@ -1113,6 +1370,16 @@ bool SerialContourGenerator::supports_fill_type(FillType fill_type)
         case FillType::CombinedOffsets:
         case FillType::CombinedCodesOffsets:
         case FillType::CombinedOffsets2:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool SerialContourGenerator::supports_line_type(LineType line_type)
+{
+    switch (line_type) {
+        case LineType::Separate:
             return true;
         default:
             return false;
@@ -1148,12 +1415,18 @@ void SerialContourGenerator::write_cache_quad(long quad) const
                     BOUNDARY_N(quad) ? 'n' : (BOUNDARY_E(quad) ? 'e' : '.')));
     std::cout << Z_LEVEL(quad);
     std::cout << ((_cache[quad] & MASK_SADDLE) >> 2);
-    std::cout << (START_BOUNDARY_S(quad) ? 's' : '.');
-    std::cout << (START_BOUNDARY_W(quad) ? 'w' : '.');
-    std::cout << (START_N(quad) ? 'n' : '.');
-    std::cout << (START_E(quad) ? 'e' : '.');
-    std::cout << (START_HOLE_N(quad) ? 'h' : '.');
-    std::cout << (LOOK_N(quad) && LOOK_S(quad) ? 'B' :
-        (LOOK_N(quad) ? '^' : (LOOK_S(quad) ? 'v' : '.')));
+    std::cout << (START_BOUNDARY_E(quad) ? 'e' : '.');
+    std::cout << (START_BOUNDARY_N(quad) ? 'n' : '.');
+    if (!_filled) {
+        std::cout << (START_BOUNDARY_S(quad) ? 's' : '.');
+        std::cout << (START_BOUNDARY_W(quad) ? 'w' : '.');
+    }
+    std::cout << (START_E(quad) ? 'E' : '.');
+    std::cout << (START_N(quad) ? 'N' : '.');
+    if (_filled) {
+        std::cout << (START_HOLE_N(quad) ? 'h' : '.');
+        std::cout << (LOOK_N(quad) && LOOK_S(quad) ? 'B' :
+            (LOOK_N(quad) ? '^' : (LOOK_S(quad) ? 'v' : '.')));
+    }
     std::cout << ' ';
 }

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -25,13 +25,17 @@ PYBIND11_MODULE(_contourpy, m) {
         .def("contour_lines", &mpl2014::Mpl2014ContourGenerator::contour_lines)
         .def_property_readonly_static(
             "fill_type",
-            [](py::object /* self */) {return FillType::OuterCodes;});
+            [](py::object /* self */) {return FillType::OuterCodes;})
+        .def_property_readonly_static(
+            "line_type",
+            [](py::object /* self */) {return LineType::Separate;});
 
     py::class_<SerialContourGenerator>(m, "SerialContourGenerator")
         .def(py::init<const CoordinateArray&,
                       const CoordinateArray&,
                       const CoordinateArray&,
                       const MaskArray&,
+                      LineType,
                       FillType,
                       long,
                       long>(),
@@ -39,11 +43,13 @@ PYBIND11_MODULE(_contourpy, m) {
              py::arg("y"),
              py::arg("z"),
              py::arg("mask"),
+             py::arg("line_type"),
              py::arg("fill_type"),
              py::kw_only(),
              py::arg("x_chunk_size") = 0,
              py::arg("y_chunk_size") = 0)
         .def("contour_filled", &SerialContourGenerator::contour_filled)
+        .def("contour_lines", &SerialContourGenerator::contour_lines)
         .def("write_cache", &SerialContourGenerator::write_cache)
         .def_property_readonly(
             "chunk_count", &SerialContourGenerator::get_chunk_count)
@@ -51,13 +57,24 @@ PYBIND11_MODULE(_contourpy, m) {
             "chunk_size", &SerialContourGenerator::get_chunk_size)
         .def_property_readonly(
             "fill_type", &SerialContourGenerator::get_fill_type)
+        .def_property_readonly(
+            "line_type", &SerialContourGenerator::get_line_type)
         .def_property_readonly_static(
             "default_fill_type",
             [](py::object /* self */) {
                 return SerialContourGenerator::default_fill_type();
             })
+        .def_property_readonly_static(
+            "default_line_type",
+            [](py::object /* self */) {
+                return SerialContourGenerator::default_line_type();
+            })
         .def_static(
-            "supports_fill_type", &SerialContourGenerator::supports_fill_type);
+            "supports_fill_type",
+            &SerialContourGenerator::supports_fill_type)
+        .def_static(
+            "supports_line_type",
+            &SerialContourGenerator::supports_line_type);
 
     py::enum_<FillType>(m, "FillType")
         .value("OuterCodes", FillType::OuterCodes)
@@ -66,5 +83,9 @@ PYBIND11_MODULE(_contourpy, m) {
         .value("CombinedOffsets", FillType::CombinedOffsets)
         .value("CombinedCodesOffsets", FillType::CombinedCodesOffsets)
         .value("CombinedOffsets2", FillType::CombinedOffsets2)
+        .export_values();
+
+    py::enum_<LineType>(m, "LineType")
+        .value("Separate", LineType::Separate)
         .export_values();
 }

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,4 +1,4 @@
-from contourpy import FillType
+from contourpy import FillType, LineType
 import pytest
 import util_test
 
@@ -10,9 +10,24 @@ def test_fill_type(name, value):
     assert t.value == value
 
 
+@pytest.mark.parametrize('name, value', util_test.all_line_types_str_value())
+def test_line_type(name, value):
+    t = LineType.__members__[name]
+    assert t.name == name
+    assert t.value == value
+
+
 def test_all_fill_types():
     # Check that all_fill_types() matches FillType.__members__
     fill_types = dict(util_test.all_fill_types_str_value())
     for name, enum in dict(FillType.__members__).items():
         assert(name in fill_types)
         assert(fill_types[name] == enum.value)
+
+
+def test_all_line_types():
+    # Check that all_line_types() matches LineType.__members__
+    line_types = dict(util_test.all_line_types_str_value())
+    for name, enum in dict(LineType.__members__).items():
+        assert(name in line_types)
+        assert(line_types[name] == enum.value)

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -1,4 +1,4 @@
-from contourpy import contour_generator
+from contourpy import contour_generator, LineType
 from contourpy.util import random_uniform, MplTestRenderer
 from image_comparison import compare_images
 import numpy as np
@@ -20,8 +20,6 @@ def xy_3x3():
 @pytest.mark.parametrize('name', util_test.all_names())
 @pytest.mark.parametrize('zlevel', [-1e-10, 1.0+1e10, np.nan, -np.nan, np.inf, -np.inf])
 def test_level_outside(xy_2x2, name, zlevel):
-    if name == 'serial':
-        pytest.skip()
     x, y = xy_2x2
     z = x
     cont_gen = contour_generator(x, y, z, name=name)
@@ -32,8 +30,6 @@ def test_level_outside(xy_2x2, name, zlevel):
 
 @pytest.mark.parametrize('name', util_test.all_names())
 def test_w_to_e(xy_2x2, name):
-    if name == 'serial':
-        pytest.skip()
     x, y = xy_2x2
     z = y.copy()
     cont_gen = contour_generator(x, y, z, name=name)
@@ -45,8 +41,6 @@ def test_w_to_e(xy_2x2, name):
 
 @pytest.mark.parametrize('name', util_test.all_names())
 def test_e_to_w(xy_2x2, name):
-    if name == 'serial':
-        pytest.skip()
     x, y = xy_2x2
     z = 1.0 - y.copy()
     cont_gen = contour_generator(x, y, z, name=name)
@@ -61,8 +55,6 @@ def test_e_to_w(xy_2x2, name):
 
 @pytest.mark.parametrize('name', util_test.all_names())
 def test_loop(xy_3x3, name):
-    if name == 'serial':
-        pytest.skip()
     x, y = xy_3x3
     z = np.zeros_like(x)
     z[1, 1] = 1.0
@@ -76,32 +68,36 @@ def test_loop(xy_3x3, name):
 
 @pytest.mark.parametrize('name', util_test.all_names())
 def test_lines_random_uniform_no_corner_mask(name):
-    if name == 'serial':
-        pytest.skip()
     x, y, z = random_uniform((30, 40), mask_fraction=0.05)
     cont_gen = contour_generator(x, y, z, name=name, corner_mask=False)
     levels = np.arange(0.0, 1.01, 0.2)
 
+    line_type = \
+        cont_gen.line_type if name != 'mpl2005' else LineType.Separate
+
     renderer = MplTestRenderer(x, y)
     for i in range(len(levels)):
-        renderer.lines(cont_gen.contour_lines(levels[i]), color=f'C{i}')
+        renderer.lines(cont_gen.contour_lines(levels[i]),
+                       line_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, 'lines_random_uniform_no_corner_mask.png',
-                   name, max_threshold=200 if name == 'mpl2005' else 10)
+                   name, max_threshold=200 if name == 'mpl2005' else 100)
 
 
 @pytest.mark.parametrize('name', util_test.corner_mask_names())
 def test_lines_random_uniform_corner_mask(name):
-    if name == 'serial':
-        pytest.skip()
     x, y, z = random_uniform((30, 40), mask_fraction=0.05)
     cont_gen = contour_generator(x, y, z, name=name, corner_mask=True)
     levels = np.arange(0.0, 1.01, 0.2)
 
+    line_type = \
+        cont_gen.line_type if name != 'mpl2005' else LineType.Separate
+
     renderer = MplTestRenderer(x, y)
     for i in range(len(levels)):
-        renderer.lines(cont_gen.contour_lines(levels[i]), color=f'C{i}')
+        renderer.lines(cont_gen.contour_lines(levels[i]),
+                       line_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, 'lines_random_uniform_corner_mask.png', name)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -31,3 +31,9 @@ def all_fill_types_str_value():
         ('CombinedCodesOffsets', 5),
         ('CombinedOffsets2', 6),
     ]
+
+
+def all_line_types_str_value():
+    return [
+        ('Separate', 0),
+    ]


### PR DESCRIPTION
Added `contour_lines` to serial algorithm (no corner mask).  Performance is better than mpl2005 but not as good as mpl2014.  Only uses line_type of `Separate` so far.