### PR TITLE
Separate contourpy.max_threads() function

### DIFF
--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -1,5 +1,5 @@
 from ._contourpy import (
-    FillType, Interp, LineType, Mpl2014ContourGenerator,
+    max_threads, FillType, Interp, LineType, Mpl2014ContourGenerator,
     SerialContourGenerator, ThreadedContourGenerator)
 from ._mpl2005 import Cntr as Mpl2005ContourGenerator
 from .util.chunk import two_factors

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ _contourpy = Pybind11Extension(
         'src/outer_or_hole.cpp',
         'src/serial.cpp',
         'src/threaded.cpp',
+        'src/util.cpp',
         'src/wrap.cpp',
     ],
     define_macros=define_macros,

--- a/src/common.h
+++ b/src/common.h
@@ -17,8 +17,8 @@ typedef py::array_t<double, py::array::c_style | py::array::forcecast> Coordinat
 typedef py::array_t<bool,   py::array::c_style | py::array::forcecast> MaskArray;
 
 // Output numpy array classes.
-typedef py::array_t<double>  PointArray;
-typedef py::array_t<uint8_t> CodeArray;
+typedef py::array_t<double>   PointArray;
+typedef py::array_t<uint8_t>  CodeArray;
 typedef py::array_t<uint32_t> OffsetArray;
 
 #endif // CONTOURPY_COMMON_H

--- a/src/threaded.cpp
+++ b/src/threaded.cpp
@@ -1,6 +1,7 @@
 #include "chunk_local.h"
 #include "converter.h"
 #include "threaded.h"
+#include "util.h"
 #include <iostream>
 #include <thread>
 
@@ -115,9 +116,8 @@ ThreadedContourGenerator::ThreadedContourGenerator(
       _upper_level(0.0),
       _identify_holes(false),
       _return_list_count(0),
-      _max_threads(static_cast<index_t>(std::thread::hardware_concurrency())),
-      _n_threads(n_threads == 0 ? std::min(_max_threads, _n_chunks)
-                                : std::min({_max_threads, _n_chunks, n_threads})),
+      _n_threads(n_threads == 0 ? std::min(Util::get_max_threads(), _n_chunks)
+                                : std::min({Util::get_max_threads(), _n_chunks, n_threads})),
       _next_chunk(0)
 {
     if (_x.ndim() != 2 || _y.ndim() != 2 || _z.ndim() != 2)
@@ -977,11 +977,6 @@ FillType ThreadedContourGenerator::get_fill_type() const
 LineType ThreadedContourGenerator::get_line_type() const
 {
     return _line_type;
-}
-
-index_t ThreadedContourGenerator::get_max_threads() const
-{
-    return _max_threads;
 }
 
 index_t ThreadedContourGenerator::get_thread_count() const

--- a/src/threaded.h
+++ b/src/threaded.h
@@ -35,7 +35,6 @@ public:
     FillType get_fill_type() const;
     LineType get_line_type() const;
 
-    index_t get_max_threads() const;
     index_t get_thread_count() const;
 
     py::sequence filled(const double& lower_level, const double& upper_level);
@@ -173,7 +172,6 @@ private:
     unsigned int _return_list_count;
 
     // Multithreading member variables.
-    index_t _max_threads;      // Max number of threads available.
     index_t _n_threads;        // Number of threads used.
     index_t _next_chunk;       // Next available chunk for thread to process.
     index_t _finished_count;   // Count of threads that have finished the cache init.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,0 +1,7 @@
+#include "util.h"
+#include <thread>
+
+index_t Util::get_max_threads()
+{
+    return static_cast<index_t>(std::thread::hardware_concurrency());
+}

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,12 @@
+#ifndef CONTOURPY_UTIL_H
+#define CONTOURPY_UTIL_H
+
+#include "common.h"
+
+class Util
+{
+public:
+    static index_t get_max_threads();
+};
+
+#endif // CONTOURPY_UTIL_H

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -5,6 +5,7 @@
 #include "mpl2014.h"
 #include "serial.h"
 #include "threaded.h"
+#include "util.h"
 
 PYBIND11_MODULE(_contourpy, m) {
     m.doc() = "doc notes";
@@ -124,8 +125,6 @@ PYBIND11_MODULE(_contourpy, m) {
         .def_property_readonly(
             "line_type", &ThreadedContourGenerator::get_line_type)
         .def_property_readonly(
-            "max_threads", &ThreadedContourGenerator::get_max_threads)
-        .def_property_readonly(
             "thread_count", &ThreadedContourGenerator::get_thread_count)
         .def_property_readonly_static(
             "default_fill_type",
@@ -164,4 +163,6 @@ PYBIND11_MODULE(_contourpy, m) {
         .value("ChunkCombinedCodes", LineType::ChunkCombinedCodes)
         .value("ChunkCombinedOffsets", LineType::ChunkCombinedOffsets)
         .export_values();
+
+    m.def("max_threads", &Util::get_max_threads, "docs");
 }

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -220,11 +220,11 @@ def test_thread_count(xyz_7x5_as_arrays, chunk_size, thread_count):
         x, y, z, name=name, chunk_size=chunk_size, thread_count=thread_count)
     ret_thread_count = cont_gen.thread_count
     ret_chunk_count = np.prod(cont_gen.chunk_count)
-    ret_max_threads = cont_gen.max_threads  
+    max_threads = contourpy.max_threads()  
     if chunk_size == 0:
         assert ret_chunk_count == 1
         assert ret_thread_count == 1
     elif thread_count == 0:
-        assert ret_thread_count == min(ret_max_threads, ret_chunk_count)
+        assert ret_thread_count == min(max_threads, ret_chunk_count)
     else:
-        assert ret_thread_count == min(ret_max_threads, ret_chunk_count, ret_thread_count)
+        assert ret_thread_count == min(max_threads, ret_chunk_count, ret_thread_count)


### PR DESCRIPTION
Moved C++ `get_max_threads()` out of threaded algorithm and into separate file.  This can now be accessed from python using
```python
contourpy.max_threads()
```
without/before having to create a `ThreadedContourGenerator`.