### PR TITLE
Accept x and y as 0D and 1D arrays in Python wrapper

### DIFF
--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -11,15 +11,39 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=0,
     y = np.asarray(y, dtype=np.float64)
     z = np.ma.asarray(z, dtype=np.float64)  # Preserve mask if present.
 
-    # Check arguments.
-    if x.ndim != 2 or y.ndim != 2 or z.ndim != 2:
-        raise ValueError('x, y and z must all be 2D arrays')
-
-    if x.shape != z.shape or y.shape != z.shape:
-        raise ValueError('x, y and z arrays must have the same shape')
-
+    # Check arguments: z.
+    if z.ndim != 2:
+        raise TypeError(f'Input z must be 2D, not {z.ndim}D')
     if z.shape[0] < 2 or z.shape[1] < 2:
-        raise ValueError('x, y and z must all be at least 2x2 arrays')
+        raise TypeError('Input z must be at least a (2, 2) shaped array, '
+                        f'but has shape {z.shape}')
+
+    # Check arguments: x and y.
+    if x.ndim != y.ndim:
+        raise TypeError(f'Number of dimensions of x ({x.ndim}) and y '
+                        f'({y.ndim}) do not match')
+    if x.ndim == 0:
+        x = np.arange(z.shape[1])
+        y = np.arange(z.shape[0])
+        x, y = np.meshgrid(x, y)
+    elif x.ndim == 1:
+        ny, nx = z.shape
+        if len(x) != nx:
+            raise TypeError(f'Length of x ({len(x)}) must match number of '
+                            f'columns in z ({nx})')
+        if len(y) != ny:
+            raise TypeError(f'Length of y ({len(y)}) must match number of '
+                            f'rows in z ({ny})')
+        x, y = np.meshgrid(x, y)
+    elif x.ndim == 2:
+        if x.shape != z.shape:
+            raise TypeError(
+                f'Shapes of x {x.shape} and z {z.shape} do not match')
+        if y.shape != z.shape:
+            raise TypeError(
+                f'Shapes of y {y.shape} and z {z.shape} do not match')
+    else:
+        raise TypeError(f'Inputs x and y must be None, 1D or 2D, not {x.ndim}D')
 
     # Extract optional mask from z array.
     mask = None

--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -92,6 +92,9 @@ class BokehRenderer:
     def grid(self, x, y, ax=0, color='black', alpha=0.1):
         fig = self._get_figure(ax)
 
+        if x.ndim == 1:
+            x, y = np.meshgrid(x, y)
+
         xs = [row for row in x] + [row for row in x.T]
         ys = [row for row in y] + [row for row in y.T]
         fig.multi_line(xs, ys, line_color=color, alpha=alpha)

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -69,6 +69,8 @@ class MplRenderer:
 
     def grid(self, x, y, ax=0, color='black', alpha=0.1):
         ax = self._get_ax(ax)
+        if x.ndim == 1:
+            x, y = np.meshgrid(x, y)
         ax.plot(x, y, x.T, y.T, color=color, alpha=alpha)
 
     def lines(self, lines, line_type, ax=0, color='C0', alpha=1.0,

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -106,7 +106,8 @@ SerialContourGenerator::SerialContourGenerator(
             throw std::invalid_argument("mask array must be a 2D array");
 
         if (mask.shape(1) != _nx || mask.shape(0) != _ny)
-            throw std::invalid_argument("If mask is set it must be a 2D array with the same shape as z");
+            throw std::invalid_argument(
+                "If mask is set it must be a 2D array with the same shape as z");
     }
 
     if (!supports_fill_type(fill_type))
@@ -114,8 +115,6 @@ SerialContourGenerator::SerialContourGenerator(
 
     if (x_chunk_size < 0 || y_chunk_size < 0)  // Check inputs, not calculated.
         throw std::invalid_argument("chunk_sizes cannot be negative");
-
-std::cout << "serial " << _nx_chunks << " " << _ny_chunks << std::endl;
 
     init_cache_grid(mask);
 }

--- a/src/serial_corner.cpp
+++ b/src/serial_corner.cpp
@@ -131,7 +131,8 @@ SerialCornerContourGenerator::SerialCornerContourGenerator(
             throw std::invalid_argument("mask array must be a 2D array");
 
         if (mask.shape(1) != _nx || mask.shape(0) != _ny)
-            throw std::invalid_argument("If mask is set it must be a 2D array with the same shape as z");
+            throw std::invalid_argument(
+                "If mask is set it must be a 2D array with the same shape as z");
     }
 
     if (!supports_fill_type(fill_type))
@@ -139,8 +140,6 @@ SerialCornerContourGenerator::SerialCornerContourGenerator(
 
     if (x_chunk_size < 0 || y_chunk_size < 0)  // Check inputs, not calculated.
         throw std::invalid_argument("chunk_sizes cannot be negative");
-
-std::cout << "serial_corner " << _nx_chunks << " " << _ny_chunks << std::endl;
 
     init_cache_grid(mask);
 }

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -1,66 +1,79 @@
 import contourpy
 import numpy as np
 import pytest
+import re
 import util_test
 
 
 @pytest.fixture
 def xyz_as_lists():
-    x = [[0, 0], [1, 1]]
-    y = [[0, 1], [0, 1]]
-    z = [[0, 1], [2, 3]]
+    x = [[0, 1, 2], [0, 1, 2]]
+    y = [[0, 0, 0], [1, 1, 1]]
+    z = [[0, 1, 2], [3, 4, 5]]
     return x, y, z
 
-
-@pytest.mark.parametrize('name', util_test.all_names())
-@pytest.mark.parametrize('x', ( [1], [[[1]]] ))
-def test_wrapper_ndim_x(xyz_as_lists, name, x):
-    _, y_ok, z_ok = xyz_as_lists
-    with pytest.raises(ValueError, match='x, y and z must all be 2D arrays'):
-        cont_gen = contourpy.contour_generator(x, y_ok, z_ok, name=name)
-
-
-@pytest.mark.parametrize('name', util_test.all_names())
-@pytest.mark.parametrize('y', ( [1], [[[1]]] ))
-def test_wrapper_ndim_y(xyz_as_lists, name, y):
-    x_ok, _, z_ok = xyz_as_lists
-    with pytest.raises(ValueError, match='x, y and z must all be 2D arrays'):
-        cont_gen = contourpy.contour_generator(x_ok, y, z_ok, name=name)
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
 @pytest.mark.parametrize('z', ( [1], [[[1]]] ))
-def test_wrapper_ndim_z(xyz_as_lists, name, z):
-    x_ok, y_ok, _ = xyz_as_lists
-    with pytest.raises(ValueError, match='x, y and z must all be 2D arrays'):
-        cont_gen = contourpy.contour_generator(x_ok, y_ok, z, name=name)
-
-
-@pytest.mark.parametrize('name', util_test.all_names())
-@pytest.mark.parametrize('diff_shape', ( [[1, 2, 3], [4, 5, 6]],
-                                         [[1, 2], [3, 4], [5, 6]] ))
-def test_wrapper_diff_shapes(xyz_as_lists, name, diff_shape):
-    x_ok, y_ok, z_ok = xyz_as_lists
-
-    with pytest.raises(ValueError, match='x, y and z arrays must have the same shape'):
-        cont_gen = contourpy.contour_generator(diff_shape, y_ok, z_ok, name=name)
-
-    with pytest.raises(ValueError, match='x, y and z arrays must have the same shape'):
-        cont_gen = contourpy.contour_generator(x_ok, diff_shape, z_ok, name=name)
-
-    with pytest.raises(ValueError, match='x, y and z arrays must have the same shape'):
-        cont_gen = contourpy.contour_generator(x_ok, y_ok, diff_shape, name=name)
+def test_ndim_z(xyz_as_lists, name, z):
+    x, y, _ = xyz_as_lists
+    with pytest.raises(TypeError):
+        cont_gen = contourpy.contour_generator(x, y, z, name=name)
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
 @pytest.mark.parametrize('all_xyz', ( [[1]], [[1], [2]], [[1, 2]] ))
-def test_wrapper_shape_too_small(all_xyz, name):
-    with pytest.raises(ValueError, match='x, y and z must all be at least 2x2 arrays'):
+def test_z_shape_too_small(all_xyz, name):
+    with pytest.raises(TypeError):
         cont_gen = contourpy.contour_generator(all_xyz, all_xyz, all_xyz, name=name)
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
-def test_wrapper_chunk_size_negative(xyz_as_lists, name):
+@pytest.mark.parametrize('wrong_ndim', ( None, [1], [[[1]]] ))
+def test_diff_ndim_xy(xyz_as_lists, name, wrong_ndim):
+    x, y, z = xyz_as_lists
+    with pytest.raises(TypeError):
+        cont_gen = contourpy.contour_generator(wrong_ndim, y, z, name=name)
+    with pytest.raises(TypeError):
+        cont_gen = contourpy.contour_generator(x, wrong_ndim, z, name=name)
+
+
+@pytest.mark.parametrize('name', util_test.all_names())
+def test_xy_None(xyz_as_lists, name):
+    _, _, z = xyz_as_lists
+    cont_gen = contourpy.contour_generator(None, None, z, name=name)
+
+
+@pytest.mark.parametrize('name', util_test.all_names())
+def test_xy_1d(name):
+    z = [[0, 1, 2], [3, 4, 5]]
+    cont_gen = contourpy.contour_generator([0, 1, 2], [0, 1], z, name=name)
+    with pytest.raises(TypeError):
+        cont_gen = contourpy.contour_generator([0, 1], [0, 1], z, name=name)
+    with pytest.raises(TypeError):
+        cont_gen = contourpy.contour_generator([0, 1, 2, 3], [0, 1], z, name=name)
+    with pytest.raises(TypeError):
+        cont_gen = contourpy.contour_generator([0, 1, 2], [0], z, name=name)
+    with pytest.raises(TypeError):
+        cont_gen = contourpy.contour_generator([0, 1, 2], [0, 1, 2], z, name=name)
+
+
+@pytest.mark.parametrize('name', util_test.all_names())
+@pytest.mark.parametrize('diff_shape', ( [[1, 2, 3, 4], [5, 6, 7, 8]],
+                                         [[1, 2], [3, 4], [5, 6]] ))
+def test_wrapper_diff_shapes(xyz_as_lists, name, diff_shape):
+    x, y, z = xyz_as_lists
+    with pytest.raises(TypeError):
+        cont_gen = contourpy.contour_generator(diff_shape, y, z, name=name)
+    with pytest.raises(TypeError):
+        cont_gen = contourpy.contour_generator(x, diff_shape, z, name=name)
+    with pytest.raises(TypeError):
+        cont_gen = contourpy.contour_generator(x, y, diff_shape, name=name)
+
+
+@pytest.mark.parametrize('name', util_test.all_names())
+def test_chunk_size_negative(xyz_as_lists, name):
     x, y, z = xyz_as_lists
     with pytest.raises(ValueError, match='chunk_size cannot be negative'):
         cont_gen = contourpy.contour_generator(x, y, z, name=name, chunk_size=-1)


### PR DESCRIPTION
In `contour_generator`, `x` and `y` can now be

- 2D arrays of shape `(ny, nx)`.
- 1D arrays of shape `(nx,)` and `(ny,)` respectively.
- `None`, in which case `np.arange(nx)` and `np.arange(ny)` are used.

C/C++ code still expects 2D arrays for both.