### PR TITLE
Change returned offset arrays to have dtype of npy_intp

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -6,10 +6,10 @@
 
 namespace py = pybind11;
 
-// quad/point index type, the same as for numpy array shape/indices.
+// quad/point index type, the same as for numpy array shape/indices (== npy_intp).
 typedef py::ssize_t index_t;
 
-// Typedef for lengths and indices of STL collections.
+// Typedef for lengths and indices of STL collections (== npy_uintp).
 typedef py::size_t size_t;
 
 // Input numpy array classes.
@@ -17,8 +17,8 @@ typedef py::array_t<double, py::array::c_style | py::array::forcecast> Coordinat
 typedef py::array_t<bool,   py::array::c_style | py::array::forcecast> MaskArray;
 
 // Output numpy array classes.
-typedef py::array_t<double>   PointArray;
-typedef py::array_t<uint8_t>  CodeArray;
-typedef py::array_t<uint32_t> OffsetArray;
+typedef py::array_t<double>  PointArray;
+typedef py::array_t<uint8_t> CodeArray;
+typedef py::array_t<index_t> OffsetArray;
 
 #endif // CONTOURPY_COMMON_H

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -1,10 +1,20 @@
 #include "converter.h"
 #include "mpl_kind_code.h"
+#include <limits>
+
+void Converter::check_max_offset(size_t max_offset)
+{
+    if (max_offset > std::numeric_limits<OffsetArray::value_type>::max())
+        throw std::range_error("Max offset too large to fit in NumPy array of dtype npy_intp. Use smaller chunks.");
+}
 
 CodeArray Converter::convert_codes(
     size_t point_count, size_t cut_count, const size_t* cut_start,
     size_t subtract)
 {
+    assert(point_count > 0);
+    assert(cut_count > 0);
+
     py::ssize_t codes_shape[1] = {static_cast<py::ssize_t>(point_count)};
     CodeArray py_codes(codes_shape);
     auto py_ptr = py_codes.mutable_data();
@@ -22,6 +32,9 @@ CodeArray Converter::convert_codes_check_closed(
     size_t point_count, size_t cut_count, const size_t* cut_start,
     const double* check_closed)
 {
+    assert(point_count > 0);
+    assert(cut_count > 0);
+
     py::ssize_t codes_shape[1] = {static_cast<py::ssize_t>(point_count)};
     CodeArray py_codes(codes_shape);
     auto py_ptr = py_codes.mutable_data();
@@ -43,6 +56,8 @@ CodeArray Converter::convert_codes_check_closed(
 CodeArray Converter::convert_codes_check_closed_single(
     size_t point_count, const double* points)
 {
+    assert(point_count > 0);
+
     py::ssize_t codes_shape[1] = {static_cast<py::ssize_t>(point_count)};
     CodeArray py_codes(codes_shape);
     auto py_ptr = py_codes.mutable_data();
@@ -64,6 +79,10 @@ CodeArray Converter::convert_codes_check_closed_single(
 OffsetArray Converter::convert_offsets(
     size_t offset_count, const size_t* start, size_t subtract)
 {
+    assert(offset_count > 0);
+
+    check_max_offset(*(start + offset_count - 1) - subtract);
+
     py::ssize_t offsets_shape[1] = {static_cast<py::ssize_t>(offset_count)};
     OffsetArray py_offsets(offsets_shape);
     if (subtract == 0)
@@ -80,6 +99,10 @@ OffsetArray Converter::convert_offsets(
 OffsetArray Converter::convert_offsets_nested(
     size_t offset_count, const size_t* start, const size_t* nested_start)
 {
+    assert(offset_count > 0);
+
+    check_max_offset(*(nested_start + *(start + offset_count - 1)));
+
     py::ssize_t offsets_shape[1] = {static_cast<py::ssize_t>(offset_count)};
     OffsetArray py_offsets(offsets_shape);
     auto py_ptr = py_offsets.mutable_data();
@@ -91,6 +114,8 @@ OffsetArray Converter::convert_offsets_nested(
 
 PointArray Converter::convert_points(size_t point_count, const double* start)
 {
+    assert(point_count > 0);
+
     py::ssize_t points_shape[2] = {static_cast<py::ssize_t>(point_count), 2};
     PointArray py_points(points_shape);
     std::copy(start, start + 2*point_count, py_points.mutable_data());

--- a/src/converter.h
+++ b/src/converter.h
@@ -25,6 +25,9 @@ public:
         size_t offset_count, const size_t* start, const size_t* nested_start);
 
     static PointArray convert_points(size_t point_count, const double* start);
+
+private:
+    static void check_max_offset(size_t max_offset);
 };
 
 #endif // CONTOURPY_CONVERTER_H

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -149,7 +149,7 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
             assert isinstance(offsets, list) and len(offsets) == 2
             for o in offsets:
                 assert isinstance(o, np.ndarray)
-                assert o.dtype == np.uint32
+                assert o.dtype == np.intp
             assert_array_equal(offsets[0], [0, 8, 13])
             assert_array_equal(offsets[1], [0, 4])
     elif fill_type in (FillType.ChunkCombinedCodes,
@@ -184,7 +184,7 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
             assert isinstance(offsets, list) and len(offsets) == 1
             offsets = offsets[0]
             assert isinstance(offsets, np.ndarray)
-            assert offsets.dtype == np.uint32
+            assert offsets.dtype == np.intp
             assert_array_equal(offsets, [0, 8, 13, 17])
 
         if fill_type in (FillType.ChunkCombinedCodesOffsets,
@@ -193,7 +193,7 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
             assert isinstance(outer_offsets, list) and len(outer_offsets) == 1
             outer_offsets = outer_offsets[0]
             assert isinstance(outer_offsets, np.ndarray)
-            assert outer_offsets.dtype == np.uint32
+            assert outer_offsets.dtype == np.intp
             if fill_type == FillType.ChunkCombinedCodesOffsets:
                 assert_array_equal(outer_offsets, [0, 13, 17])
             else:

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -214,7 +214,7 @@ def test_return_by_line_type(one_loop_one_strip, name, line_type):
             offsets = lines[1]
             assert isinstance(offsets, list) and len(offsets) == 1
             assert isinstance(offsets[0], np.ndarray)
-            assert offsets[0].dtype == np.uint32
+            assert offsets[0].dtype == np.intp
             assert_array_equal(offsets[0], [0, 5, 7])
     else:
         raise RuntimeError(f'Unexpected line_type {line_type}')


### PR DESCRIPTION
Change the `dtype` of offset numpy arrays returned to python to be `npy_intp`.  This will be `int64_t` on 64-bit systems and `int32_t` on 32-bit systems.  This ensures that the offset values can indeed be used as offsets within the `points` and other arrays.

Internally the offsets are stored as unsigned integers as they are determined from the lengths/offsets of `std::vector`s.  Hence also added code that throws an exception if an offset will exceed the signed limit.