### PR TITLE
Improved build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,6 @@ To build and install in developer's mode
 
     pip install -ve .
 
-Alternatively can use
-
-    python setup.py install
-
-which will only recompile what has changed, but it does need pybind11 explicitly
-installed beforehand using
-
-    pip install pybind11
-
 To run tests
 
     pip install -r requirements/test.txt

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-from setuptools import setup
-from pybind11.setup_helpers import Pybind11Extension, build_ext
+from setuptools import setup, find_packages
+from pybind11.setup_helpers import (
+    Pybind11Extension, build_ext, ParallelCompile, naive_recompile)
 
 
 # Set want_debug to True if want to enable asserts in C++ code.
@@ -17,6 +18,8 @@ undef_macros = []
 if want_debug:
     define_macros.append(('DEBUG',1))
     undef_macros.append('NDEBUG')
+
+ParallelCompile(default=0, needs_recompile=naive_recompile).install()
 
 _contourpy = Pybind11Extension(
     'contourpy._contourpy',
@@ -72,7 +75,7 @@ setup(
     author_email='ianthomas23@gmail.com',
     license='BSD',
     package_dir={'': 'lib'},
-    packages=['contourpy'],
+    packages=find_packages('lib'),
     ext_modules=ext_modules,
     cmdclass={'build_ext': build_ext},
     zip_safe=False,


### PR DESCRIPTION
Using pybind11's `ParallelCompile` and `naive_recompile` to build in parallel and only build source code files that have changed (but ignoring header file changes).

Also using `setuptools.find_packages` to correctly find directories to install so that building works in place or not.