### PR TITLE
Fix bug when chunking on windows

### DIFF
--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -868,8 +868,8 @@ void SerialContourGenerator::init_cache_levels_and_starts(ChunkLocal& local)
         index_t quad = istart + j*_nx;
         const double* z_ptr = _z.data() + quad;
         bool start_in_row = false;
-        ZLevel z_nw = istart == 0 ? 0 : Z_NW;
-        ZLevel z_sw = istart == 0 ? 0 : Z_SW;
+        ZLevel z_nw = (istart > 0) ? Z_NW : 0;
+        ZLevel z_sw = (istart > 0 && j > 0) ? Z_SW : 0;
 
         for (index_t i = istart; i <= iend; ++i, ++quad, ++z_ptr) {
             _cache[quad] &= keep_mask;
@@ -888,7 +888,7 @@ void SerialContourGenerator::init_cache_levels_and_starts(ChunkLocal& local)
 
             // z-level of SE point already calculated if j > 0; not needed
             // if j == 0.
-            ZLevel z_se = (j > 0 ? Z_SE : 0);
+            ZLevel z_se = (j > 0) ? Z_SE : 0;
 
             if (EXISTS_QUAD(quad)) {
                 if (_filled) {

--- a/src/serial_corner.cpp
+++ b/src/serial_corner.cpp
@@ -1174,8 +1174,8 @@ void SerialCornerContourGenerator::init_cache_levels_and_starts(ChunkLocal& loca
         index_t quad = istart + j*_nx;
         const double* z_ptr = _z.data() + quad;
         bool start_in_row = false;
-        ZLevel z_nw = istart == 0 ? 0 : Z_NW;
-        ZLevel z_sw = istart == 0 ? 0 : Z_SW;
+        ZLevel z_nw = (istart > 0) ? Z_NW : 0;
+        ZLevel z_sw = (istart > 0 && j > 0) ? Z_SW : 0;
 
         for (index_t i = istart; i <= iend; ++i, ++quad, ++z_ptr) {
             _cache[quad] &= keep_mask;
@@ -1194,7 +1194,7 @@ void SerialCornerContourGenerator::init_cache_levels_and_starts(ChunkLocal& loca
 
             // z-level of SE point already calculated if j > 0; not needed
             // if j == 0.
-            ZLevel z_se = (j > 0 ? Z_SE : 0);
+            ZLevel z_se = (j > 0) ? Z_SE : 0;
 
             if (EXISTS_ANY(quad)) {
                 if (_filled) {

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -41,9 +41,6 @@ def test_filled_random_uniform_no_corner_mask(name, fill_type):
 @pytest.mark.parametrize(
     'name, fill_type', util_test.all_names_and_fill_types())
 def test_filled_random_uniform_no_corner_mask_chunk(name, fill_type):
-
-    pytest.skip()
-
     if name in ('mpl2005', 'mpl2014'):
         pytest.skip()
 

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -115,9 +115,6 @@ def test_lines_random_uniform_no_corner_mask(name, line_type):
 @pytest.mark.parametrize(
     'name, line_type', util_test.all_names_and_line_types())
 def test_lines_random_uniform_no_corner_mask_chunk(name, line_type):
-
-    pytest.skip()
-
     if name in ('mpl2005', 'mpl2014'):
         pytest.skip()
 


### PR DESCRIPTION
Access violation when using chunking on windows (issue #19) due to reading memory before the beginning of `_cache` in `init_cache_levels_and_starts`.  Value read was never used.  Didn't report any access violations on linux or macos.