### PR TITLE
Renderer improvements

### DIFF
--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -1,5 +1,4 @@
-from contourpy import FillType, LineType
-from .mpl_util import mpl_codes_to_offsets
+from .bokeh_util import filled_to_bokeh, lines_to_bokeh
 
 from bokeh.io import export_png, export_svg
 from bokeh.layouts import gridplot
@@ -43,48 +42,7 @@ class BokehRenderer:
     def filled(self, filled, fill_type, ax=0, color='C0', alpha=0.7):
         fig = self._get_figure(ax)
         color = self._convert_color(color)
-        xs = []
-        ys = []
-
-        if fill_type in (FillType.OuterOffsets, FillType.ChunkCombinedOffsets,
-                         FillType.OuterCodes, FillType.ChunkCombinedCodes):
-            have_codes = \
-                fill_type in (FillType.OuterCodes,
-                              FillType.ChunkCombinedCodes)
-
-            for points, offsets in zip(*filled):
-                if points is None:
-                    continue
-                if have_codes:
-                    offsets = mpl_codes_to_offsets(offsets)
-                xs.append([])  # New outer with zero or more holes.
-                ys.append([])
-                for i in range(len(offsets)-1):
-                    xys = points[offsets[i]:offsets[i+1]]
-                    xs[-1].append(xys[:, 0])
-                    ys[-1].append(xys[:, 1])
-        elif fill_type in (FillType.ChunkCombinedCodesOffsets,
-                           FillType.ChunkCombinedOffsets2):
-            for points, codes_or_offsets, outer_offsets in zip(*filled):
-                if points is None:
-                    continue
-                for j in range(len(outer_offsets)-1):
-                    if fill_type == FillType.ChunkCombinedCodesOffsets:
-                        codes = codes_or_offsets[outer_offsets[j]:
-                                                 outer_offsets[j+1]]
-                        offsets = mpl_codes_to_offsets(codes) + outer_offsets[j]
-                    else:
-                        offsets = codes_or_offsets[outer_offsets[j]:
-                                                   outer_offsets[j+1]+1]
-                    xs.append([])  # New outer with zero or more holes.
-                    ys.append([])
-                    for k in range(len(offsets)-1):
-                        xys = points[offsets[k]:offsets[k+1]]
-                        xs[-1].append(xys[:, 0])
-                        ys[-1].append(xys[:, 1])
-        else:
-            raise RuntimeError(f'Rendering FillType {fill_type} not implemented')
-
+        xs, ys = filled_to_bokeh(filled, fill_type)
         if len(xs) > 0:
             fig.multi_polygons(
                 xs=[xs], ys=[ys], color=color, fill_alpha=alpha, line_width=0)
@@ -104,32 +62,7 @@ class BokehRenderer:
         # Assumes all lines are open line loops.
         fig = self._get_figure(ax)
         color = self._convert_color(color)
-        xs = []
-        ys = []
-
-        if line_type == LineType.Separate:
-            for line in lines:
-                xs.append(line[:, 0])
-                ys.append(line[:, 1])
-        elif line_type == LineType.SeparateCodes:
-            for line in lines[0]:
-                xs.append(line[:, 0])
-                ys.append(line[:, 1])
-        elif line_type in (LineType.ChunkCombinedCodes,
-                           LineType.ChunkCombinedOffsets):
-            for points, offsets in zip(*lines):
-                if points is None:
-                    continue
-                if line_type == LineType.ChunkCombinedCodes:
-                    offsets = mpl_codes_to_offsets(offsets)
-
-                for i in range(len(offsets)-1):
-                    line = points[offsets[i]:offsets[i+1]]
-                    xs.append(line[:, 0])
-                    ys.append(line[:, 1])
-        else:
-            raise RuntimeError(f'Rendering LineType {line_type} not implemented')
-
+        xs, ys = lines_to_bokeh(lines, line_type)
         if len(xs) > 0:
             fig.multi_line(xs, ys, line_color=color, line_alpha=alpha,
                            line_width=linewidth)

--- a/lib/contourpy/util/bokeh_util.py
+++ b/lib/contourpy/util/bokeh_util.py
@@ -1,0 +1,75 @@
+from contourpy import FillType, LineType
+from .mpl_util import mpl_codes_to_offsets
+import numpy as np
+
+
+def filled_to_bokeh(filled, fill_type):
+    xs = []
+    ys = []
+    if fill_type in (
+        FillType.OuterOffsets, FillType.ChunkCombinedOffsets,
+        FillType.OuterCodes, FillType.ChunkCombinedCodes):
+        have_codes = \
+            fill_type in (FillType.OuterCodes, FillType.ChunkCombinedCodes)
+
+        for points, offsets in zip(*filled):
+            if points is None:
+                continue
+            if have_codes:
+                offsets = mpl_codes_to_offsets(offsets)
+            xs.append([])  # New outer with zero or more holes.
+            ys.append([])
+            for i in range(len(offsets)-1):
+                xys = points[offsets[i]:offsets[i+1]]
+                xs[-1].append(xys[:, 0])
+                ys[-1].append(xys[:, 1])
+    elif fill_type in (
+        FillType.ChunkCombinedCodesOffsets, FillType.ChunkCombinedOffsets2):
+        for points, codes_or_offsets, outer_offsets in zip(*filled):
+            if points is None:
+                continue
+            for j in range(len(outer_offsets)-1):
+                if fill_type == FillType.ChunkCombinedCodesOffsets:
+                    codes = codes_or_offsets[outer_offsets[j]:outer_offsets[j+1]]
+                    offsets = mpl_codes_to_offsets(codes) + outer_offsets[j]
+                else:
+                    offsets = codes_or_offsets[outer_offsets[j]:outer_offsets[j+1]+1]
+                xs.append([])  # New outer with zero or more holes.
+                ys.append([])
+                for k in range(len(offsets)-1):
+                    xys = points[offsets[k]:offsets[k+1]]
+                    xs[-1].append(xys[:, 0])
+                    ys[-1].append(xys[:, 1])
+    else:
+        raise RuntimeError(f'Conversion of FillType {fill_type} to Bokeh is not implemented')
+
+    return xs, ys
+
+
+def lines_to_bokeh(lines, line_type):
+    xs = []
+    ys = []
+
+    if line_type == LineType.Separate:
+        for line in lines:
+            xs.append(line[:, 0])
+            ys.append(line[:, 1])
+    elif line_type == LineType.SeparateCodes:
+        for line in lines[0]:
+            xs.append(line[:, 0])
+            ys.append(line[:, 1])
+    elif line_type in (LineType.ChunkCombinedCodes, LineType.ChunkCombinedOffsets):
+        for points, offsets in zip(*lines):
+            if points is None:
+                continue
+            if line_type == LineType.ChunkCombinedCodes:
+                offsets = mpl_codes_to_offsets(offsets)
+
+            for i in range(len(offsets)-1):
+                line = points[offsets[i]:offsets[i+1]]
+                xs.append(line[:, 0])
+                ys.append(line[:, 1])
+    else:
+        raise RuntimeError(f'Conversion of LineType {line_type} to Bokeh is not implemented')
+
+    return xs, ys

--- a/lib/contourpy/util/mpl_util.py
+++ b/lib/contourpy/util/mpl_util.py
@@ -1,4 +1,60 @@
+from contourpy import FillType, LineType
+import matplotlib.path as mpath
 import numpy as np
+
+
+def filled_to_mpl_paths(filled, fill_type):
+    if fill_type in (FillType.OuterCodes,
+                        FillType.ChunkCombinedCodes):
+        paths = [mpath.Path(points, codes) for points, codes
+                 in zip(*filled) if points is not None]
+    elif fill_type in (FillType.OuterOffsets, FillType.ChunkCombinedOffsets):
+        paths = [mpath.Path(points, offsets_to_mpl_codes(offsets))
+                 for points, offsets in zip(*filled) if points is not None]
+    elif fill_type == FillType.ChunkCombinedCodesOffsets:
+        paths = []
+        for points, codes, outer_offsets in zip(*filled):
+            if points is None:
+                continue
+            points = np.split(points, outer_offsets[1:-1])
+            codes = np.split(codes, outer_offsets[1:-1])
+            paths += [mpath.Path(p, c) for p, c in zip(points, codes)]
+    elif fill_type == FillType.ChunkCombinedOffsets2:
+        paths = []
+        for points, offsets, outer_offsets in zip(*filled):
+            if points is None:
+                continue
+            for i in range(len(outer_offsets)-1):
+                offs = offsets[outer_offsets[i]:outer_offsets[i+1]+1]
+                pts = points[offs[0]:offs[-1]]
+                paths += [mpath.Path(pts, offsets_to_mpl_codes(offs - offs[0]))]
+    else:
+        raise RuntimeError(f'Conversion of FillType {fill_type} to MPL Paths is not implemented')
+    return paths
+
+
+def lines_to_mpl_paths(lines, line_type):
+    if line_type == LineType.Separate:
+        paths = []
+        for line in lines:
+            # Drawing as Paths so that they can be closed correctly.
+            closed = line[0, 0] == line[-1, 0] and line[0, 1] == line[-1, 1]
+            paths.append(mpath.Path(line, closed=closed))
+    elif line_type in (LineType.SeparateCodes, LineType.ChunkCombinedCodes):
+        paths = [mpath.Path(points, codes) for points, codes
+                 in zip(*lines) if points is not None]
+    elif line_type == LineType.ChunkCombinedOffsets:
+        paths = []
+        for points, offsets in zip(*lines):
+            if points is None:
+                continue
+            for i in range(len(offsets)-1):
+                line = points[offsets[i]:offsets[i+1]]
+                closed = line[0, 0] == line[-1, 0] and line[0, 1] == line[-1, 1]
+                paths.append(mpath.Path(line, closed=closed))
+    else:
+        raise RuntimeError(f'Conversion of LineType {line_type} to MPL Paths is not implemented')
+    return paths
 
 
 def mpl_codes_to_offsets(codes):

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -27,7 +27,7 @@ def test_filled_random_uniform_no_corner_mask(name, fill_type):
 
     assert cont_gen.fill_type == fill_type
 
-    renderer = MplTestRenderer(x, y)
+    renderer = MplTestRenderer()
     for i in range(len(levels)-1):
         renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type,
                         color=f'C{i}')
@@ -46,7 +46,7 @@ def test_filled_random_uniform_no_corner_mask_chunk(name, fill_type):
         chunk_size=2)
     levels = np.arange(0.0, 1.01, 0.2)
 
-    renderer = MplTestRenderer(x, y)
+    renderer = MplTestRenderer()
     for i in range(len(levels)-1):
         renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type,
                         color=f'C{i}')
@@ -80,7 +80,7 @@ def test_filled_random_uniform_corner_mask(name):
         x, y, z, name=name, corner_mask=True, fill_type=fill_type)
     levels = np.arange(0.0, 1.01, 0.2)
 
-    renderer = MplTestRenderer(x, y)
+    renderer = MplTestRenderer()
     for i in range(len(levels)-1):
         renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type,
                         color=f'C{i}')
@@ -98,7 +98,7 @@ def test_filled_random_uniform_corner_mask_chunk(name):
         x, y, z, name=name, corner_mask=True, fill_type=fill_type, chunk_size=2)
     levels = np.arange(0.0, 1.01, 0.2)
 
-    renderer = MplTestRenderer(x, y)
+    renderer = MplTestRenderer()
     for i in range(len(levels)-1):
         renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type,
                         color=f'C{i}')

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -102,7 +102,7 @@ def test_lines_random_uniform_no_corner_mask(name, line_type):
 
     assert cont_gen.line_type == line_type
 
-    renderer = MplTestRenderer(x, y)
+    renderer = MplTestRenderer()
     for i in range(len(levels)):
         renderer.lines(cont_gen.lines(levels[i]), line_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
@@ -123,7 +123,7 @@ def test_lines_random_uniform_no_corner_mask_chunk(name, line_type):
         chunk_size=2)
     levels = np.arange(0.0, 1.01, 0.2)
 
-    renderer = MplTestRenderer(x, y)
+    renderer = MplTestRenderer()
     for i in range(len(levels)):
         renderer.lines(cont_gen.lines(levels[i]), line_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
@@ -141,7 +141,7 @@ def test_lines_random_uniform_corner_mask(name):
         x, y, z, name=name, corner_mask=True, line_type=line_type)
     levels = np.arange(0.0, 1.01, 0.2)
 
-    renderer = MplTestRenderer(x, y)
+    renderer = MplTestRenderer()
     for i in range(len(levels)):
         renderer.lines(cont_gen.lines(levels[i]), line_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
@@ -158,7 +158,7 @@ def test_lines_random_uniform_corner_mask_chunk(name):
         x, y, z, name=name, corner_mask=True, line_type=line_type)
     levels = np.arange(0.0, 1.01, 0.2)
 
-    renderer = MplTestRenderer(x, y)
+    renderer = MplTestRenderer()
     for i in range(len(levels)):
         renderer.lines(cont_gen.lines(levels[i]), line_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()


### PR DESCRIPTION
Improvements to Matplotlib and Bokeh renderers:

  - Removed grid `x, y` from `Renderer` constructors.
  - Created Matplotlib utility functions: `filled_to_mpl_paths` and `lines_to_mpl_paths`.
  - Created Bokeh utility functions: `filled_to_bokeh` and `lines_to_bokeh`.