### PR TITLE
Add full set of properties and static functions to mpl2005 and mpl2014

### DIFF
--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -1,10 +1,15 @@
 from ._contourpy import (
     max_threads, FillType, Interp, LineType, Mpl2014ContourGenerator,
     SerialContourGenerator, ThreadedContourGenerator)
-from ._mpl2005 import Cntr as Mpl2005ContourGenerator
-from .util.chunk import two_factors
-import math
+from .mpl2005 import Mpl2005ContourGenerator
+from .util.chunk import calc_chunk_sizes
 import numpy as np
+
+
+def _name_to_class(name):
+    class_name = f'{name.capitalize()}ContourGenerator'
+    cls = globals()[class_name]
+    return cls
 
 
 def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None,
@@ -20,7 +25,7 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None,
     if z.shape[0] < 2 or z.shape[1] < 2:
         raise TypeError('Input z must be at least a (2, 2) shaped array, '
                         f'but has shape {z.shape}')
-    
+
     ny, nx = z.shape
 
     # Check arguments: x and y.
@@ -58,112 +63,63 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None,
     if mask is not None and mask.shape != z.shape:
         raise ValueError('If mask is set it must be a 2D array with the same shape as z')
 
-    # Default name.
+    # Check arguments: name.
     if name is None:
-        name = 'mpl2014'
+        name = 'serial'  # Default algorithm.
 
-    # Chunk size, count and total count.
-    if sum([chunk_size is not None, chunk_count is not None,
-        total_chunk_count is not None]) > 1:
-        raise ValueError('Only one of chunk_size, chunk_count and total_chunk_count should be set')
+    if name not in ('mpl2005', 'mpl2014', 'serial', 'threaded'):
+        raise ValueError(f'Unrecognised contour generator name: {name}')
 
-    if total_chunk_count is not None:
-        max_chunk_count = (nx-1)*(ny-1)
-        total_chunk_count = min(max(total_chunk_count, 1), max_chunk_count)
-        if total_chunk_count == 1:
-            chunk_size = 0
-        elif total_chunk_count == max_chunk_count:
-            chunk_size = (1, 1)
-        else:
-            factors = two_factors(total_chunk_count)
-            if ny > nx:
-                chunk_count = factors
-            else:
-                chunk_count = (factors[1], factors[0])
+    # Check arguments: chunk_size, chunk_count and total_chunk_count.
+    y_chunk_size, x_chunk_size = calc_chunk_sizes(
+        chunk_size, chunk_count, total_chunk_count, ny, nx)
 
-    if chunk_count is not None:
-        if isinstance(chunk_count, tuple):
-            y_chunk_count, x_chunk_count = chunk_count
-        else:
-            y_chunk_count = x_chunk_count = chunk_count
-        x_chunk_count = min(max(x_chunk_count, 1), nx-1)
-        y_chunk_count = min(max(y_chunk_count, 1), ny-1)
-        chunk_size = (math.ceil((ny-1) / y_chunk_count),
-                      math.ceil((nx-1) / x_chunk_count))
+    cls = _name_to_class(name)
 
-    if chunk_size is None:
-        y_chunk_size = x_chunk_size = 0
-    elif isinstance(chunk_size, tuple):
-        y_chunk_size, x_chunk_size = chunk_size
+    # Check arguments: corner_mask.
+    if corner_mask is None:
+        # Set it to default.
+        corner_mask = getattr(cls, 'supports_corner_mask')()
+    elif corner_mask and not getattr(cls, 'supports_corner_mask')():
+            raise ValueError(f'{name} contour generator does not support corner_mask=True')
+
+    # Check arguments: line_type.
+    if line_type is None:
+        line_type = getattr(cls, 'default_line_type')
+    if not getattr(cls, 'supports_line_type')(line_type):
+        raise ValueError(f'{name} contour generator does not support line_type {line_type}')
+
+    # Check arguments: fill_type.
+    if fill_type is None:
+        fill_type = getattr(cls, 'default_fill_type')
+    if not getattr(cls, 'supports_fill_type')(fill_type):
+        raise ValueError(f'{name} contour generator does not support fill_type {fill_type}')
+
+    # Check arguments: interp.
+    if interp != Interp.Linear and not getattr(cls, 'supports_interp')():
+        raise ValueError(f'{name} contour generator does not support interp {interp}')
+
+    # Check arguments: thread_count.
+    if thread_count not in (0, 1) and not getattr(cls, 'supports_threads')():
+        raise ValueError(f'{name} contour generator does not support thread_count {thread_count}')
+
+    # Create contour generator.
+    if name == 'mpl2005':
+        cont_gen = Mpl2005ContourGenerator(
+            x, y, z, mask, x_chunk_size=x_chunk_size,
+            y_chunk_size=y_chunk_size)
+    elif name == 'mpl2014':
+        cont_gen = Mpl2014ContourGenerator(
+            x, y, z, mask, corner_mask=corner_mask,
+            x_chunk_size=x_chunk_size, y_chunk_size=y_chunk_size)
+    elif name == 'serial':
+        cont_gen = SerialContourGenerator(
+            x, y, z, mask, corner_mask, line_type, fill_type, interp,
+            x_chunk_size=x_chunk_size, y_chunk_size=y_chunk_size)
     else:
-        y_chunk_size = x_chunk_size = chunk_size
-
-    if x_chunk_size < 0 or y_chunk_size < 0:
-        raise ValueError('chunk_size cannot be negative')
-
-    if name in ('serial', 'threaded'):
-        if corner_mask is None:
-            corner_mask = True
-
-        if name == 'serial':
-            if line_type is None:
-                line_type = SerialContourGenerator.default_line_type
-            if not SerialContourGenerator.supports_line_type(line_type):
-                raise ValueError(f'{name} contour generator does not support line_type {line_type}')
-
-            if fill_type is None:
-                fill_type = SerialContourGenerator.default_fill_type
-            if not SerialContourGenerator.supports_fill_type(fill_type):
-                raise ValueError(f'{name} contour generator does not support fill_type {fill_type}')
-        else:
-            if line_type is None:
-                line_type = ThreadedContourGenerator.default_line_type
-            if not ThreadedContourGenerator.supports_line_type(line_type):
-                raise ValueError(f'{name} contour generator does not support line_type {line_type}')
-
-            if fill_type is None:
-                fill_type = ThreadedContourGenerator.default_fill_type
-            if not ThreadedContourGenerator.supports_fill_type(fill_type):
-                raise ValueError(f'{name} contour generator does not support fill_type {fill_type}')
-
-        if name == 'serial' and thread_count != 0:
-            raise ValueError(f'{name} contour generator does not support thread_count {thread_count}')
-
-        if name == 'serial':
-            cont_gen = SerialContourGenerator(
-                x, y, z, mask, corner_mask, line_type, fill_type, interp,
-                x_chunk_size=x_chunk_size, y_chunk_size=y_chunk_size)
-        else:
-            cont_gen = ThreadedContourGenerator(
-                x, y, z, mask, corner_mask, line_type, fill_type, interp,
-                x_chunk_size=x_chunk_size, y_chunk_size=y_chunk_size,
-                thread_count=thread_count)
-    else:
-        if line_type not in (None, LineType.SeparateCodes):
-            raise ValueError(f'{name} contour generator does not support line_type {line_type}')
-
-        if fill_type not in (None, FillType.OuterCodes):
-            raise ValueError(f'{name} contour generator does not support fill_type {fill_type}')
-
-        if interp != Interp.Linear:
-            raise ValueError(f'{name} contour generator does not support interp {interp}')
-
-        if thread_count != 0:
-            raise ValueError(f'{name} contour generator does not support thread_count {thread_count}')
-
-        if name == 'mpl2014':
-            if corner_mask is None:
-                corner_mask = True
-            cont_gen = Mpl2014ContourGenerator(
-                x, y, z, mask, corner_mask=corner_mask,
-                x_chunk_size=x_chunk_size, y_chunk_size=y_chunk_size)
-        elif name == 'mpl2005':
-            if corner_mask:
-                raise ValueError('mpl2005 contour generator does not support corner_mask=True')
-            cont_gen = Mpl2005ContourGenerator(
-                x, y, z, mask, x_chunk_size=x_chunk_size,
-                y_chunk_size=y_chunk_size)
-        else:
-            raise ValueError(f'Unrecognised contour generator name: {name}')
+        cont_gen = ThreadedContourGenerator(
+            x, y, z, mask, corner_mask, line_type, fill_type, interp,
+            x_chunk_size=x_chunk_size, y_chunk_size=y_chunk_size,
+            thread_count=thread_count)
 
     return cont_gen

--- a/lib/contourpy/mpl2005.py
+++ b/lib/contourpy/mpl2005.py
@@ -1,0 +1,46 @@
+from ._contourpy import FillType, LineType
+from ._mpl2005 import Cntr
+
+
+class Mpl2005ContourGenerator(Cntr):
+    default_fill_type = FillType.OuterCodes
+    default_line_type = LineType.SeparateCodes
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @property
+    def chunk_count(self):
+        return self._get_chunk_count()
+
+    @property
+    def chunk_size(self):
+        return self._get_chunk_size()
+
+    @property
+    def fill_type(self):
+        return Mpl2005ContourGenerator.default_fill_type
+
+    @property
+    def line_type(self):
+        return Mpl2005ContourGenerator.default_line_type
+
+    @staticmethod
+    def supports_corner_mask():
+        return False
+
+    @staticmethod
+    def supports_fill_type(fill_type):
+        return fill_type == Mpl2005ContourGenerator.default_fill_type
+
+    @staticmethod
+    def supports_interp():
+        return False
+
+    @staticmethod
+    def supports_line_type(line_type):
+        return line_type == Mpl2005ContourGenerator.default_line_type
+
+    @staticmethod
+    def supports_threads():
+        return False

--- a/lib/contourpy/util/chunk.py
+++ b/lib/contourpy/util/chunk.py
@@ -1,8 +1,51 @@
 import math
 
+
+def calc_chunk_sizes(chunk_size, chunk_count, total_chunk_count, ny, nx):
+    if sum([chunk_size is not None, chunk_count is not None,
+        total_chunk_count is not None]) > 1:
+        raise ValueError('Only one of chunk_size, chunk_count and total_chunk_count should be set')
+
+    if total_chunk_count is not None:
+        max_chunk_count = (nx-1)*(ny-1)
+        total_chunk_count = min(max(total_chunk_count, 1), max_chunk_count)
+        if total_chunk_count == 1:
+            chunk_size = 0
+        elif total_chunk_count == max_chunk_count:
+            chunk_size = (1, 1)
+        else:
+            factors = two_factors(total_chunk_count)
+            if ny > nx:
+                chunk_count = factors
+            else:
+                chunk_count = (factors[1], factors[0])
+
+    if chunk_count is not None:
+        if isinstance(chunk_count, tuple):
+            y_chunk_count, x_chunk_count = chunk_count
+        else:
+            y_chunk_count = x_chunk_count = chunk_count
+        x_chunk_count = min(max(x_chunk_count, 1), nx-1)
+        y_chunk_count = min(max(y_chunk_count, 1), ny-1)
+        chunk_size = (math.ceil((ny-1) / y_chunk_count),
+                        math.ceil((nx-1) / x_chunk_count))
+
+    if chunk_size is None:
+        y_chunk_size = x_chunk_size = 0
+    elif isinstance(chunk_size, tuple):
+        y_chunk_size, x_chunk_size = chunk_size
+    else:
+        y_chunk_size = x_chunk_size = chunk_size
+
+    if x_chunk_size < 0 or y_chunk_size < 0:
+        raise ValueError('chunk_size cannot be negative')
+
+    return y_chunk_size, x_chunk_size
+
+
 # Splits integer n into two integer factors that are as close as possible to
 # the sqrt of n, and returns them in decreasing order.  Worst case returns
-# (n, 1). 
+# (n, 1).
 def two_factors(n):
     i = math.ceil(math.sqrt(n))
     while n % i != 0:

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
-from setuptools import setup, find_packages
+import numpy as np
+from setuptools import Extension, find_packages, setup
 from pybind11.setup_helpers import (
-    Pybind11Extension, build_ext, ParallelCompile, naive_recompile)
+    build_ext, naive_recompile, ParallelCompile, Pybind11Extension)
 
 
 # Set want_debug to True if want to enable asserts in C++ code.
 want_debug = False
-
-want_mpl2005 = True
 
 
 __version__ = '0.0.1'
@@ -40,27 +39,19 @@ _contourpy = Pybind11Extension(
     undef_macros=undef_macros,
 )
 
-ext_modules=[_contourpy]
+_mpl2005 = Extension(
+    'contourpy._mpl2005',
+    sources=['src/mpl2005.c'],
+    undef_macros=undef_macros,
+    include_dirs=[np.get_include()],
+    define_macros=define_macros + [
+        ('PY_ARRAY_UNIQUE_SYMBOL', 'CNTR_ARRAY_API'),
+        ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION'),
+        ('__STDC_FORMAT_MACROS', 1),
+    ],
+)
 
-
-if want_mpl2005:
-    # Using original C code and Python/C API wrapper.
-    # numpy is in pyproject.toml rather than requirements/install.txt for this.
-    import numpy as np
-    from setuptools import Extension
-
-    _mpl2005 = Extension(
-        'contourpy._mpl2005',
-        sources=['src/mpl2005.c'],
-        undef_macros=undef_macros,
-        include_dirs=[np.get_include()],
-        define_macros=define_macros + [
-            ('PY_ARRAY_UNIQUE_SYMBOL', 'CNTR_ARRAY_API'),
-            ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION'),
-            ('__STDC_FORMAT_MACROS', 1),
-        ],
-    )
-    ext_modules.append(_mpl2005)
+ext_modules=[_contourpy, _mpl2005]
 
 
 

--- a/src/mpl2014.cpp
+++ b/src/mpl2014.cpp
@@ -534,6 +534,16 @@ index_t Mpl2014ContourGenerator::calc_chunk_count(
         return 1;
 }
 
+FillType Mpl2014ContourGenerator::default_fill_type()
+{
+    return FillType::OuterCodes;
+}
+
+LineType Mpl2014ContourGenerator::default_line_type()
+{
+    return LineType::SeparateCodes;
+}
+
 void Mpl2014ContourGenerator::edge_interp(const QuadEdge& quad_edge,
                                           const double& level,
                                           ContourLine& contour_line)
@@ -1071,6 +1081,16 @@ Edge Mpl2014ContourGenerator::get_exit_edge(const QuadEdge& quad_edge,
             default: assert(0 && "Invalid edge"); return Edge_None;
         }
     }
+}
+
+FillType Mpl2014ContourGenerator::get_fill_type() const
+{
+    return FillType::OuterCodes;
+}
+
+LineType Mpl2014ContourGenerator::get_line_type() const
+{
+    return LineType::SeparateCodes;
 }
 
 const double& Mpl2014ContourGenerator::get_point_x(index_t point) const
@@ -1802,6 +1822,16 @@ bool Mpl2014ContourGenerator::start_line(
         contour_line, vertices_list, codes_list);
 
     return VISITED(quad,1);
+}
+
+bool Mpl2014ContourGenerator::supports_fill_type(FillType fill_type)
+{
+    return fill_type == FillType::OuterCodes;
+}
+
+bool Mpl2014ContourGenerator::supports_line_type(LineType line_type)
+{
+    return line_type == LineType::SeparateCodes;
 }
 
 void Mpl2014ContourGenerator::write_cache(bool grid_only) const

--- a/src/mpl2014.h
+++ b/src/mpl2014.h
@@ -143,6 +143,8 @@
 #define CONTOURPY_MPL_2014_H
 
 #include "common.h"
+#include "fill_type.h"
+#include "line_type.h"
 #include <list>
 #include <iostream>
 #include <vector>
@@ -285,6 +287,9 @@ public:
     // Destructor.
     ~Mpl2014ContourGenerator();
 
+    static FillType default_fill_type();
+    static LineType default_line_type();
+
     // Create and return polygons for a filled contour between the two
     // specified levels.
     py::tuple filled(const double& lower_level, const double& upper_level);
@@ -292,9 +297,15 @@ public:
     py::tuple get_chunk_count() const;  // Return (y_chunk_count, x_chunk_count)
     py::tuple get_chunk_size() const;   // Return (y_chunk_size, x_chunk_size)
 
+    FillType get_fill_type() const;
+    LineType get_line_type() const;
+
     // Create and return polygons for a line (i.e. non-filled) contour at the
     // specified level.
     py::tuple lines(const double& level);
+
+    static bool supports_fill_type(FillType fill_type);
+    static bool supports_line_type(LineType line_type);
 
 private:
     // Typedef for following either a boundary of the domain or the interior;

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -33,11 +33,28 @@ PYBIND11_MODULE(_contourpy, m) {
         .def_property_readonly(
             "chunk_size", &mpl2014::Mpl2014ContourGenerator::get_chunk_size)
         .def_property_readonly_static(
-            "fill_type",
-            [](py::object /* self */) {return FillType::OuterCodes;})
+            "default_fill_type",
+            [](py::object /* self */) {
+                return mpl2014::Mpl2014ContourGenerator::default_fill_type();
+            })
         .def_property_readonly_static(
-            "line_type",
-            [](py::object /* self */) {return LineType::SeparateCodes;});
+            "default_line_type",
+            [](py::object /* self */) {
+                return mpl2014::Mpl2014ContourGenerator::default_line_type();
+            })
+        .def_property_readonly(
+            "fill_type", &mpl2014::Mpl2014ContourGenerator::get_fill_type)
+        .def_property_readonly(
+            "line_type", &mpl2014::Mpl2014ContourGenerator::get_line_type)
+        .def_static("supports_corner_mask", []() {return true;})
+        .def_static(
+            "supports_fill_type",
+            &mpl2014::Mpl2014ContourGenerator::supports_fill_type)
+        .def_static("supports_interp", []() {return false;})
+        .def_static(
+            "supports_line_type",
+            &mpl2014::Mpl2014ContourGenerator::supports_line_type)
+        .def_static("supports_threads", []() {return false;});
 
     py::class_<SerialContourGenerator>(m, "SerialContourGenerator")
         .def(py::init<const CoordinateArray&,
@@ -68,10 +85,6 @@ PYBIND11_MODULE(_contourpy, m) {
             "chunk_count", &SerialContourGenerator::get_chunk_count)
         .def_property_readonly(
             "chunk_size", &SerialContourGenerator::get_chunk_size)
-        .def_property_readonly(
-            "fill_type", &SerialContourGenerator::get_fill_type)
-        .def_property_readonly(
-            "line_type", &SerialContourGenerator::get_line_type)
         .def_property_readonly_static(
             "default_fill_type",
             [](py::object /* self */) {
@@ -82,12 +95,19 @@ PYBIND11_MODULE(_contourpy, m) {
             [](py::object /* self */) {
                 return SerialContourGenerator::default_line_type();
             })
+        .def_property_readonly(
+            "fill_type", &SerialContourGenerator::get_fill_type)
+        .def_property_readonly(
+            "line_type", &SerialContourGenerator::get_line_type)
+        .def_static("supports_corner_mask", []() {return true;})
         .def_static(
             "supports_fill_type",
             &SerialContourGenerator::supports_fill_type)
+        .def_static("supports_interp", []() {return true;})
         .def_static(
             "supports_line_type",
-            &SerialContourGenerator::supports_line_type);
+            &SerialContourGenerator::supports_line_type)
+        .def_static("supports_threads", []() {return false;});
 
     py::class_<ThreadedContourGenerator>(m, "ThreadedContourGenerator")
         .def(py::init<const CoordinateArray&,
@@ -120,12 +140,6 @@ PYBIND11_MODULE(_contourpy, m) {
             "chunk_count", &ThreadedContourGenerator::get_chunk_count)
         .def_property_readonly(
             "chunk_size", &ThreadedContourGenerator::get_chunk_size)
-        .def_property_readonly(
-            "fill_type", &ThreadedContourGenerator::get_fill_type)
-        .def_property_readonly(
-            "line_type", &ThreadedContourGenerator::get_line_type)
-        .def_property_readonly(
-            "thread_count", &ThreadedContourGenerator::get_thread_count)
         .def_property_readonly_static(
             "default_fill_type",
             [](py::object /* self */) {
@@ -136,12 +150,21 @@ PYBIND11_MODULE(_contourpy, m) {
             [](py::object /* self */) {
                 return ThreadedContourGenerator::default_line_type();
             })
+        .def_property_readonly(
+            "fill_type", &ThreadedContourGenerator::get_fill_type)
+        .def_property_readonly(
+            "line_type", &ThreadedContourGenerator::get_line_type)
+        .def_property_readonly(
+            "thread_count", &ThreadedContourGenerator::get_thread_count)
+        .def_static("supports_corner_mask", []() {return true;})
         .def_static(
             "supports_fill_type",
             &ThreadedContourGenerator::supports_fill_type)
+        .def_static("supports_interp", []() {return true;})
         .def_static(
             "supports_line_type",
-            &ThreadedContourGenerator::supports_line_type);
+            &ThreadedContourGenerator::supports_line_type)
+        .def_static("supports_threads", []() {return true;});
 
     py::enum_<FillType>(m, "FillType")
         .value("OuterCodes", FillType::OuterCodes)

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -1,7 +1,6 @@
 import contourpy
 import numpy as np
 import pytest
-import re
 import util_test
 
 
@@ -98,7 +97,7 @@ def test_chunk_size_negative(xyz_3x3_as_lists, name):
         cont_gen = contourpy.contour_generator(x, y, z, name=name, chunk_size=(0, -1))
 
 
-@pytest.mark.parametrize('name', util_test.all_names(exclude='mpl2005'))
+@pytest.mark.parametrize('name', util_test.all_names())
 @pytest.mark.parametrize('chunk_size', np.arange(9))
 def test_chunk_size_1d(xyz_7x5_as_arrays, name, chunk_size):
     x, y, z = xyz_7x5_as_arrays
@@ -118,7 +117,7 @@ def test_chunk_size_1d(xyz_7x5_as_arrays, name, chunk_size):
     assert (ret_x_chunk_count-1)*ret_x_chunk_size < nx-1
 
 
-@pytest.mark.parametrize('name', util_test.all_names(exclude='mpl2005'))
+@pytest.mark.parametrize('name', util_test.all_names())
 @pytest.mark.parametrize('x_chunk_size', np.arange(9))
 @pytest.mark.parametrize('y_chunk_size', np.arange(9))
 def test_chunk_size_2d(xyz_7x5_as_arrays, name, x_chunk_size, y_chunk_size):
@@ -157,7 +156,7 @@ def test_chunk_size_and_count(xyz_7x5_as_arrays):
             x, y, z, name=name, chunk_count=1, total_chunk_count=1)
 
 
-@pytest.mark.parametrize('name', util_test.all_names(exclude='mpl2005'))
+@pytest.mark.parametrize('name', util_test.all_names())
 @pytest.mark.parametrize('chunk_count, ret_chunk_count',
     [[0, (1, 1)], [1, (1, 1)], [2, (2, 2)], [3, (3, 2)], [4, (3, 4)], [9, (6, 4)]])
 def test_chunk_count_1d(xyz_7x5_as_arrays, name, chunk_count, ret_chunk_count):
@@ -174,7 +173,7 @@ def test_chunk_count_1d(xyz_7x5_as_arrays, name, chunk_count, ret_chunk_count):
     assert (ret_x_chunk_count-1)*ret_x_chunk_size < nx-1
 
 
-@pytest.mark.parametrize('name', util_test.all_names(exclude='mpl2005'))
+@pytest.mark.parametrize('name', util_test.all_names())
 @pytest.mark.parametrize('chunk_count, ret_chunk_count',
     [[(0, 1), (1, 1)], [(1, 0), (1, 1)], [(2, 3), (2, 2)], [(3, 2), (3, 2)],
      [(1, 9), (1, 4)], [(9, 1), (6, 1)]])
@@ -192,7 +191,7 @@ def test_chunk_count_1d(xyz_7x5_as_arrays, name, chunk_count, ret_chunk_count):
     assert (ret_x_chunk_count-1)*ret_x_chunk_size < nx-1
 
 
-@pytest.mark.parametrize('name', util_test.all_names(exclude='mpl2005'))
+@pytest.mark.parametrize('name', util_test.all_names())
 @pytest.mark.parametrize('total_chunk_count, ret_chunk_count',
     [[0, (1, 1)], [1, (1, 1)], [2, (2, 1)], [3, (3, 1)], [4, (2, 2)],
      [6, (3, 2)], [9, (3, 2)], [25, (6, 4)]])
@@ -220,7 +219,7 @@ def test_thread_count(xyz_7x5_as_arrays, chunk_size, thread_count):
         x, y, z, name=name, chunk_size=chunk_size, thread_count=thread_count)
     ret_thread_count = cont_gen.thread_count
     ret_chunk_count = np.prod(cont_gen.chunk_count)
-    max_threads = contourpy.max_threads()  
+    max_threads = contourpy.max_threads()
     if chunk_size == 0:
         assert ret_chunk_count == 1
         assert ret_thread_count == 1

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -25,8 +25,7 @@ def test_filled_random_uniform_no_corner_mask(name, fill_type):
         x, y, z, name=name, fill_type=fill_type, corner_mask=False)
     levels = np.arange(0.0, 1.01, 0.2)
 
-    if name != 'mpl2005':
-        assert cont_gen.fill_type == fill_type
+    assert cont_gen.fill_type == fill_type
 
     renderer = MplTestRenderer(x, y)
     for i in range(len(levels)-1):
@@ -110,6 +109,8 @@ def test_filled_random_uniform_corner_mask_chunk(name):
     if name in ('serial', 'threaded'):
         max_threshold = 134
         mean_threshold = 0.17
+
+
 
     compare_images(image_buffer, 'filled_random_uniform_corner_mask_chunk.png',
                    f'{name}_{fill_type}', max_threshold=max_threshold,

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -100,8 +100,7 @@ def test_lines_random_uniform_no_corner_mask(name, line_type):
         x, y, z, name=name, line_type=line_type, corner_mask=False)
     levels = np.arange(0.0, 1.01, 0.2)
 
-    if name != 'mpl2005':
-        assert cont_gen.line_type == line_type
+    assert cont_gen.line_type == line_type
 
     renderer = MplTestRenderer(x, y)
     for i in range(len(levels)):

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,0 +1,83 @@
+from contourpy import (
+    FillType, LineType, Mpl2005ContourGenerator, Mpl2014ContourGenerator,
+    SerialContourGenerator, ThreadedContourGenerator)
+import pytest
+import util_test
+
+
+def get_class_from_name(name):
+    return globals()[name]
+
+
+@pytest.mark.parametrize('class_name', util_test.all_class_names())
+def test_default_fill_type(class_name):
+    cls = get_class_from_name(class_name)
+    default = getattr(cls, 'default_fill_type')
+    assert isinstance(default, FillType)
+    expect = FillType.OuterCodes
+    assert default == expect
+
+
+@pytest.mark.parametrize('class_name', util_test.all_class_names())
+def test_default_line_type(class_name):
+    cls = get_class_from_name(class_name)
+    default = getattr(cls, 'default_line_type')
+    assert isinstance(default, LineType)
+    expect = LineType.SeparateCodes
+    assert default == expect
+
+
+@pytest.mark.parametrize('class_name', util_test.all_class_names())
+def test_supports_corner_mask(class_name):
+    cls = get_class_from_name(class_name)
+    supports = getattr(cls, 'supports_corner_mask')()
+    assert isinstance(supports, bool)
+    expect = class_name != 'Mpl2005ContourGenerator'
+    assert supports == expect
+
+
+@pytest.mark.parametrize('class_name', util_test.all_class_names())
+def test_supports_fill_type(class_name):
+    cls = get_class_from_name(class_name)
+    supports = getattr(cls, 'supports_fill_type')(FillType.OuterCodes)
+    assert isinstance(supports, bool)
+    expect = True
+    assert supports == expect
+    supports = getattr(cls, 'supports_fill_type')(FillType.ChunkCombinedOffsets2)
+    assert isinstance(supports, bool)
+    expect = class_name not in (
+        'Mpl2005ContourGenerator', 'Mpl2014ContourGenerator')
+    assert supports == expect
+
+
+@pytest.mark.parametrize('class_name', util_test.all_class_names())
+def test_supports_interp(class_name):
+    cls = get_class_from_name(class_name)
+    supports = getattr(cls, 'supports_interp')()
+    assert isinstance(supports, bool)
+    expect = class_name not in (
+        'Mpl2005ContourGenerator', 'Mpl2014ContourGenerator')
+    assert supports == expect
+
+
+@pytest.mark.parametrize('class_name', util_test.all_class_names())
+def test_supports_line_type(class_name):
+    cls = get_class_from_name(class_name)
+    supports = getattr(cls, 'supports_line_type')(LineType.SeparateCodes)
+    assert isinstance(supports, bool)
+    expect = True
+    assert supports == expect
+    supports = getattr(cls, 'supports_line_type')(LineType.ChunkCombinedOffsets)
+    assert isinstance(supports, bool)
+    expect = class_name not in (
+        'Mpl2005ContourGenerator', 'Mpl2014ContourGenerator')
+    assert supports == expect
+
+
+@pytest.mark.parametrize('class_name', util_test.all_class_names())
+def test_supports_threads(class_name):
+    cls = get_class_from_name(class_name)
+    supports = getattr(cls, 'supports_threads')()
+    assert isinstance(supports, bool)
+    expect = class_name == 'ThreadedContourGenerator'
+    assert supports == expect

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,8 +1,17 @@
 from contourpy import FillType, LineType
 
 
+def all_class_names():
+    return [
+        'Mpl2005ContourGenerator',
+        'Mpl2014ContourGenerator',
+        'SerialContourGenerator',
+        'ThreadedContourGenerator',
+    ]
+
+
 def all_names(exclude=None):
-    all_ = ['mpl2014', 'mpl2005', 'serial', 'threaded']
+    all_ = ['mpl2005', 'mpl2014', 'serial', 'threaded']
     if exclude is not None:
         all_.remove(exclude)
     return all_


### PR DESCRIPTION
Added various `default_` and `supports_` functions/properties to `mpl2005` and `mpl2014`.

Wrapped `mpl2005` C extension with a Python wrapper so that don't have to make C extension aware of C++ enums like `FillType`.  Removed some unused code in C extension.

Improved `contour_generator` in `__init__.py` to check validity of arguments and their default values using the classes themselves rather than being hard-coded.