### PR TITLE
Create contour generators using args and kwargs

### DIFF
--- a/lib/contourpy/mpl2005.py
+++ b/lib/contourpy/mpl2005.py
@@ -3,10 +3,18 @@ from ._mpl2005 import Cntr
 
 
 class Mpl2005ContourGenerator(Cntr):
-    default_fill_type = FillType.OuterCodes
     default_line_type = LineType.SeparateCodes
+    default_fill_type = FillType.OuterCodes
 
     def __init__(self, *args, **kwargs):
+        line_type = kwargs.pop('line_type', None)
+        if line_type is not None and line_type != self.default_line_type:
+            raise ValueError(f'mpl2005 contour generator does not support line_type {line_type}')
+
+        fill_type = kwargs.pop('fill_type', None)
+        if fill_type is not None and fill_type != self.default_fill_type:
+            raise ValueError(f'mpl2005 contour generator does not support fill_type {fill_type}')
+
         super().__init__(*args, **kwargs)
 
     @property
@@ -19,11 +27,11 @@ class Mpl2005ContourGenerator(Cntr):
 
     @property
     def fill_type(self):
-        return Mpl2005ContourGenerator.default_fill_type
+        return self.default_fill_type
 
     @property
     def line_type(self):
-        return Mpl2005ContourGenerator.default_line_type
+        return self.default_line_type
 
     @staticmethod
     def supports_corner_mask():

--- a/src/mpl2014.cpp
+++ b/src/mpl2014.cpp
@@ -337,6 +337,8 @@ Mpl2014ContourGenerator::Mpl2014ContourGenerator(const CoordinateArray& x,
                                                  const CoordinateArray& z,
                                                  const MaskArray& mask,
                                                  bool corner_mask,
+                                                 LineType line_type,
+                                                 FillType fill_type,
                                                  index_t x_chunk_size,
                                                  index_t y_chunk_size)
     : _x(x),
@@ -373,6 +375,12 @@ Mpl2014ContourGenerator::Mpl2014ContourGenerator(const CoordinateArray& x,
         if (mask.shape(1) != _nx || mask.shape(0) != _ny)
             throw std::invalid_argument("If mask is set it must be a 2D array with the same shape as z");
     }
+
+    if (!supports_line_type(line_type))
+        throw std::invalid_argument("Unsupported LineType");
+
+    if (!supports_fill_type(fill_type))
+        throw std::invalid_argument("Unsupported FillType");
 
     if (x_chunk_size < 0 || y_chunk_size < 0)
         throw std::invalid_argument("chunk_size cannot be negative");

--- a/src/mpl2014.h
+++ b/src/mpl2014.h
@@ -281,6 +281,8 @@ public:
                             const CoordinateArray& z,
                             const MaskArray& mask,
                             bool corner_mask,
+                            LineType line_type,
+                            FillType fill_type,
                             index_t x_chunk_size,
                             index_t y_chunk_size);
 

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -134,8 +134,11 @@ SerialContourGenerator::SerialContourGenerator(
                 "If mask is set it must be a 2D array with the same shape as z");
     }
 
+    if (!supports_line_type(line_type))
+        throw std::invalid_argument("Unsupported LineType");
+
     if (!supports_fill_type(fill_type))
-        throw std::invalid_argument("Invalid FillType");
+        throw std::invalid_argument("Unsupported FillType");
 
     if (x_chunk_size < 0 || y_chunk_size < 0)  // Check inputs, not calculated.
         throw std::invalid_argument("chunk_sizes cannot be negative");
@@ -411,7 +414,7 @@ py::sequence SerialContourGenerator::filled(
                        _fill_type != FillType::ChunkCombinedOffsets);
     _return_list_count = (_fill_type == FillType::ChunkCombinedCodesOffsets ||
                           _fill_type == FillType::ChunkCombinedOffsets2) ? 3 : 2;
-  
+
     return march();
 }
 
@@ -1364,7 +1367,7 @@ py::sequence SerialContourGenerator::lines(const double& level)
     _lower_level = _upper_level = level;
     _identify_holes = false;
     _return_list_count = (_line_type == LineType::Separate) ? 1 : 2;
-  
+
     return march();
 }
 
@@ -1376,7 +1379,7 @@ py::sequence SerialContourGenerator::march()
         (!_filled && (_line_type == LineType::Separate ||
                       _line_type == LineType::SeparateCodes)))
         list_len = 0;
-    
+
     // Prepare lists to return to python.
     std::vector<py::list> return_lists;
     return_lists.reserve(_return_list_count);

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -10,12 +10,37 @@
 PYBIND11_MODULE(_contourpy, m) {
     m.doc() = "doc notes";
 
+    py::enum_<FillType>(m, "FillType")
+        .value("OuterCodes", FillType::OuterCodes)
+        .value("OuterOffsets", FillType::OuterOffsets)
+        .value("ChunkCombinedCodes", FillType::ChunkCombinedCodes)
+        .value("ChunkCombinedOffsets", FillType::ChunkCombinedOffsets)
+        .value("ChunkCombinedCodesOffsets", FillType::ChunkCombinedCodesOffsets)
+        .value("ChunkCombinedOffsets2", FillType::ChunkCombinedOffsets2)
+        .export_values();
+
+    py::enum_<Interp>(m, "Interp")
+        .value("Linear", Interp::Linear)
+        .value("Log", Interp::Log)
+        .export_values();
+
+    py::enum_<LineType>(m, "LineType")
+        .value("Separate", LineType::Separate)
+        .value("SeparateCodes", LineType::SeparateCodes)
+        .value("ChunkCombinedCodes", LineType::ChunkCombinedCodes)
+        .value("ChunkCombinedOffsets", LineType::ChunkCombinedOffsets)
+        .export_values();
+
+    m.def("max_threads", &Util::get_max_threads, "docs");
+
     py::class_<mpl2014::Mpl2014ContourGenerator>(m, "Mpl2014ContourGenerator")
         .def(py::init<const CoordinateArray&,
                       const CoordinateArray&,
                       const CoordinateArray&,
                       const MaskArray&,
                       bool,
+                      LineType,
+                      FillType,
                       index_t,
                       index_t>(),
              py::arg("x"),
@@ -23,7 +48,9 @@ PYBIND11_MODULE(_contourpy, m) {
              py::arg("z"),
              py::arg("mask"),
              py::kw_only(),
-             py::arg("corner_mask") = true,
+             py::arg("corner_mask"),
+             py::arg("line_type"),
+             py::arg("fill_type"),
              py::arg("x_chunk_size") = 0,
              py::arg("y_chunk_size") = 0)
         .def("filled", &mpl2014::Mpl2014ContourGenerator::filled)
@@ -71,11 +98,11 @@ PYBIND11_MODULE(_contourpy, m) {
              py::arg("y"),
              py::arg("z"),
              py::arg("mask"),
+             py::kw_only(),
              py::arg("corner_mask"),
              py::arg("line_type"),
              py::arg("fill_type"),
              py::arg("interp"),
-             py::kw_only(),
              py::arg("x_chunk_size") = 0,
              py::arg("y_chunk_size") = 0)
         .def("filled", &SerialContourGenerator::filled)
@@ -125,11 +152,11 @@ PYBIND11_MODULE(_contourpy, m) {
              py::arg("y"),
              py::arg("z"),
              py::arg("mask"),
+             py::kw_only(),
              py::arg("corner_mask"),
              py::arg("line_type"),
              py::arg("fill_type"),
              py::arg("interp"),
-             py::kw_only(),
              py::arg("x_chunk_size") = 0,
              py::arg("y_chunk_size") = 0,
              py::arg("thread_count") = 0)
@@ -165,27 +192,4 @@ PYBIND11_MODULE(_contourpy, m) {
             "supports_line_type",
             &ThreadedContourGenerator::supports_line_type)
         .def_static("supports_threads", []() {return true;});
-
-    py::enum_<FillType>(m, "FillType")
-        .value("OuterCodes", FillType::OuterCodes)
-        .value("OuterOffsets", FillType::OuterOffsets)
-        .value("ChunkCombinedCodes", FillType::ChunkCombinedCodes)
-        .value("ChunkCombinedOffsets", FillType::ChunkCombinedOffsets)
-        .value("ChunkCombinedCodesOffsets", FillType::ChunkCombinedCodesOffsets)
-        .value("ChunkCombinedOffsets2", FillType::ChunkCombinedOffsets2)
-        .export_values();
-
-    py::enum_<Interp>(m, "Interp")
-        .value("Linear", Interp::Linear)
-        .value("Log", Interp::Log)
-        .export_values();
-
-    py::enum_<LineType>(m, "LineType")
-        .value("Separate", LineType::Separate)
-        .value("SeparateCodes", LineType::SeparateCodes)
-        .value("ChunkCombinedCodes", LineType::ChunkCombinedCodes)
-        .value("ChunkCombinedOffsets", LineType::ChunkCombinedOffsets)
-        .export_values();
-
-    m.def("max_threads", &Util::get_max_threads, "docs");
 }

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -12,7 +12,7 @@ def get_class_from_name(name):
 @pytest.mark.parametrize('class_name', util_test.all_class_names())
 def test_default_fill_type(class_name):
     cls = get_class_from_name(class_name)
-    default = getattr(cls, 'default_fill_type')
+    default = cls.default_fill_type
     assert isinstance(default, FillType)
     expect = FillType.OuterCodes
     assert default == expect
@@ -21,7 +21,7 @@ def test_default_fill_type(class_name):
 @pytest.mark.parametrize('class_name', util_test.all_class_names())
 def test_default_line_type(class_name):
     cls = get_class_from_name(class_name)
-    default = getattr(cls, 'default_line_type')
+    default = cls.default_line_type
     assert isinstance(default, LineType)
     expect = LineType.SeparateCodes
     assert default == expect
@@ -30,7 +30,7 @@ def test_default_line_type(class_name):
 @pytest.mark.parametrize('class_name', util_test.all_class_names())
 def test_supports_corner_mask(class_name):
     cls = get_class_from_name(class_name)
-    supports = getattr(cls, 'supports_corner_mask')()
+    supports = cls.supports_corner_mask()
     assert isinstance(supports, bool)
     expect = class_name != 'Mpl2005ContourGenerator'
     assert supports == expect
@@ -39,11 +39,11 @@ def test_supports_corner_mask(class_name):
 @pytest.mark.parametrize('class_name', util_test.all_class_names())
 def test_supports_fill_type(class_name):
     cls = get_class_from_name(class_name)
-    supports = getattr(cls, 'supports_fill_type')(FillType.OuterCodes)
+    supports = cls.supports_fill_type(FillType.OuterCodes)
     assert isinstance(supports, bool)
     expect = True
     assert supports == expect
-    supports = getattr(cls, 'supports_fill_type')(FillType.ChunkCombinedOffsets2)
+    supports = cls.supports_fill_type(FillType.ChunkCombinedOffsets2)
     assert isinstance(supports, bool)
     expect = class_name not in (
         'Mpl2005ContourGenerator', 'Mpl2014ContourGenerator')
@@ -53,7 +53,7 @@ def test_supports_fill_type(class_name):
 @pytest.mark.parametrize('class_name', util_test.all_class_names())
 def test_supports_interp(class_name):
     cls = get_class_from_name(class_name)
-    supports = getattr(cls, 'supports_interp')()
+    supports = cls.supports_interp()
     assert isinstance(supports, bool)
     expect = class_name not in (
         'Mpl2005ContourGenerator', 'Mpl2014ContourGenerator')
@@ -63,11 +63,11 @@ def test_supports_interp(class_name):
 @pytest.mark.parametrize('class_name', util_test.all_class_names())
 def test_supports_line_type(class_name):
     cls = get_class_from_name(class_name)
-    supports = getattr(cls, 'supports_line_type')(LineType.SeparateCodes)
+    supports = cls.supports_line_type(LineType.SeparateCodes)
     assert isinstance(supports, bool)
     expect = True
     assert supports == expect
-    supports = getattr(cls, 'supports_line_type')(LineType.ChunkCombinedOffsets)
+    supports = cls.supports_line_type(LineType.ChunkCombinedOffsets)
     assert isinstance(supports, bool)
     expect = class_name not in (
         'Mpl2005ContourGenerator', 'Mpl2014ContourGenerator')
@@ -77,7 +77,7 @@ def test_supports_line_type(class_name):
 @pytest.mark.parametrize('class_name', util_test.all_class_names())
 def test_supports_threads(class_name):
     cls = get_class_from_name(class_name)
-    supports = getattr(cls, 'supports_threads')()
+    supports = cls.supports_threads()
     assert isinstance(supports, bool)
     expect = class_name == 'ThreadedContourGenerator'
     assert supports == expect


### PR DESCRIPTION
`contour_generator` creates `ContourGenerator` objects using `args` and `kwargs`.  `line_type` and `fill_type` are now keyword args to all contour generators.