### PR TITLE
Add different return LineTypes to serial algorithm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ _contourpy = Pybind11Extension(
     'contourpy._contourpy',
     sources=[
         'src/chunk_local.cpp',
+        'src/converter.cpp',
         'src/fill_type.cpp',
         'src/line_type.cpp',
         'src/mpl2014.cpp',

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -1,0 +1,103 @@
+#include "converter.h"
+#include "mpl_kind_code.h"
+
+void Converter::convert_codes(
+    unsigned long point_count, unsigned long cut_count,
+    const unsigned long* cut_start, py::list& return_list,
+    unsigned long subtract)
+{
+    py::size_t codes_shape[1] = {point_count};
+    CodeArray py_codes(codes_shape);
+    auto py_ptr = py_codes.mutable_data();
+
+    std::fill(py_ptr + 1, py_ptr + point_count - 1, LINETO);
+    for (unsigned long i = 0; i < cut_count-1; ++i) {
+        py_ptr[*(cut_start + i) - subtract] = MOVETO;
+        py_ptr[*(cut_start + i+1) - 1 - subtract] = CLOSEPOLY;
+    }
+
+    return_list.append(py_codes);
+}
+
+void Converter::convert_codes_check_closed(
+    unsigned long point_count, unsigned long cut_count,
+    const unsigned long* cut_start, const double* check_closed,
+    py::list& return_list)
+{
+    py::size_t codes_shape[1] = {point_count};
+    CodeArray py_codes(codes_shape);
+    auto py_ptr = py_codes.mutable_data();
+
+    std::fill(py_ptr + 1, py_ptr + point_count, LINETO);
+    for (unsigned long i = 0; i < cut_count-1; ++i) {
+        auto start = *(cut_start + i);
+        auto end = *(cut_start + i+1);
+        py_ptr[start] = MOVETO;
+        bool closed = check_closed[2*start] == check_closed[2*end-2] &&
+                      check_closed[2*start+1] == check_closed[2*end-1];
+        if (closed)
+            py_ptr[end-1] = CLOSEPOLY;
+    }
+
+    return_list.append(py_codes);
+}
+
+void Converter::convert_codes_check_closed_single(
+    unsigned long point_count, const double* points, py::list& return_list)
+{
+    py::size_t codes_shape[1] = {point_count};
+    CodeArray py_codes(codes_shape);
+    auto py_ptr = py_codes.mutable_data();
+
+    py_ptr[0] = MOVETO;
+    auto start = points;
+    auto end = points + 2*point_count;
+    bool closed = *start == *(end-2) && *(start+1) == *(end-1);
+    if (closed) {
+        std::fill(py_ptr + 1, py_ptr + point_count - 1, LINETO);
+        py_ptr[point_count-1] = CLOSEPOLY;
+    }
+    else
+        std::fill(py_ptr + 1, py_ptr + point_count, LINETO);
+
+    return_list.append(py_codes);
+}
+
+void Converter::convert_offsets(
+    unsigned long offset_count, const unsigned long* start,
+    py::list& return_list, unsigned long subtract)
+{
+    py::size_t offsets_shape[1] = {offset_count};
+    OffsetArray py_offsets(offsets_shape);
+    if (subtract == 0)
+        std::copy(start, start + offset_count, py_offsets.mutable_data());
+    else {
+        auto py_ptr = py_offsets.mutable_data();
+        for (unsigned long i = 0; i < offset_count; ++i)
+            *py_ptr++ = *(start + i) - subtract;
+    }
+    return_list.append(py_offsets);
+}
+
+void Converter::convert_offsets_nested(
+    unsigned long offset_count, const unsigned long* start,
+    const unsigned long* nested_start, py::list& return_list)
+{
+    py::size_t offsets_shape[1] = {offset_count};
+    OffsetArray py_offsets(offsets_shape);
+    auto py_ptr = py_offsets.mutable_data();
+    for (unsigned long i = 0; i < offset_count; ++i)
+        *py_ptr++ = *(nested_start + *(start + i));
+
+    return_list.append(py_offsets);
+}
+
+void Converter::convert_points(
+    unsigned long point_count, const double* start, py::list& return_list)
+{
+    py::size_t points_shape[2] = {point_count, 2};
+    PointArray py_points(points_shape);
+    std::copy(start, start + 2*point_count, py_points.mutable_data());
+
+    return_list.append(py_points);
+}

--- a/src/converter.h
+++ b/src/converter.h
@@ -1,0 +1,35 @@
+#ifndef CONTOURPY_CONVERTER_H
+#define CONTOURPY_CONVERTER_H
+
+#include "common.h"
+
+// Conversion of C++ object to return to python.
+class Converter
+{
+public:
+    static void convert_codes(
+        unsigned long point_count, unsigned long cut_count,
+        const unsigned long* cut_start, py::list& return_list,
+        unsigned long subtract = 0);
+
+    static void convert_codes_check_closed(
+        unsigned long point_count, unsigned long cut_count,
+        const unsigned long* cut_start, const double* points,
+        py::list& return_list);
+
+    static void convert_codes_check_closed_single(
+        unsigned long point_count, const double* points, py::list& return_list);
+
+    static void convert_offsets(
+        unsigned long offset_count, const unsigned long* start,
+        py::list& return_list, unsigned long subtract = 0);
+
+    static void convert_offsets_nested(
+        unsigned long offset_count, const unsigned long* start,
+        const unsigned long* nested_start, py::list& return_list);
+
+    static void convert_points(
+        unsigned long point_count, const double* start, py::list& return_list);
+};
+
+#endif // CONTOURPY_CONVERTER_H

--- a/src/fill_type.h
+++ b/src/fill_type.h
@@ -6,12 +6,12 @@
 // C++11 scoped enum, must be fully qualified to use.
 enum class FillType
 {
-    OuterCodes = 1,
-    OuterOffsets = 2,
-    CombinedCodes = 3,
-    CombinedOffsets = 4,
-    CombinedCodesOffsets = 5,
-    CombinedOffsets2 = 6,
+    OuterCodes = 201,
+    OuterOffsets = 202,
+    CombinedCodes = 203,
+    CombinedOffsets = 204,
+    CombinedCodesOffsets = 205,
+    CombinedOffsets2 = 206,
 };
 
 std::ostream &operator<<(std::ostream &os, const FillType& fill_type);

--- a/src/line_type.cpp
+++ b/src/line_type.cpp
@@ -7,6 +7,15 @@ std::ostream &operator<<(std::ostream &os, const LineType& line_type)
         case LineType::Separate:
             os << "Separate";
             break;
+        case LineType::SeparateCodes:
+            os << "SeparateCodes";
+            break;
+        case LineType::CombinedCodes:
+            os << "CombinedCodes";
+            break;
+        case LineType::CombinedOffsets:
+            os << "CombinedOffsets";
+            break;
     }
     return os;
 }

--- a/src/line_type.h
+++ b/src/line_type.h
@@ -6,7 +6,10 @@
 // C++11 scoped enum, must be fully qualified to use.
 enum class LineType
 {
-    Separate = 0,
+    Separate = 101,
+    SeparateCodes = 102,
+    CombinedCodes = 103,
+    CombinedOffsets = 104,
 };
 
 std::ostream &operator<<(std::ostream &os, const LineType& line_type);

--- a/src/mpl2005.c
+++ b/src/mpl2005.c
@@ -1590,7 +1590,16 @@ build_cntr_list_v2(long *np, double *xp, double *yp, short *kp,
     }
     else
     {
-        return all_verts;
+        tuple = PyTuple_New(1);
+        if (tuple == NULL)
+        {
+            PyErr_SetString(PyExc_RuntimeError, "Error creating tuple");
+            goto error;
+        }
+
+        // No error checking here as filling in a brand new pre-allocated tuple.
+        PyTuple_SET_ITEM(tuple, 0, all_verts);
+        return tuple;
     }
 
     error:

--- a/src/mpl2014.cpp
+++ b/src/mpl2014.cpp
@@ -540,11 +540,10 @@ py::tuple Mpl2014ContourGenerator::contour_filled(
     py::tuple tuple(2);
     tuple[0] = vertices;
     tuple[1] = codes;
-
     return tuple;
 }
 
-py::list Mpl2014ContourGenerator::contour_lines(const double& level)
+py::tuple Mpl2014ContourGenerator::contour_lines(const double& level)
 {
     init_cache_levels(level, level);
 
@@ -628,7 +627,9 @@ py::list Mpl2014ContourGenerator::contour_lines(const double& level)
         }
     }
 
-    return vertices_list;
+    py::tuple tuple(1);
+    tuple[0] = vertices_list;
+    return tuple;
 }
 
 void Mpl2014ContourGenerator::edge_interp(const QuadEdge& quad_edge,

--- a/src/mpl2014.h
+++ b/src/mpl2014.h
@@ -289,7 +289,7 @@ public:
 
     // Create and return polygons for a line (i.e. non-filled) contour at the
     // specified level.
-    py::list contour_lines(const double& level);
+    py::tuple contour_lines(const double& level);
 
 private:
     // Typedef for following either a boundary of the domain or the interior;

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -249,26 +249,28 @@ py::tuple SerialContourGenerator::contour_filled(
     return tuple;
 }
 
-py::list SerialContourGenerator::contour_lines(const double& level)
+py::tuple SerialContourGenerator::contour_lines(const double& level)
 {
     _filled = false;
     _lower_level = _upper_level = level;
     _identify_holes = false;
-    _return_list_count = 1;
+    _return_list_count = (_line_type == LineType::Separate) ? 1 : 2;
 
     init_cache_levels_and_starts();
 
-    //std::vector<py::list> return_lists(_return_list_count);
-    py::list return_list;
+    std::vector<py::list> return_lists(_return_list_count);
 
     ChunkLocal local;
     for (long chunk = 0; chunk < _n_chunks; ++chunk) {
         get_chunk_limits(chunk, local);
-        single_chunk_lines(chunk, local, return_list);
+        single_chunk_lines(chunk, local, return_lists);
         local.clear();
     }
 
-    return return_list;
+    py::tuple tuple(_return_list_count);
+    for (unsigned int i = 0; i < _return_list_count; ++i)
+        tuple[i] = return_lists[i];
+    return tuple;
 }
 
 FillType SerialContourGenerator::default_fill_type()
@@ -902,7 +904,7 @@ void SerialContourGenerator::line(
     Location location = start_location;
     unsigned long point_count = 0;
 
-    // finished indicates closed line loop.
+    // finished == true indicates closed line loop.
     bool finished = follow_interior(
         location, start_location, local, point_count);
 
@@ -1159,6 +1161,9 @@ void SerialContourGenerator::single_chunk_filled(
         assert(local.outer_offsets.empty());
     }
 
+    if (local.total_point_count == 0)
+        return;
+
     // Write points and offsets/codes to output numpy arrays.
     // Needs refactoring so that each FillType is clear, with actual C++ to
     // Python conversions in separate functions.
@@ -1261,10 +1266,11 @@ void SerialContourGenerator::single_chunk_filled(
 }
 
 void SerialContourGenerator::single_chunk_lines(
-    long chunk, ChunkLocal& local, py::list& return_list)
+    long chunk, ChunkLocal& local, std::vector<py::list>& return_lists)
 {
     // Allocated at end of pass 0, depending on _line_type.
     std::vector<double> all_points;
+    const double* all_points_ptr = nullptr;
 
     for (local.pass = 0; local.pass < 2; ++local.pass) {
         long j_final_start = local.jstart;
@@ -1329,8 +1335,24 @@ void SerialContourGenerator::single_chunk_lines(
             _cache[local.istart + (j_final_start+1)*_nx] |= MASK_NO_MORE_STARTS;
 
         if (local.pass == 0) {
-            all_points.resize(2*local.total_point_count);
-            local.points = all_points.data();
+            if (_line_type == LineType::Separate ||
+                _line_type == LineType::SeparateCodes) {
+                all_points.resize(2*local.total_point_count);
+
+                // Where to store contour points.
+                local.points = all_points.data();
+            }
+            else {  // Combined points.
+                py::size_t points_shape[2] = {local.total_point_count, 2};
+                PointArray py_all_points(points_shape);
+                return_lists[0].append(py_all_points);
+
+                // Where to store contour points.
+                local.points = py_all_points.mutable_data();
+
+                // Needed to check if lines are closed loops or not.
+                all_points_ptr = py_all_points.data();
+            }
 
             // Allocate space for line_offsets, and set final offsets.
             local.line_offsets.resize(local.line_count + 1);
@@ -1345,31 +1367,80 @@ void SerialContourGenerator::single_chunk_lines(
     assert(local.line_offsets.size() == local.line_count + 1);
     assert(local.line_offsets.back() == local.total_point_count);
 
-    for (unsigned long i = 0; i < local.line_count; ++i) {
-        // Copy points to new numpy array.
-        auto point_start = local.line_offsets[i];
-        auto point_end = local.line_offsets[i+1];
-        auto point_count = point_end - point_start;
-        assert(point_count > 1);
-        py::size_t points_shape[2] = {point_count, 2};
-        PointArray py_points(points_shape);
-        std::copy(all_points.data() + 2*point_start,
-                  all_points.data() + 2*point_end,
-                  py_points.mutable_data());
+    if (local.total_point_count == 0)
+        return;
 
-        return_list.append(py_points);
+    if (_line_type == LineType::Separate ||
+        _line_type == LineType::SeparateCodes) {
+        for (unsigned long i = 0; i < local.line_count; ++i) {
+            // Copy points to new numpy array.
+            auto point_start = local.line_offsets[i];
+            auto point_end = local.line_offsets[i+1];
+            auto point_count = point_end - point_start;
+            assert(point_count > 1);
+            py::size_t points_shape[2] = {point_count, 2};
+            PointArray py_points(points_shape);
+            const double* start = all_points.data() + 2*point_start;
+            const double* end = all_points.data() + 2*point_end;
+            std::copy(start, end, py_points.mutable_data());
+
+            return_lists[0].append(py_points);
+
+            if (_line_type == LineType::SeparateCodes) {
+                py::size_t codes_shape[1] = {point_count};
+                CodeArray py_codes(codes_shape);
+                auto py_ptr = py_codes.mutable_data();
+                std::fill(py_ptr + 1, py_ptr + point_count, LINETO);
+                py_ptr[0] = MOVETO;
+                bool closed = *start == *(end-2) && *(start+1) == *(end-1);
+                if (closed)
+                    py_ptr[point_count-1] = CLOSEPOLY;
+
+                return_lists[1].append(py_codes);
+            }
+        }
+    }
+    else if (_line_type == LineType::CombinedCodes) {
+        assert(all_points_ptr != nullptr);
+        // Offsets converted to codes in new numpy array.
+        auto point_count = local.line_offsets.back();
+        py::size_t codes_shape[1] = {point_count};
+        CodeArray py_codes(codes_shape);
+        auto py_ptr = py_codes.mutable_data();
+        std::fill(py_ptr + 1, py_ptr + point_count, LINETO);
+        for (unsigned long i = 0; i < local.line_offsets.size()-1; ++i) {
+            auto start = local.line_offsets[i];
+            auto end = local.line_offsets[i+1];
+            py_ptr[start] = MOVETO;
+            bool closed = all_points_ptr[2*start] == all_points_ptr[2*end-2] &&
+                          all_points_ptr[2*start+1] == all_points_ptr[2*end-1];
+            if (closed)
+                py_ptr[end-1] = CLOSEPOLY;
+        }
+
+        return_lists[1].append(py_codes);
+    }
+    else if (_line_type == LineType::CombinedOffsets) {
+        // Copy offsets to new numpy array.
+        auto line_count = local.line_offsets.size();
+        py::size_t offsets_shape[1] = {line_count};
+        OffsetArray py_offsets(offsets_shape);
+        std::copy(local.line_offsets.begin(), local.line_offsets.end(),
+                  py_offsets.mutable_data());
+
+        return_lists[1].append(py_offsets);
     }
 }
 
 bool SerialContourGenerator::supports_fill_type(FillType fill_type)
 {
     switch (fill_type) {
-        case FillType::OuterCodes:
-        case FillType::OuterOffsets:
         case FillType::CombinedCodes:
         case FillType::CombinedOffsets:
         case FillType::CombinedCodesOffsets:
         case FillType::CombinedOffsets2:
+        case FillType::OuterCodes:
+        case FillType::OuterOffsets:
             return true;
         default:
             return false;
@@ -1380,6 +1451,9 @@ bool SerialContourGenerator::supports_line_type(LineType line_type)
 {
     switch (line_type) {
         case LineType::Separate:
+        case LineType::SeparateCodes:
+        case LineType::CombinedCodes:
+        case LineType::CombinedOffsets:
             return true;
         default:
             return false;

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -1,4 +1,5 @@
 #include "chunk_local.h"
+#include "converter.h"
 #include "mpl_kind_code.h"
 #include "serial.h"
 #include <iostream>
@@ -285,6 +286,116 @@ LineType SerialContourGenerator::default_line_type()
     LineType line_type = LineType::Separate;
     assert(supports_line_type(line_type));
     return line_type;
+}
+
+void SerialContourGenerator::export_filled(
+    long chunk, ChunkLocal& local, const std::vector<double>& all_points,
+    std::vector<py::list>& return_lists)
+{
+    // all_points is only used for fill_types OuterCodes and OuterOffsets.
+
+    switch (_fill_type)
+    {
+        case FillType::OuterCodes:
+        case FillType::OuterOffsets: {
+            auto outer_count = local.line_count - local.hole_count;
+            for (decltype(outer_count) i = 0; i < outer_count; ++i) {
+                auto outer_start = local.outer_offsets[i];
+                auto outer_end = local.outer_offsets[i+1];
+                auto point_start = local.line_offsets[outer_start];
+                auto point_end = local.line_offsets[outer_end];
+                auto point_count = point_end - point_start;
+                assert(point_count > 2);
+
+                Converter::convert_points(
+                    point_count, all_points.data() + 2*point_start,
+                    return_lists[0]);
+
+                if (_fill_type == FillType::OuterCodes)
+                    Converter::convert_codes(
+                        point_count, outer_end - outer_start + 1,
+                        local.line_offsets.data() + outer_start,
+                        return_lists[1], point_start);
+                else
+                    Converter::convert_offsets(
+                        outer_end - outer_start + 1,
+                        local.line_offsets.data() + outer_start,
+                        return_lists[1], point_start);
+            }
+            break;
+        }
+        case FillType::CombinedCodes:
+        case FillType::CombinedCodesOffsets:
+            // return_lists[0] already set.
+            assert(!local.line_offsets.empty());
+            Converter::convert_codes(
+                local.total_point_count, local.line_offsets.size(),
+                local.line_offsets.data(), return_lists[1]);
+
+            if (_fill_type == FillType::CombinedCodesOffsets)
+                Converter::convert_offsets_nested(
+                    local.outer_offsets.size(), local.outer_offsets.data(),
+                    local.line_offsets.data(), return_lists[2]);
+            break;
+        case FillType::CombinedOffsets:
+        case FillType::CombinedOffsets2:
+            // return_lists[0] already set.
+            assert(!local.line_offsets.empty());
+            Converter::convert_offsets(
+                local.line_offsets.size(), local.line_offsets.data(),
+                return_lists[1]);
+
+            if (_fill_type == FillType::CombinedOffsets2)
+                Converter::convert_offsets(
+                    local.outer_offsets.size(), local.outer_offsets.data(),
+                    return_lists[2]);
+            break;
+    }
+}
+
+void SerialContourGenerator::export_lines(
+    long chunk, ChunkLocal& local, const double* all_points_ptr,
+    std::vector<py::list>& return_lists)
+{
+    switch (_line_type)
+    {
+        case LineType::Separate:
+        case LineType::SeparateCodes:
+            assert(all_points_ptr != nullptr);
+            for (unsigned long i = 0; i < local.line_count; ++i) {
+                auto point_start = local.line_offsets[i];
+                auto point_end = local.line_offsets[i+1];
+                auto point_count = point_end - point_start;
+                assert(point_count > 1);
+
+                Converter::convert_points(
+                    point_count, all_points_ptr + 2*point_start,
+                    return_lists[0]);
+
+                if (_line_type == LineType::SeparateCodes) {
+                    Converter::convert_codes_check_closed_single(
+                        point_count, all_points_ptr + 2*point_start,
+                        return_lists[1]);
+                }
+            }
+            break;
+        case LineType::CombinedCodes: {
+            // return_lists[0] already set.
+            assert(all_points_ptr != nullptr);
+            assert(!local.line_offsets.empty());
+            Converter::convert_codes_check_closed(
+                local.total_point_count, local.line_offsets.size(),
+                local.line_offsets.data(), all_points_ptr, return_lists[1]);
+            break;
+        }
+        case LineType::CombinedOffsets:
+            // return_lists[0] already set.
+            assert(!local.line_offsets.empty());
+            Converter::convert_offsets(
+                local.line_offsets.size(), local.line_offsets.data(),
+                return_lists[1]);
+            break;
+    }
 }
 
 long SerialContourGenerator::find_look_S(long look_N_quad) const
@@ -1161,108 +1272,8 @@ void SerialContourGenerator::single_chunk_filled(
         assert(local.outer_offsets.empty());
     }
 
-    if (local.total_point_count == 0)
-        return;
-
-    // Write points and offsets/codes to output numpy arrays.
-    // Needs refactoring so that each FillType is clear, with actual C++ to
-    // Python conversions in separate functions.
-    if (_identify_holes) {
-        auto outer_count = local.line_count - local.hole_count;
-        for (decltype(outer_count) i = 0; i < outer_count; ++i) {
-            auto outer_start = local.outer_offsets[i];
-            auto outer_end = local.outer_offsets[i+1];
-            auto point_start = local.line_offsets[outer_start];
-            auto point_end = local.line_offsets[outer_end];
-
-            auto point_count = point_end - point_start;
-            assert(point_count > 2);
-
-            if (_fill_type == FillType::OuterCodes ||
-                _fill_type == FillType::OuterOffsets) {
-                // Copy points to new numpy array.
-                py::size_t points_shape[2] = {point_count, 2};
-                PointArray py_points(points_shape);
-                std::copy(all_points.data() + 2*point_start,
-                          all_points.data() + 2*point_end,
-                          py_points.mutable_data());
-
-                return_lists[0].append(py_points);
-            }
-
-            if (_fill_type == FillType::OuterCodes) {
-                // Offsets converted to codes in new numpy array.
-                py::size_t codes_shape[1] = {point_count};
-                CodeArray py_codes(codes_shape);
-                auto py_ptr = py_codes.mutable_data();
-                std::fill(py_ptr + 1, py_ptr + point_count - 1, LINETO);
-                for (auto j = outer_start; j < outer_end; ++j) {
-                    py_ptr[local.line_offsets[j] - point_start] = MOVETO;
-                    py_ptr[local.line_offsets[j+1]-1 - point_start] = CLOSEPOLY;
-                }
-
-                return_lists[1].append(py_codes);
-            }
-            else if (_fill_type == FillType::OuterOffsets) {
-                // Offsets to new numpy array.
-                auto offset_count = outer_end - outer_start;
-                py::size_t offsets_shape[1] = {offset_count + 1};
-                OffsetArray py_offsets(offsets_shape);
-                auto py_ptr = py_offsets.mutable_data();
-                *py_ptr++ = 0;
-                for (auto j = outer_start + 1; j < outer_end; ++j)
-                    *py_ptr++ = local.line_offsets[j] - point_start;
-                *py_ptr = point_count;
-
-                return_lists[1].append(py_offsets);
-            }
-        }
-    }
-
-    if (_fill_type == FillType::CombinedCodes ||
-        _fill_type == FillType::CombinedCodesOffsets) {
-        // Offsets converted to codes in new numpy array.
-        auto point_count =
-            local.line_offsets.empty() ? 0 : local.line_offsets.back();
-        py::size_t codes_shape[1] = {point_count};
-        CodeArray py_codes(codes_shape);
-        auto py_ptr = py_codes.mutable_data();
-        std::fill(py_ptr + 1, py_ptr + point_count - 1, LINETO);
-        for (unsigned long i = 0; i < local.line_offsets.size()-1; ++i) {
-            py_ptr[local.line_offsets[i]] = MOVETO;
-            py_ptr[local.line_offsets[i+1]-1] = CLOSEPOLY;
-        }
-
-        return_lists[1].append(py_codes);
-    }
-    else if (_fill_type == FillType::CombinedOffsets ||
-             _fill_type == FillType::CombinedOffsets2) {
-        // Copy offsets to new numpy array.
-        auto line_count = local.line_offsets.size();
-        py::size_t offsets_shape[1] = {line_count};
-        OffsetArray py_offsets(offsets_shape);
-        std::copy(local.line_offsets.begin(), local.line_offsets.end(),
-                  py_offsets.mutable_data());
-
-        return_lists[1].append(py_offsets);
-    }
-
-    if (_return_list_count == 3) {
-        auto outer_count = local.outer_offsets.size();
-        py::size_t offsets_shape[1] = {outer_count};
-        OffsetArray py_offsets(offsets_shape);
-        if (_fill_type == FillType::CombinedCodesOffsets) {
-            auto py_ptr = py_offsets.mutable_data();
-            for (const auto& offset : local.outer_offsets)
-                *py_ptr++ = local.line_offsets[offset];
-        }
-        else {
-            std::copy(local.outer_offsets.begin(), local.outer_offsets.end(),
-                      py_offsets.mutable_data());
-        }
-
-        return_lists[2].append(py_offsets);
-    }
+    if (local.total_point_count > 0)
+        export_filled(chunk, local, all_points, return_lists);
 }
 
 void SerialContourGenerator::single_chunk_lines(
@@ -1341,6 +1352,9 @@ void SerialContourGenerator::single_chunk_lines(
 
                 // Where to store contour points.
                 local.points = all_points.data();
+
+                // Needed to check if lines are closed loops or not.
+                all_points_ptr = all_points.data();
             }
             else {  // Combined points.
                 py::size_t points_shape[2] = {local.total_point_count, 2};
@@ -1367,69 +1381,8 @@ void SerialContourGenerator::single_chunk_lines(
     assert(local.line_offsets.size() == local.line_count + 1);
     assert(local.line_offsets.back() == local.total_point_count);
 
-    if (local.total_point_count == 0)
-        return;
-
-    if (_line_type == LineType::Separate ||
-        _line_type == LineType::SeparateCodes) {
-        for (unsigned long i = 0; i < local.line_count; ++i) {
-            // Copy points to new numpy array.
-            auto point_start = local.line_offsets[i];
-            auto point_end = local.line_offsets[i+1];
-            auto point_count = point_end - point_start;
-            assert(point_count > 1);
-            py::size_t points_shape[2] = {point_count, 2};
-            PointArray py_points(points_shape);
-            const double* start = all_points.data() + 2*point_start;
-            const double* end = all_points.data() + 2*point_end;
-            std::copy(start, end, py_points.mutable_data());
-
-            return_lists[0].append(py_points);
-
-            if (_line_type == LineType::SeparateCodes) {
-                py::size_t codes_shape[1] = {point_count};
-                CodeArray py_codes(codes_shape);
-                auto py_ptr = py_codes.mutable_data();
-                std::fill(py_ptr + 1, py_ptr + point_count, LINETO);
-                py_ptr[0] = MOVETO;
-                bool closed = *start == *(end-2) && *(start+1) == *(end-1);
-                if (closed)
-                    py_ptr[point_count-1] = CLOSEPOLY;
-
-                return_lists[1].append(py_codes);
-            }
-        }
-    }
-    else if (_line_type == LineType::CombinedCodes) {
-        assert(all_points_ptr != nullptr);
-        // Offsets converted to codes in new numpy array.
-        auto point_count = local.line_offsets.back();
-        py::size_t codes_shape[1] = {point_count};
-        CodeArray py_codes(codes_shape);
-        auto py_ptr = py_codes.mutable_data();
-        std::fill(py_ptr + 1, py_ptr + point_count, LINETO);
-        for (unsigned long i = 0; i < local.line_offsets.size()-1; ++i) {
-            auto start = local.line_offsets[i];
-            auto end = local.line_offsets[i+1];
-            py_ptr[start] = MOVETO;
-            bool closed = all_points_ptr[2*start] == all_points_ptr[2*end-2] &&
-                          all_points_ptr[2*start+1] == all_points_ptr[2*end-1];
-            if (closed)
-                py_ptr[end-1] = CLOSEPOLY;
-        }
-
-        return_lists[1].append(py_codes);
-    }
-    else if (_line_type == LineType::CombinedOffsets) {
-        // Copy offsets to new numpy array.
-        auto line_count = local.line_offsets.size();
-        py::size_t offsets_shape[1] = {line_count};
-        OffsetArray py_offsets(offsets_shape);
-        std::copy(local.line_offsets.begin(), local.line_offsets.end(),
-                  py_offsets.mutable_data());
-
-        return_lists[1].append(py_offsets);
-    }
+    if (local.total_point_count > 0)
+        export_lines(chunk, local, all_points_ptr, return_lists);
 }
 
 bool SerialContourGenerator::supports_fill_type(FillType fill_type)

--- a/src/serial.h
+++ b/src/serial.h
@@ -69,6 +69,15 @@ private:
         const Location& start_location, OuterOrHole outer_or_hole,
         ChunkLocal& local);
 
+    // Write points and offsets/codes to output numpy arrays.
+    void export_filled(
+        long chunk, ChunkLocal& local, const std::vector<double>& all_points,
+        std::vector<py::list>& return_lists);
+
+    void export_lines(
+        long chunk, ChunkLocal& local, const double* all_points_ptr,
+        std::vector<py::list>& return_lists);
+
     long find_look_S(long look_N_quad) const;
 
     // Return true if finished (i.e. back to start quad, direction and upper).

--- a/src/serial.h
+++ b/src/serial.h
@@ -23,7 +23,7 @@ public:
     py::tuple contour_filled(
         const double& lower_level, const double& upper_level);
 
-    py::list contour_lines(const double& level);
+    py::tuple contour_lines(const double& level);
 
     static FillType default_fill_type();
     static LineType default_line_type();
@@ -116,7 +116,7 @@ private:
         long chunk, ChunkLocal& local, std::vector<py::list>& return_lists);
 
     void single_chunk_lines(
-        long chunk, ChunkLocal& local, py::list& return_list);
+        long chunk, ChunkLocal& local, std::vector<py::list>& return_lists);
 
     void write_cache_quad(long quad) const;
 

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -77,15 +77,18 @@ PYBIND11_MODULE(_contourpy, m) {
             &SerialContourGenerator::supports_line_type);
 
     py::enum_<FillType>(m, "FillType")
-        .value("OuterCodes", FillType::OuterCodes)
-        .value("OuterOffsets", FillType::OuterOffsets)
         .value("CombinedCodes", FillType::CombinedCodes)
         .value("CombinedOffsets", FillType::CombinedOffsets)
         .value("CombinedCodesOffsets", FillType::CombinedCodesOffsets)
         .value("CombinedOffsets2", FillType::CombinedOffsets2)
+        .value("OuterCodes", FillType::OuterCodes)
+        .value("OuterOffsets", FillType::OuterOffsets)
         .export_values();
 
     py::enum_<LineType>(m, "LineType")
         .value("Separate", LineType::Separate)
+        .value("SeparateCodes", LineType::SeparateCodes)
+        .value("CombinedCodes", LineType::CombinedCodes)
+        .value("CombinedOffsets", LineType::CombinedOffsets)
         .export_values();
 }

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -24,6 +24,9 @@ def test_filled_random_uniform_no_corner_mask(name, fill_type):
         x, y, z, name=name, fill_type=fill_type, corner_mask=False)
     levels = np.arange(0.0, 1.01, 0.2)
 
+    if name != 'mpl2005':
+        assert cont_gen.fill_type == fill_type
+
     renderer = MplTestRenderer(x, y)
     for i in range(len(levels)-1):
         renderer.filled(cont_gen.contour_filled(levels[i], levels[i+1]),

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -99,7 +99,6 @@ def test_lines_random_uniform_no_corner_mask(name, line_type):
 
     renderer = MplTestRenderer(x, y)
     for i in range(len(levels)):
-        pass
         renderer.lines(cont_gen.contour_lines(levels[i]),
                        line_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -2,7 +2,7 @@ from contourpy import contour_generator, LineType
 from contourpy.util import random_uniform, MplTestRenderer
 from image_comparison import compare_images
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 import util_test
 
@@ -17,25 +17,39 @@ def xy_3x3():
     return np.meshgrid([0.0, 0.5, 1.0], [0.0, 0.5, 1.0])
 
 
+@pytest.fixture
+def one_loop_one_strip():
+    x, y = np.meshgrid([0., 1., 2., 3.], [0., 1., 2.])
+    z = np.array([[1.5, 1.5, 0.9, 0.0],
+                  [1.5, 2.8, 0.4, 0.8],
+                  [0.0, 0.0, 0.8, 6.0]])
+    return x, y, z
+
+
 @pytest.mark.parametrize('name', util_test.all_names())
 @pytest.mark.parametrize('zlevel', [-1e-10, 1.0+1e10, np.nan, -np.nan, np.inf, -np.inf])
 def test_level_outside(xy_2x2, name, zlevel):
     x, y = xy_2x2
     z = x
-    cont_gen = contour_generator(x, y, z, name=name)
+    cont_gen = contour_generator(
+        x, y, z, name=name, line_type=LineType.Separate)
     lines = cont_gen.contour_lines(zlevel)
-    assert(isinstance(lines, list))
-    assert(len(lines) == 0)
+    assert(isinstance(lines, tuple))
+    assert(isinstance(lines[0], list))
+    assert(len(lines[0]) == 0)
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
 def test_w_to_e(xy_2x2, name):
     x, y = xy_2x2
     z = y.copy()
-    cont_gen = contour_generator(x, y, z, name=name)
+    cont_gen = contour_generator(
+        x, y, z, name=name, line_type=LineType.Separate)
     lines = cont_gen.contour_lines(0.5)
-    assert(len(lines) == 1)
-    line = lines[0]
+    assert(isinstance(lines, tuple))
+    assert(isinstance(lines[0], list))
+    assert(len(lines[0]) == 1)
+    line = lines[0][0]
     assert_allclose(line, [[0.0, 0.5], [1.0, 0.5]])
 
 
@@ -43,10 +57,13 @@ def test_w_to_e(xy_2x2, name):
 def test_e_to_w(xy_2x2, name):
     x, y = xy_2x2
     z = 1.0 - y.copy()
-    cont_gen = contour_generator(x, y, z, name=name)
+    cont_gen = contour_generator(
+        x, y, z, name=name, line_type=LineType.Separate)
     lines = cont_gen.contour_lines(0.5)
-    assert(len(lines) == 1)
-    line = lines[0]
+    assert(isinstance(lines, tuple))
+    assert(isinstance(lines[0], list))
+    assert(len(lines[0]) == 1)
+    line = lines[0][0]
     if name == 'mpl2005':    # Line directions are not consistent.
         assert_allclose(line, [[0.0, 0.5], [1.0, 0.5]])
     else:
@@ -58,25 +75,31 @@ def test_loop(xy_3x3, name):
     x, y = xy_3x3
     z = np.zeros_like(x)
     z[1, 1] = 1.0
-    cont_gen = contour_generator(x, y, z, name=name)
+    cont_gen = contour_generator(
+        x, y, z, name=name, line_type=LineType.Separate)
     lines = cont_gen.contour_lines(0.5)
-    assert(len(lines) == 1)
-    line = lines[0]
+    assert(isinstance(lines, tuple))
+    assert(isinstance(lines[0], list))
+    assert(len(lines[0]) == 1)
+    line = lines[0][0]
     assert(line.shape == (5, 2))
     assert_allclose(line[0], line[-1])
 
 
-@pytest.mark.parametrize('name', util_test.all_names())
-def test_lines_random_uniform_no_corner_mask(name):
+@pytest.mark.parametrize(
+    'name, line_type', util_test.all_names_and_line_types())
+def test_lines_random_uniform_no_corner_mask(name, line_type):
     x, y, z = random_uniform((30, 40), mask_fraction=0.05)
-    cont_gen = contour_generator(x, y, z, name=name, corner_mask=False)
+    cont_gen = contour_generator(
+        x, y, z, name=name, line_type=line_type, corner_mask=False)
     levels = np.arange(0.0, 1.01, 0.2)
 
-    line_type = \
-        cont_gen.line_type if name != 'mpl2005' else LineType.Separate
+    if name != 'mpl2005':
+        assert cont_gen.line_type == line_type
 
     renderer = MplTestRenderer(x, y)
     for i in range(len(levels)):
+        pass
         renderer.lines(cont_gen.contour_lines(levels[i]),
                        line_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
@@ -101,3 +124,54 @@ def test_lines_random_uniform_corner_mask(name):
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, 'lines_random_uniform_corner_mask.png', name)
+
+
+
+@pytest.mark.parametrize('line_type', LineType.__members__.values())
+@pytest.mark.parametrize('name', ['serial'])
+def test_return_by_line_type(one_loop_one_strip, name, line_type):
+    x, y, z = one_loop_one_strip
+    cont_gen = contour_generator(x, y, z, name, line_type=line_type)
+    assert cont_gen.line_type == line_type
+    lines = cont_gen.contour_lines(2.0)
+    if line_type in (LineType.Separate, LineType.SeparateCodes):
+        assert isinstance(lines, tuple)
+        assert len(lines) == 1 if line_type == LineType.Separate else 2
+        points = lines[0]
+        assert isinstance(points, list) and len(points) == 2
+        for p in points:
+            assert isinstance(p, np.ndarray)
+            assert p.dtype == np.float64
+        assert points[0].shape == (5, 2)
+        assert points[1].shape == (2, 2)
+        assert_array_equal(points[0][0], points[0][4])
+        if line_type == LineType.SeparateCodes:
+            codes = lines[1]
+            assert isinstance(codes, list) and len(codes) == 2
+            for c in codes:
+                assert isinstance(c, np.ndarray)
+                assert c.dtype == np.uint8
+            assert_array_equal(codes[0], [1, 2, 2, 2, 79])
+            assert_array_equal(codes[1], [1, 2])
+    elif line_type in (LineType.CombinedCodes, LineType.CombinedOffsets):
+        assert isinstance(lines, tuple) and len(lines) == 2
+        points = lines[0]
+        assert isinstance(points, list) and len(points) == 1
+        assert isinstance(points[0], np.ndarray)
+        assert points[0].dtype == np.float64
+        assert points[0].shape == (7, 2)
+        assert_array_equal(points[0][0], points[0][4])
+        if line_type == LineType.CombinedCodes:
+            codes = lines[1]
+            assert isinstance(codes, list) and len(codes) == 1
+            assert isinstance(codes[0], np.ndarray)
+            assert codes[0].dtype == np.uint8
+            assert_array_equal(codes[0], [1, 2, 2, 2, 79, 1, 2])
+        else:
+            offsets = lines[1]
+            assert isinstance(offsets, list) and len(offsets) == 1
+            assert isinstance(offsets[0], np.ndarray)
+            assert offsets[0].dtype == np.int32
+            assert_array_equal(offsets[0], [0, 5, 7])
+    else:
+        raise RuntimeError(f'Unexpected fill_type {fill_type}')

--- a/tests/util_config.py
+++ b/tests/util_config.py
@@ -39,6 +39,14 @@ class Config:
         self.x, self.y = np.meshgrid([0.0, 1.0], [0.0, 1.0])
         self.mask = False
 
+        # Set in derived classes.
+        self.fig = None
+        self.axes = None
+
+    def __del__(self):
+        if self.fig:
+            plt.close(self.fig)
+
     def _arrow(self, ax, line_start, line_end, color):
         mid = 0.5*(line_start + line_end)
         along = line_end - line_start
@@ -107,6 +115,7 @@ class Config:
             lines = filled[0]
         else:
             lines = cont_gen.contour_lines(zlower)
+            lines = lines[0]
 
         # May be 0..2 polygons, and there cannot be any holes.
         for points in lines:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,4 +1,4 @@
-from contourpy import FillType
+from contourpy import FillType, LineType
 
 
 def all_names():
@@ -7,8 +7,8 @@ def all_names():
 
 def all_names_and_fill_types():
     return [
-        ('mpl2014', FillType.OuterCodes),
         ('mpl2005', FillType.OuterCodes),
+        ('mpl2014', FillType.OuterCodes),
         ('serial', FillType.OuterCodes),
         ('serial', FillType.OuterOffsets),
         ('serial', FillType.CombinedCodes),
@@ -18,22 +18,36 @@ def all_names_and_fill_types():
     ]
 
 
+def all_names_and_line_types():
+    return [
+        ('mpl2005', LineType.Separate),
+        ('mpl2014', LineType.Separate),
+        ('serial', LineType.Separate),
+        ('serial', LineType.SeparateCodes),
+        ('serial', LineType.CombinedCodes),
+        ('serial', LineType.CombinedOffsets),
+    ]
+
+
 def corner_mask_names():
     return ['mpl2014']
 
 
 def all_fill_types_str_value():
     return [
-        ('OuterCodes', 1),
-        ('OuterOffsets', 2),
-        ('CombinedCodes', 3),
-        ('CombinedOffsets', 4),
-        ('CombinedCodesOffsets', 5),
-        ('CombinedOffsets2', 6),
+        ('OuterCodes', 201),
+        ('OuterOffsets', 202),
+        ('CombinedCodes', 203),
+        ('CombinedOffsets', 204),
+        ('CombinedCodesOffsets', 205),
+        ('CombinedOffsets2', 206),
     ]
 
 
 def all_line_types_str_value():
     return [
-        ('Separate', 0),
+        ('Separate', 101),
+        ('SeparateCodes', 102),
+        ('CombinedCodes', 103),
+        ('CombinedOffsets', 104),
     ]


### PR DESCRIPTION
Added various `LineType`s to serial algorithm, and improved conversion functions from C++ to Python objects.

Also modified return of mpl2005 and mpl2014 algorithms to be a tuple of a single list, in preparation for chunking.