### PR TITLE
Add flake8 linting

### DIFF
--- a/benchmarks/benchmarks/bench_fill_type.py
+++ b/benchmarks/benchmarks/bench_fill_type.py
@@ -3,6 +3,7 @@ from contourpy.util.data import random_uniform
 import numpy as np
 from .util_bench import corner_masks, fill_types, problem_sizes
 
+
 class BenchFillType:
     params = (corner_masks(), fill_types(), problem_sizes())
     param_names = ['corner_mask', 'fill_type', 'n']
@@ -14,8 +15,9 @@ class BenchFillType:
         self.levels = np.arange(0.0, 1.01, 0.1)
 
     def time_fill_type(self, corner_mask, fill_type, n):
+        if corner_mask == 'no mask':
+            corner_mask = False
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name='serial', fill_type=fill_type,
-            corner_mask=corner_mask if corner_mask != 'no mask' else False)
-        all_filled = [cont_gen.filled(lower, upper) for lower, upper in
-                      zip(self.levels[:-1], self.levels[1:])]
+            self.x, self.y, self.z, name='serial', fill_type=fill_type, corner_mask=corner_mask)
+        for lower, upper in zip(self.levels[:-1], self.levels[1:]):
+            cont_gen.filled(lower, upper)

--- a/benchmarks/benchmarks/bench_fill_type_render.py
+++ b/benchmarks/benchmarks/bench_fill_type_render.py
@@ -4,6 +4,7 @@ from contourpy.util.mpl_renderer import MplTestRenderer
 import numpy as np
 from .util_bench import corner_masks, fill_types, problem_sizes
 
+
 class BenchFillTypeRender:
     params = (corner_masks(), fill_types(), problem_sizes())
     param_names = ['corner_mask', 'fill_type', 'n']
@@ -15,9 +16,10 @@ class BenchFillTypeRender:
         self.levels = np.arange(0.0, 1.01, 0.1)
 
     def time_fill_type_render(self, corner_mask, fill_type, n):
+        if corner_mask == 'no mask':
+            corner_mask = False
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name='serial', fill_type=fill_type,
-            corner_mask=corner_mask if corner_mask != 'no mask' else False)
+            self.x, self.y, self.z, name='serial', fill_type=fill_type, corner_mask=corner_mask)
         renderer = MplTestRenderer(self.x, self.y)
         for i in range(len(self.levels)-1):
             filled = cont_gen.filled(self.levels[i], self.levels[i+1])

--- a/benchmarks/benchmarks/bench_filled.py
+++ b/benchmarks/benchmarks/bench_filled.py
@@ -3,6 +3,7 @@ from contourpy.util.data import random_uniform
 import numpy as np
 from .util_bench import corner_masks, problem_sizes
 
+
 class BenchFilled:
     params = (['mpl2005', 'mpl2014', 'serial'], corner_masks(), problem_sizes())
     param_names = ['name', 'corner_mask', 'n']
@@ -14,10 +15,12 @@ class BenchFilled:
         self.levels = np.arange(0.0, 1.01, 0.1)
 
     def time_filled(self, name, corner_mask, n):
-        if name == 'mpl2005' and corner_mask == True:
+        if name == 'mpl2005' and corner_mask is True:
             raise NotImplementedError  # Does not support corner_mask=True
+        if corner_mask == 'no mask':
+            corner_mask = False
         cont_gen = contour_generator(
             self.x, self.y, self.z, name=name, fill_type=FillType.OuterCodes,
-            corner_mask=corner_mask if corner_mask != 'no mask' else False)
-        all_filled = [cont_gen.filled(lower, upper) for lower, upper in
-                      zip(self.levels[:-1], self.levels[1:])]
+            corner_mask=corner_mask)
+        for lower, upper in zip(self.levels[:-1], self.levels[1:]):
+            cont_gen.filled(lower, upper)

--- a/benchmarks/benchmarks/bench_filled_chunk.py
+++ b/benchmarks/benchmarks/bench_filled_chunk.py
@@ -3,6 +3,7 @@ from contourpy.util.data import random_uniform
 import numpy as np
 from .util_bench import corner_masks
 
+
 class BenchFilledChunk:
     params = (corner_masks(), [1000], [1, 10, 100])
     param_names = ['corner_mask', 'n', 'chunk_count']
@@ -14,9 +15,10 @@ class BenchFilledChunk:
         self.levels = np.arange(0.0, 1.01, 0.1)
 
     def time_filled_chunk(self, corner_mask, n, chunk_count):
+        if corner_mask == 'no mask':
+            corner_mask = False
         cont_gen = contour_generator(
             self.x, self.y, self.z, name='serial', chunk_count=chunk_count,
-            fill_type=FillType.ChunkCombinedOffsets2,
-            corner_mask=corner_mask if corner_mask != 'no mask' else False)
-        all_filled = [cont_gen.filled(lower, upper) for lower, upper in
-                      zip(self.levels[:-1], self.levels[1:])]
+            fill_type=FillType.ChunkCombinedOffsets2, corner_mask=corner_mask)
+        for lower, upper in zip(self.levels[:-1], self.levels[1:]):
+            cont_gen.filled(lower, upper)

--- a/benchmarks/benchmarks/bench_filled_threaded.py
+++ b/benchmarks/benchmarks/bench_filled_threaded.py
@@ -3,6 +3,7 @@ from contourpy.util.data import random_uniform
 import numpy as np
 from .util_bench import corner_masks, problem_sizes, thread_counts
 
+
 class BenchFilledThreaded:
     params = (thread_counts(), corner_masks(), problem_sizes())
     param_names = ['thread_count', 'corner_mask', 'n']
@@ -14,9 +15,10 @@ class BenchFilledThreaded:
         self.levels = np.arange(0.0, 1.01, 0.1)
 
     def time_filled_threaded(self, thread_count, corner_mask, n):
+        if corner_mask == 'no mask':
+            corner_mask = False
         cont_gen = contour_generator(
             self.x, self.y, self.z, name='threaded', thread_count=thread_count,
-            chunk_count=24, fill_type=FillType.ChunkCombinedOffsets2,
-            corner_mask=corner_mask if corner_mask != 'no mask' else False)
-        all_filled = [cont_gen.filled(lower, upper) for lower, upper in
-                      zip(self.levels[:-1], self.levels[1:])]
+            chunk_count=24, fill_type=FillType.ChunkCombinedOffsets2, corner_mask=corner_mask)
+        for lower, upper in zip(self.levels[:-1], self.levels[1:]):
+            cont_gen.filled(lower, upper)

--- a/benchmarks/benchmarks/bench_line_type.py
+++ b/benchmarks/benchmarks/bench_line_type.py
@@ -3,6 +3,7 @@ from contourpy.util.data import random_uniform
 import numpy as np
 from .util_bench import corner_masks, line_types, problem_sizes
 
+
 class BenchLineType:
     params = (corner_masks(), line_types(), problem_sizes())
     param_names = ['corner_mask', 'line_type', 'n']
@@ -14,7 +15,9 @@ class BenchLineType:
         self.levels = np.arange(0.0, 1.01, 0.1)
 
     def time_line_type(self, corner_mask, line_type, n):
+        if corner_mask == 'no mask':
+            corner_mask = False
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name='serial', line_type=line_type,
-            corner_mask=corner_mask if corner_mask != 'no mask' else False)
-        all_lines = [cont_gen.lines(level) for level in self.levels]
+            self.x, self.y, self.z, name='serial', line_type=line_type, corner_mask=corner_mask)
+        for level in self.levels:
+            cont_gen.lines(level)

--- a/benchmarks/benchmarks/bench_line_type_render.py
+++ b/benchmarks/benchmarks/bench_line_type_render.py
@@ -4,6 +4,7 @@ from contourpy.util.mpl_renderer import MplTestRenderer
 import numpy as np
 from .util_bench import corner_masks, line_types, problem_sizes
 
+
 class BenchLineTypeRender:
     params = (corner_masks(), line_types(), problem_sizes())
     param_names = ['corner_mask', 'line_type', 'n']
@@ -15,9 +16,10 @@ class BenchLineTypeRender:
         self.levels = np.arange(0.0, 1.01, 0.1)
 
     def time_line_type_render(self, corner_mask, line_type, n):
+        if corner_mask == 'no mask':
+            corner_mask = False
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name='serial', line_type=line_type,
-            corner_mask=corner_mask if corner_mask != 'no mask' else False)
+            self.x, self.y, self.z, name='serial', line_type=line_type, corner_mask=corner_mask)
         renderer = MplTestRenderer(self.x, self.y)
         for i, level in enumerate(self.levels):
             lines = cont_gen.lines(level)

--- a/benchmarks/benchmarks/bench_lines.py
+++ b/benchmarks/benchmarks/bench_lines.py
@@ -3,6 +3,7 @@ from contourpy.util.data import random_uniform
 import numpy as np
 from .util_bench import corner_masks, problem_sizes
 
+
 class BenchFilled:
     params = (['mpl2005', 'mpl2014', 'serial'], corner_masks(), problem_sizes())
     param_names = ['name', 'corner_mask', 'n']
@@ -14,10 +15,12 @@ class BenchFilled:
         self.levels = np.arange(0.0, 1.01, 0.1)
 
     def time_lines(self, name, corner_mask, n):
-        if name == 'mpl2005' and corner_mask == True:
+        if name == 'mpl2005' and corner_mask is True:
             raise NotImplementedError  # Does not support corner_mask=True
+        if corner_mask == 'no mask':
+            corner_mask = False
         cont_gen = contour_generator(
             self.x, self.y, self.z, name=name, line_type=LineType.SeparateCodes,
-            corner_mask=corner_mask if corner_mask != 'no mask' else False)
-        all_lines = [cont_gen.lines(level) for level in self.levels]
-        
+            corner_mask=corner_mask)
+        for level in self.levels:
+            cont_gen.lines(level)

--- a/benchmarks/benchmarks/bench_lines_chunk.py
+++ b/benchmarks/benchmarks/bench_lines_chunk.py
@@ -3,6 +3,7 @@ from contourpy.util.data import random_uniform
 import numpy as np
 from .util_bench import corner_masks
 
+
 class BenchLinesChunk:
     params = (corner_masks(), [1000], [1, 10, 100])
     param_names = ['corner_mask', 'n', 'chunk_count']
@@ -14,8 +15,10 @@ class BenchLinesChunk:
         self.levels = np.arange(0.0, 1.01, 0.1)
 
     def time_lines_chunk(self, corner_mask, n, chunk_count):
+        if corner_mask == 'no mask':
+            corner_mask = False
         cont_gen = contour_generator(
             self.x, self.y, self.z, name='serial', chunk_count=chunk_count,
-            line_type=LineType.ChunkCombinedOffsets,
-            corner_mask=corner_mask if corner_mask != 'no mask' else False)
-        all_lines = [cont_gen.lines(level) for level in self.levels]
+            line_type=LineType.ChunkCombinedOffsets, corner_mask=corner_mask)
+        for level in self.levels:
+            cont_gen.lines(level)

--- a/benchmarks/benchmarks/bench_lines_threaded.py
+++ b/benchmarks/benchmarks/bench_lines_threaded.py
@@ -3,6 +3,7 @@ from contourpy.util.data import random_uniform
 import numpy as np
 from .util_bench import corner_masks, problem_sizes, thread_counts
 
+
 class BenchLinesThreaded:
     params = (thread_counts(), corner_masks(), problem_sizes())
     param_names = ['thread_count', 'corner_mask', 'n']
@@ -14,8 +15,10 @@ class BenchLinesThreaded:
         self.levels = np.arange(0.0, 1.01, 0.1)
 
     def time_lines_threaded(self, thread_count, corner_mask, n):
+        if corner_mask == 'no mask':
+            corner_mask = False
         cont_gen = contour_generator(
             self.x, self.y, self.z, name='threaded', thread_count=thread_count,
-            chunk_count=24, line_type=LineType.ChunkCombinedOffsets,
-            corner_mask=corner_mask if corner_mask != 'no mask' else False)
-        all_lines = [cont_gen.lines(level) for level in self.levels]
+            chunk_count=24, line_type=LineType.ChunkCombinedOffsets, corner_mask=corner_mask)
+        for level in self.levels:
+            cont_gen.lines(level)

--- a/benchmarks/benchmarks/util_bench.py
+++ b/benchmarks/benchmarks/util_bench.py
@@ -3,15 +3,19 @@ from contourpy import FillType, LineType, max_threads
 
 def corner_masks():
     return ['no mask', False, True]
-    
+
+
 def fill_types():
     return list(FillType.__members__.values())
+
 
 def line_types():
     return list(LineType.__members__.values())
 
+
 def problem_sizes():
     return [10, 30, 100, 300, 1000]
+
 
 def thread_counts():
     thread_counts = [1, 2, 4, 6, 8]

--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -1,9 +1,23 @@
 from ._contourpy import (
-    max_threads, FillType, Interp, LineType, Mpl2014ContourGenerator,
-    SerialContourGenerator, ThreadedContourGenerator)
+    max_threads, FillType, Interp, LineType, Mpl2014ContourGenerator, SerialContourGenerator,
+    ThreadedContourGenerator,
+)
 from .mpl2005 import Mpl2005ContourGenerator
 from .util.chunk import calc_chunk_sizes
 import numpy as np
+
+
+__all__ = [
+    'contour_generator',
+    'max_threads',
+    'FillType',
+    'Interp',
+    'LineType',
+    'Mpl2005ContourGenerator',
+    'Mpl2014ContourGenerator',
+    'SerialContourGenerator',
+    'ThreadedContourGenerator',
+]
 
 
 def _name_to_class(name):
@@ -12,9 +26,9 @@ def _name_to_class(name):
     return cls
 
 
-def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None,
-                      line_type=None, fill_type=None, interp=Interp.Linear,
-                      thread_count=0, chunk_count=None, total_chunk_count=None):
+def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None, line_type=None,
+                      fill_type=None, interp=Interp.Linear, thread_count=0, chunk_count=None,
+                      total_chunk_count=None):
     x = np.asarray(x, dtype=np.float64)
     y = np.asarray(y, dtype=np.float64)
     z = np.ma.asarray(z, dtype=np.float64)  # Preserve mask if present.
@@ -23,34 +37,28 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None,
     if z.ndim != 2:
         raise TypeError(f'Input z must be 2D, not {z.ndim}D')
     if z.shape[0] < 2 or z.shape[1] < 2:
-        raise TypeError('Input z must be at least a (2, 2) shaped array, '
-                        f'but has shape {z.shape}')
+        raise TypeError(f'Input z must be at least a (2, 2) shaped array, but has shape {z.shape}')
 
     ny, nx = z.shape
 
     # Check arguments: x and y.
     if x.ndim != y.ndim:
-        raise TypeError(f'Number of dimensions of x ({x.ndim}) and y '
-                        f'({y.ndim}) do not match')
+        raise TypeError(f'Number of dimensions of x ({x.ndim}) and y ({y.ndim}) do not match')
     if x.ndim == 0:
         x = np.arange(nx)
         y = np.arange(ny)
         x, y = np.meshgrid(x, y)
     elif x.ndim == 1:
         if len(x) != nx:
-            raise TypeError(f'Length of x ({len(x)}) must match number of '
-                            f'columns in z ({nx})')
+            raise TypeError(f'Length of x ({len(x)}) must match number of columns in z ({nx})')
         if len(y) != ny:
-            raise TypeError(f'Length of y ({len(y)}) must match number of '
-                            f'rows in z ({ny})')
+            raise TypeError(f'Length of y ({len(y)}) must match number of rows in z ({ny})')
         x, y = np.meshgrid(x, y)
     elif x.ndim == 2:
         if x.shape != z.shape:
-            raise TypeError(
-                f'Shapes of x {x.shape} and z {z.shape} do not match')
+            raise TypeError(f'Shapes of x {x.shape} and z {z.shape} do not match')
         if y.shape != z.shape:
-            raise TypeError(
-                f'Shapes of y {y.shape} and z {z.shape} do not match')
+            raise TypeError(f'Shapes of y {y.shape} and z {z.shape} do not match')
     else:
         raise TypeError(f'Inputs x and y must be None, 1D or 2D, not {x.ndim}D')
 
@@ -84,7 +92,7 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None,
         # Set it to default, which is True if the algorithm supports it.
         corner_mask = cls.supports_corner_mask()
     elif corner_mask and not cls.supports_corner_mask():
-            raise ValueError(f'{name} contour generator does not support corner_mask=True')
+        raise ValueError(f'{name} contour generator does not support corner_mask=True')
 
     # Check arguments: line_type.
     if line_type is None:

--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -44,8 +44,7 @@ class BokehRenderer:
         color = self._convert_color(color)
         xs, ys = filled_to_bokeh(filled, fill_type)
         if len(xs) > 0:
-            fig.multi_polygons(
-                xs=[xs], ys=[ys], color=color, fill_alpha=alpha, line_width=0)
+            fig.multi_polygons(xs=[xs], ys=[ys], color=color, fill_alpha=alpha, line_width=0)
 
     def grid(self, x, y, ax=0, color='black', alpha=0.1):
         fig = self._get_figure(ax)
@@ -57,15 +56,13 @@ class BokehRenderer:
         ys = [row for row in y] + [row for row in y.T]
         fig.multi_line(xs, ys, line_color=color, alpha=alpha)
 
-    def lines(self, lines, line_type, ax=0, color='C0', alpha=1.0,
-              linewidth=1):
+    def lines(self, lines, line_type, ax=0, color='C0', alpha=1.0, linewidth=1):
         # Assumes all lines are open line loops.
         fig = self._get_figure(ax)
         color = self._convert_color(color)
         xs, ys = lines_to_bokeh(lines, line_type)
         if len(xs) > 0:
-            fig.multi_line(xs, ys, line_color=color, line_alpha=alpha,
-                           line_width=linewidth)
+            fig.multi_line(xs, ys, line_color=color, line_alpha=alpha, line_width=linewidth)
 
     def save(self, filename):
         if self._want_svg:

--- a/lib/contourpy/util/bokeh_util.py
+++ b/lib/contourpy/util/bokeh_util.py
@@ -1,16 +1,13 @@
 from contourpy import FillType, LineType
 from .mpl_util import mpl_codes_to_offsets
-import numpy as np
 
 
 def filled_to_bokeh(filled, fill_type):
     xs = []
     ys = []
-    if fill_type in (
-        FillType.OuterOffsets, FillType.ChunkCombinedOffsets,
-        FillType.OuterCodes, FillType.ChunkCombinedCodes):
-        have_codes = \
-            fill_type in (FillType.OuterCodes, FillType.ChunkCombinedCodes)
+    if fill_type in (FillType.OuterOffsets, FillType.ChunkCombinedOffsets,
+                     FillType.OuterCodes, FillType.ChunkCombinedCodes):
+        have_codes = fill_type in (FillType.OuterCodes, FillType.ChunkCombinedCodes)
 
         for points, offsets in zip(*filled):
             if points is None:
@@ -23,8 +20,7 @@ def filled_to_bokeh(filled, fill_type):
                 xys = points[offsets[i]:offsets[i+1]]
                 xs[-1].append(xys[:, 0])
                 ys[-1].append(xys[:, 1])
-    elif fill_type in (
-        FillType.ChunkCombinedCodesOffsets, FillType.ChunkCombinedOffsets2):
+    elif fill_type in (FillType.ChunkCombinedCodesOffsets, FillType.ChunkCombinedOffsets2):
         for points, codes_or_offsets, outer_offsets in zip(*filled):
             if points is None:
                 continue

--- a/lib/contourpy/util/chunk.py
+++ b/lib/contourpy/util/chunk.py
@@ -2,8 +2,7 @@ import math
 
 
 def calc_chunk_sizes(chunk_size, chunk_count, total_chunk_count, ny, nx):
-    if sum([chunk_size is not None, chunk_count is not None,
-        total_chunk_count is not None]) > 1:
+    if sum([chunk_size is not None, chunk_count is not None, total_chunk_count is not None]) > 1:
         raise ValueError('Only one of chunk_size, chunk_count and total_chunk_count should be set')
 
     if total_chunk_count is not None:
@@ -27,8 +26,7 @@ def calc_chunk_sizes(chunk_size, chunk_count, total_chunk_count, ny, nx):
             y_chunk_count = x_chunk_count = chunk_count
         x_chunk_count = min(max(x_chunk_count, 1), nx-1)
         y_chunk_count = min(max(y_chunk_count, 1), ny-1)
-        chunk_size = (math.ceil((ny-1) / y_chunk_count),
-                        math.ceil((nx-1) / x_chunk_count))
+        chunk_size = (math.ceil((ny-1) / y_chunk_count), math.ceil((nx-1) / x_chunk_count))
 
     if chunk_size is None:
         y_chunk_size = x_chunk_size = 0
@@ -43,9 +41,8 @@ def calc_chunk_sizes(chunk_size, chunk_count, total_chunk_count, ny, nx):
     return y_chunk_size, x_chunk_size
 
 
-# Splits integer n into two integer factors that are as close as possible to
-# the sqrt of n, and returns them in decreasing order.  Worst case returns
-# (n, 1).
+# Splits integer n into two integer factors that are as close as possible to the sqrt of n, and
+# returns them in decreasing order.  Worst case returns (n, 1).
 def two_factors(n):
     i = math.ceil(math.sqrt(n))
     while n % i != 0:

--- a/lib/contourpy/util/mpl_util.py
+++ b/lib/contourpy/util/mpl_util.py
@@ -4,10 +4,8 @@ import numpy as np
 
 
 def filled_to_mpl_paths(filled, fill_type):
-    if fill_type in (FillType.OuterCodes,
-                        FillType.ChunkCombinedCodes):
-        paths = [mpath.Path(points, codes) for points, codes
-                 in zip(*filled) if points is not None]
+    if fill_type in (FillType.OuterCodes, FillType.ChunkCombinedCodes):
+        paths = [mpath.Path(points, codes) for points, codes in zip(*filled) if points is not None]
     elif fill_type in (FillType.OuterOffsets, FillType.ChunkCombinedOffsets):
         paths = [mpath.Path(points, offsets_to_mpl_codes(offsets))
                  for points, offsets in zip(*filled) if points is not None]
@@ -41,8 +39,7 @@ def lines_to_mpl_paths(lines, line_type):
             closed = line[0, 0] == line[-1, 0] and line[0, 1] == line[-1, 1]
             paths.append(mpath.Path(line, closed=closed))
     elif line_type in (LineType.SeparateCodes, LineType.ChunkCombinedCodes):
-        paths = [mpath.Path(points, codes) for points, codes
-                 in zip(*lines) if points is not None]
+        paths = [mpath.Path(points, codes) for points, codes in zip(*lines) if points is not None]
     elif line_type == LineType.ChunkCombinedOffsets:
         paths = []
         for points, offsets in zip(*lines):

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
+flake8
 matplotlib
 numpy
 Pillow

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,15 @@
+[flake8]
+exclude =
+    .git,
+    .asv,
+    __pycache__,
+    benchmarks,
+    build,
+    docs,
+max-line-length = 100
+per-file-ignores =
+    # E402 = module level import not at top of file.
+    lib/contourpy/util/mpl_renderer.py: E402,
+    tests/util_config.py: E402,
+    # F401 = module imported but unused.
+    tests/test_static.py: F401,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ define_macros = []
 undef_macros = []
 
 if want_debug:
-    define_macros.append(('DEBUG',1))
+    define_macros.append(('DEBUG', 1))
     undef_macros.append('NDEBUG')
 
 ParallelCompile(default=0, needs_recompile=naive_recompile).install()
@@ -51,8 +51,7 @@ _mpl2005 = Extension(
     ],
 )
 
-ext_modules=[_contourpy, _mpl2005]
-
+ext_modules = [_contourpy, _mpl2005]
 
 
 def read_requirements(filename):

--- a/tests/image_comparison.py
+++ b/tests/image_comparison.py
@@ -4,8 +4,8 @@ from PIL import Image
 from shutil import copyfile
 
 
-def compare_images(test_buffer, baseline_filename, test_filename_suffix=None,
-                   max_threshold=None, mean_threshold=None):
+def compare_images(test_buffer, baseline_filename, test_filename_suffix=None, max_threshold=None,
+                   mean_threshold=None):
     if max_threshold is None:
         max_threshold = 100
     if mean_threshold is None:
@@ -21,19 +21,18 @@ def compare_images(test_buffer, baseline_filename, test_filename_suffix=None,
     mean_diff = None
 
     try:
-        test_image = np.asarray(Image.open(test_buffer).convert("RGBA"),
-                                dtype=np.int16)
+        test_image = np.asarray(Image.open(test_buffer).convert('RGBA'))
+        test_image = test_image.astype(np.int16)
 
-        full_baseline_filename = os.path.join('tests', 'baseline_images',
-                                              baseline_filename)
+        full_baseline_filename = os.path.join('tests', 'baseline_images', baseline_filename)
         assert os.path.isfile(full_baseline_filename)
 
-        baseline_image = np.asarray(
-            Image.open(full_baseline_filename).convert("RGBA"), dtype=np.int16)
+        baseline_image = np.asarray(Image.open(full_baseline_filename).convert('RGBA'))
+        baseline_image = baseline_image.astype(np.int16)
 
         diff = np.abs(test_image - baseline_image)
-        max_diff = diff[:,:,:3].max()
-        mean_diff = diff[:,:,:3].mean()
+        max_diff = diff[:, :, :3].max()
+        mean_diff = diff[:, :, :3].mean()
 
         assert max_diff < max_threshold and mean_diff < mean_threshold
     except AssertionError:

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -1,0 +1,6 @@
+from subprocess import run
+
+
+def test_flake8():
+    proc = run(['flake8'], capture_output=True)
+    assert proc.returncode == 0, f"Flake8 issues:\n{proc.stdout.decode('utf-8')}"

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -28,61 +28,60 @@ def xyz_7x5_as_arrays():  # shape (7, 5)
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
-@pytest.mark.parametrize('z', ( [1], [[[1]]] ))
+@pytest.mark.parametrize('z', ([1], [[[1]]]))
 def test_ndim_z(xyz_3x3_as_lists, name, z):
     x, y, _ = xyz_3x3_as_lists
     with pytest.raises(TypeError):
-        cont_gen = contourpy.contour_generator(x, y, z, name=name)
+        contourpy.contour_generator(x, y, z, name=name)
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
-@pytest.mark.parametrize('all_xyz', ( [[1]], [[1], [2]], [[1, 2]] ))
+@pytest.mark.parametrize('all_xyz', ([[1]], [[1], [2]], [[1, 2]]))
 def test_z_shape_too_small(all_xyz, name):
     with pytest.raises(TypeError):
-        cont_gen = contourpy.contour_generator(all_xyz, all_xyz, all_xyz, name=name)
+        contourpy.contour_generator(all_xyz, all_xyz, all_xyz, name=name)
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
-@pytest.mark.parametrize('wrong_ndim', ( None, [1], [[[1]]] ))
+@pytest.mark.parametrize('wrong_ndim', (None, [1], [[[1]]]))
 def test_diff_ndim_xy(xyz_3x3_as_lists, name, wrong_ndim):
     x, y, z = xyz_3x3_as_lists
     with pytest.raises(TypeError):
-        cont_gen = contourpy.contour_generator(wrong_ndim, y, z, name=name)
+        contourpy.contour_generator(wrong_ndim, y, z, name=name)
     with pytest.raises(TypeError):
-        cont_gen = contourpy.contour_generator(x, wrong_ndim, z, name=name)
+        contourpy.contour_generator(x, wrong_ndim, z, name=name)
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
 def test_xy_None(xyz_3x3_as_lists, name):
     _, _, z = xyz_3x3_as_lists
-    cont_gen = contourpy.contour_generator(None, None, z, name=name)
+    contourpy.contour_generator(None, None, z, name=name)
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
 def test_xy_1d(name):
     z = [[0, 1, 2], [3, 4, 5]]
-    cont_gen = contourpy.contour_generator([0, 1, 2], [0, 1], z, name=name)
+    contourpy.contour_generator([0, 1, 2], [0, 1], z, name=name)
     with pytest.raises(TypeError):
-        cont_gen = contourpy.contour_generator([0, 1], [0, 1], z, name=name)
+        contourpy.contour_generator([0, 1], [0, 1], z, name=name)
     with pytest.raises(TypeError):
-        cont_gen = contourpy.contour_generator([0, 1, 2, 3], [0, 1], z, name=name)
+        contourpy.contour_generator([0, 1, 2, 3], [0, 1], z, name=name)
     with pytest.raises(TypeError):
-        cont_gen = contourpy.contour_generator([0, 1, 2], [0], z, name=name)
+        contourpy.contour_generator([0, 1, 2], [0], z, name=name)
     with pytest.raises(TypeError):
-        cont_gen = contourpy.contour_generator([0, 1, 2], [0, 1, 2], z, name=name)
+        contourpy.contour_generator([0, 1, 2], [0, 1, 2], z, name=name)
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
-@pytest.mark.parametrize('diff_shape', ( [[1, 2, 3, 4], [5, 6, 7, 8]],
-                                         [[1, 2], [3, 4], [5, 6]] ))
+@pytest.mark.parametrize('diff_shape', ([[1, 2, 3, 4], [5, 6, 7, 8]], [[1, 2], [3, 4], [5, 6]]))
 def test_xyz_diff_shapes(xyz_3x3_as_lists, name, diff_shape):
     x, y, z = xyz_3x3_as_lists
     with pytest.raises(TypeError):
-        cont_gen = contourpy.contour_generator(diff_shape, y, z, name=name)
+        contourpy.contour_generator(diff_shape, y, z, name=name)
     with pytest.raises(TypeError):
-        cont_gen = contourpy.contour_generator(x, diff_shape, z, name=name)
+        contourpy.contour_generator(x, diff_shape, z, name=name)
     with pytest.raises(TypeError):
-        cont_gen = contourpy.contour_generator(x, y, diff_shape, name=name)
+        contourpy.contour_generator(x, y, diff_shape, name=name)
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
@@ -90,11 +89,11 @@ def test_chunk_size_negative(xyz_3x3_as_lists, name):
     x, y, z = xyz_3x3_as_lists
     msg = 'chunk_size cannot be negative'
     with pytest.raises(ValueError, match=msg):
-        cont_gen = contourpy.contour_generator(x, y, z, name=name, chunk_size=-1)
+        contourpy.contour_generator(x, y, z, name=name, chunk_size=-1)
     with pytest.raises(ValueError, match=msg):
-        cont_gen = contourpy.contour_generator(x, y, z, name=name, chunk_size=(-1, 0))
+        contourpy.contour_generator(x, y, z, name=name, chunk_size=(-1, 0))
     with pytest.raises(ValueError, match=msg):
-        cont_gen = contourpy.contour_generator(x, y, z, name=name, chunk_size=(0, -1))
+        contourpy.contour_generator(x, y, z, name=name, chunk_size=(0, -1))
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
@@ -146,24 +145,22 @@ def test_chunk_size_and_count(xyz_7x5_as_arrays):
     name = 'serial'
     msg = 'Only one of chunk_size, chunk_count and total_chunk_count should be set'
     with pytest.raises(ValueError, match=msg):
-        cont_gen = contourpy.contour_generator(
-            x, y, z, name=name, chunk_size=1, chunk_count=1)
+        contourpy.contour_generator(x, y, z, name=name, chunk_size=1, chunk_count=1)
     with pytest.raises(ValueError, match=msg):
-        cont_gen = contourpy.contour_generator(
-            x, y, z, name=name, chunk_size=1, total_chunk_count=1)
+        contourpy.contour_generator(x, y, z, name=name, chunk_size=1, total_chunk_count=1)
     with pytest.raises(ValueError, match=msg):
-        cont_gen = contourpy.contour_generator(
-            x, y, z, name=name, chunk_count=1, total_chunk_count=1)
+        contourpy.contour_generator(x, y, z, name=name, chunk_count=1, total_chunk_count=1)
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
-@pytest.mark.parametrize('chunk_count, ret_chunk_count',
-    [[0, (1, 1)], [1, (1, 1)], [2, (2, 2)], [3, (3, 2)], [4, (3, 4)], [9, (6, 4)]])
+@pytest.mark.parametrize(
+    'chunk_count, ret_chunk_count',
+    [[0, (1, 1)], [1, (1, 1)], [2, (2, 2)], [3, (3, 2)], [4, (3, 4)], [9, (6, 4)]],
+)
 def test_chunk_count_1d(xyz_7x5_as_arrays, name, chunk_count, ret_chunk_count):
     x, y, z = xyz_7x5_as_arrays
     ny, nx = z.shape
-    cont_gen = contourpy.contour_generator(
-        x, y, z, name=name, chunk_count=chunk_count)
+    cont_gen = contourpy.contour_generator(x, y, z, name=name, chunk_count=chunk_count)
     ret_y_chunk_size, ret_x_chunk_size = cont_gen.chunk_size
     assert cont_gen.chunk_count == ret_chunk_count
     ret_y_chunk_count, ret_x_chunk_count = ret_chunk_count
@@ -174,14 +171,15 @@ def test_chunk_count_1d(xyz_7x5_as_arrays, name, chunk_count, ret_chunk_count):
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
-@pytest.mark.parametrize('chunk_count, ret_chunk_count',
-    [[(0, 1), (1, 1)], [(1, 0), (1, 1)], [(2, 3), (2, 2)], [(3, 2), (3, 2)],
-     [(1, 9), (1, 4)], [(9, 1), (6, 1)]])
-def test_chunk_count_1d(xyz_7x5_as_arrays, name, chunk_count, ret_chunk_count):
+@pytest.mark.parametrize(
+    'chunk_count, ret_chunk_count',
+    [[(0, 1), (1, 1)], [(1, 0), (1, 1)], [(2, 3), (2, 2)], [(3, 2), (3, 2)], [(1, 9), (1, 4)],
+     [(9, 1), (6, 1)]],
+)
+def test_chunk_count_2d(xyz_7x5_as_arrays, name, chunk_count, ret_chunk_count):
     x, y, z = xyz_7x5_as_arrays
     ny, nx = z.shape
-    cont_gen = contourpy.contour_generator(
-        x, y, z, name=name, chunk_count=chunk_count)
+    cont_gen = contourpy.contour_generator(x, y, z, name=name, chunk_count=chunk_count)
     ret_y_chunk_size, ret_x_chunk_size = cont_gen.chunk_size
     assert cont_gen.chunk_count == ret_chunk_count
     ret_y_chunk_count, ret_x_chunk_count = ret_chunk_count
@@ -192,15 +190,15 @@ def test_chunk_count_1d(xyz_7x5_as_arrays, name, chunk_count, ret_chunk_count):
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
-@pytest.mark.parametrize('total_chunk_count, ret_chunk_count',
-    [[0, (1, 1)], [1, (1, 1)], [2, (2, 1)], [3, (3, 1)], [4, (2, 2)],
-     [6, (3, 2)], [9, (3, 2)], [25, (6, 4)]])
-def test_total_chunk_count(
-    xyz_7x5_as_arrays, name, total_chunk_count, ret_chunk_count):
+@pytest.mark.parametrize(
+    'total_chunk_count, ret_chunk_count',
+    [[0, (1, 1)], [1, (1, 1)], [2, (2, 1)], [3, (3, 1)], [4, (2, 2)], [6, (3, 2)], [9, (3, 2)],
+     [25, (6, 4)]],
+)
+def test_total_chunk_count(xyz_7x5_as_arrays, name, total_chunk_count, ret_chunk_count):
     x, y, z = xyz_7x5_as_arrays
     ny, nx = z.shape
-    cont_gen = contourpy.contour_generator(
-        x, y, z, name=name, total_chunk_count=total_chunk_count)
+    cont_gen = contourpy.contour_generator(x, y, z, name=name, total_chunk_count=total_chunk_count)
     ret_y_chunk_size, ret_x_chunk_size = cont_gen.chunk_size
     assert cont_gen.chunk_count == ret_chunk_count
     ret_y_chunk_count, ret_x_chunk_count = ret_chunk_count

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -21,21 +21,21 @@ def test_all_fill_types():
     # Check that all_fill_types() matches FillType.__members__
     fill_types = dict(util_test.all_fill_types_str_value())
     for name, enum in dict(FillType.__members__).items():
-        assert(name in fill_types)
-        assert(fill_types[name] == enum.value)
+        assert name in fill_types
+        assert fill_types[name] == enum.value
 
 
 def test_all_line_types():
     # Check that all_line_types() matches LineType.__members__
     line_types = dict(util_test.all_line_types_str_value())
     for name, enum in dict(LineType.__members__).items():
-        assert(name in line_types)
-        assert(line_types[name] == enum.value)
+        assert name in line_types
+        assert line_types[name] == enum.value
 
 
 def test_all_interps():
     # Check that all_interps() matches Interp.__members__
     interps = dict(util_test.all_interps_str_value())
     for name, enum in dict(Interp.__members__).items():
-        assert(name in interps)
-        assert(interps[name] == enum.value)
+        assert name in interps
+        assert interps[name] == enum.value

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -17,39 +17,32 @@ def two_outers_one_hole():
     return x, y, z
 
 
-@pytest.mark.parametrize(
-    'name, fill_type', util_test.all_names_and_fill_types())
+@pytest.mark.parametrize('name, fill_type', util_test.all_names_and_fill_types())
 def test_filled_random_uniform_no_corner_mask(name, fill_type):
     x, y, z = random_uniform((30, 40), mask_fraction=0.05)
-    cont_gen = contour_generator(
-        x, y, z, name=name, fill_type=fill_type, corner_mask=False)
+    cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, corner_mask=False)
     levels = np.arange(0.0, 1.01, 0.2)
 
     assert cont_gen.fill_type == fill_type
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type,
-                        color=f'C{i}')
+        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
 
-    compare_images(image_buffer, 'filled_random_uniform_no_corner_mask.png',
-                   f'{name}_{fill_type}')
+    compare_images(image_buffer, 'filled_random_uniform_no_corner_mask.png', f'{name}_{fill_type}')
 
 
-@pytest.mark.parametrize(
-    'name, fill_type', util_test.all_names_and_fill_types())
+@pytest.mark.parametrize('name, fill_type', util_test.all_names_and_fill_types())
 def test_filled_random_uniform_no_corner_mask_chunk(name, fill_type):
     x, y, z = random_uniform((30, 40), mask_fraction=0.05)
     cont_gen = contour_generator(
-        x, y, z, name=name, fill_type=fill_type, corner_mask=False,
-        chunk_size=2)
+        x, y, z, name=name, fill_type=fill_type, corner_mask=False, chunk_size=2)
     levels = np.arange(0.0, 1.01, 0.2)
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type,
-                        color=f'C{i}')
+        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
 
     max_threshold = None
@@ -58,36 +51,35 @@ def test_filled_random_uniform_no_corner_mask_chunk(name, fill_type):
         max_threshold = 128
         mean_threshold = 0.19
     elif name in ('serial', 'threaded'):
-        if fill_type in (
-            FillType.ChunkCombinedCodes, FillType.ChunkCombinedOffsets):
+        if fill_type in (FillType.ChunkCombinedCodes, FillType.ChunkCombinedOffsets):
             max_threshold = 99
             mean_threshold = 0.18
         else:
             max_threshold = 134
             mean_threshold = 0.23
 
-    compare_images(image_buffer,
-                   'filled_random_uniform_no_corner_mask_chunk.png',
-                   f'{name}_{fill_type}', max_threshold=max_threshold,
-                   mean_threshold=mean_threshold)
+    compare_images(
+        image_buffer,
+        'filled_random_uniform_no_corner_mask_chunk.png',
+        f'{name}_{fill_type}',
+        max_threshold=max_threshold,
+        mean_threshold=mean_threshold,
+    )
 
 
 @pytest.mark.parametrize('name', util_test.corner_mask_names())
 def test_filled_random_uniform_corner_mask(name):
     x, y, z = random_uniform((30, 40), mask_fraction=0.05)
     fill_type = FillType.OuterCodes
-    cont_gen = contour_generator(
-        x, y, z, name=name, corner_mask=True, fill_type=fill_type)
+    cont_gen = contour_generator(x, y, z, name=name, corner_mask=True, fill_type=fill_type)
     levels = np.arange(0.0, 1.01, 0.2)
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type,
-                        color=f'C{i}')
+        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
 
-    compare_images(image_buffer, 'filled_random_uniform_corner_mask.png',
-                   f'{name}_{fill_type}')
+    compare_images(image_buffer, 'filled_random_uniform_corner_mask.png', f'{name}_{fill_type}')
 
 
 @pytest.mark.parametrize('name', util_test.corner_mask_names())
@@ -100,8 +92,7 @@ def test_filled_random_uniform_corner_mask_chunk(name):
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type,
-                        color=f'C{i}')
+        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
 
     max_threshold = None
@@ -110,11 +101,12 @@ def test_filled_random_uniform_corner_mask_chunk(name):
         max_threshold = 134
         mean_threshold = 0.17
 
-
-
-    compare_images(image_buffer, 'filled_random_uniform_corner_mask_chunk.png',
-                   f'{name}_{fill_type}', max_threshold=max_threshold,
-                   mean_threshold=mean_threshold)
+    compare_images(
+        image_buffer, 'filled_random_uniform_corner_mask_chunk.png',
+        f'{name}_{fill_type}',
+        max_threshold=max_threshold,
+        mean_threshold=mean_threshold,
+    )
 
 
 @pytest.mark.parametrize('fill_type', FillType.__members__.values())
@@ -152,12 +144,9 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
                 assert o.dtype == np.intp
             assert_array_equal(offsets[0], [0, 8, 13])
             assert_array_equal(offsets[1], [0, 4])
-    elif fill_type in (FillType.ChunkCombinedCodes,
-                       FillType.ChunkCombinedOffsets,
-                       FillType.ChunkCombinedCodesOffsets,
-                       FillType.ChunkCombinedOffsets2):
-        if fill_type in (FillType.ChunkCombinedCodes,
-                         FillType.ChunkCombinedOffsets):
+    elif fill_type in (FillType.ChunkCombinedCodes, FillType.ChunkCombinedOffsets,
+                       FillType.ChunkCombinedCodesOffsets, FillType.ChunkCombinedOffsets2):
+        if fill_type in (FillType.ChunkCombinedCodes, FillType.ChunkCombinedOffsets):
             assert isinstance(filled, tuple) and len(filled) == 2
         else:
             assert isinstance(filled, tuple) and len(filled) == 3
@@ -170,15 +159,13 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
         assert_array_equal(points[0], points[7])
         assert_array_equal(points[8], points[12])
         assert_array_equal(points[13], points[16])
-        if fill_type in (FillType.ChunkCombinedCodes,
-                         FillType.ChunkCombinedCodesOffsets):
+        if fill_type in (FillType.ChunkCombinedCodes, FillType.ChunkCombinedCodesOffsets):
             codes = filled[1]
             assert isinstance(codes, list) and len(codes) == 1
             codes = codes[0]
             assert isinstance(codes, np.ndarray)
             assert codes.dtype == np.uint8
-            assert_array_equal(
-                codes, [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79, 1, 2, 2, 79])
+            assert_array_equal(codes, [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79, 1, 2, 2, 79])
         else:
             offsets = filled[1]
             assert isinstance(offsets, list) and len(offsets) == 1
@@ -187,8 +174,7 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
             assert offsets.dtype == np.intp
             assert_array_equal(offsets, [0, 8, 13, 17])
 
-        if fill_type in (FillType.ChunkCombinedCodesOffsets,
-                         FillType.ChunkCombinedOffsets2):
+        if fill_type in (FillType.ChunkCombinedCodesOffsets, FillType.ChunkCombinedOffsets2):
             outer_offsets = filled[2]
             assert isinstance(outer_offsets, list) and len(outer_offsets) == 1
             outer_offsets = outer_offsets[0]

--- a/tests/test_interp.py
+++ b/tests/test_interp.py
@@ -21,8 +21,7 @@ def xyz_log():
 @pytest.mark.parametrize('name', ['serial', 'threaded'])
 def test_interp_log(xyz_log, name):
     x, y, z = xyz_log
-    cont_gen = contour_generator(
-        x, y, z, name, interp=Interp.Log, line_type=LineType.Separate)
+    cont_gen = contour_generator(x, y, z, name, interp=Interp.Log, line_type=LineType.Separate)
     for level in [0.3, 1, 3, 10, 30, 100]:
         expected_y = np.log10(level) / 2.5
         lines = cont_gen.lines(level)

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -32,8 +32,7 @@ def one_loop_one_strip():
 def test_level_outside(xy_2x2, name, zlevel):
     x, y = xy_2x2
     z = x
-    cont_gen = contour_generator(
-        x, y, z, name=name, line_type=LineType.SeparateCodes)
+    cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCodes)
     lines = cont_gen.lines(zlevel)
     assert isinstance(lines, tuple) and len(lines) == 2
     points, codes = lines
@@ -45,8 +44,7 @@ def test_level_outside(xy_2x2, name, zlevel):
 def test_w_to_e(xy_2x2, name):
     x, y = xy_2x2
     z = y.copy()
-    cont_gen = contour_generator(
-        x, y, z, name=name, line_type=LineType.SeparateCodes)
+    cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCodes)
     lines = cont_gen.lines(0.5)
     assert isinstance(lines, tuple) and len(lines) == 2
     points, codes = lines
@@ -60,8 +58,7 @@ def test_w_to_e(xy_2x2, name):
 def test_e_to_w(xy_2x2, name):
     x, y = xy_2x2
     z = 1.0 - y.copy()
-    cont_gen = contour_generator(
-        x, y, z, name=name, line_type=LineType.SeparateCodes)
+    cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCodes)
     lines = cont_gen.lines(0.5)
     assert isinstance(lines, tuple) and len(lines) == 2
     points, codes = lines
@@ -79,8 +76,7 @@ def test_loop(xy_3x3, name):
     x, y = xy_3x3
     z = np.zeros_like(x)
     z[1, 1] = 1.0
-    cont_gen = contour_generator(
-        x, y, z, name=name, line_type=LineType.SeparateCodes)
+    cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCodes)
     lines = cont_gen.lines(0.5)
     assert isinstance(lines, tuple) and len(lines) == 2
     points, codes = lines
@@ -96,8 +92,7 @@ def test_loop(xy_3x3, name):
     'name, line_type', util_test.all_names_and_line_types())
 def test_lines_random_uniform_no_corner_mask(name, line_type):
     x, y, z = random_uniform((30, 40), mask_fraction=0.05)
-    cont_gen = contour_generator(
-        x, y, z, name=name, line_type=line_type, corner_mask=False)
+    cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, corner_mask=False)
     levels = np.arange(0.0, 1.01, 0.2)
 
     assert cont_gen.line_type == line_type
@@ -107,8 +102,11 @@ def test_lines_random_uniform_no_corner_mask(name, line_type):
         renderer.lines(cont_gen.lines(levels[i]), line_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
 
-    compare_images(image_buffer, 'lines_random_uniform_no_corner_mask.png',
-                   f'{name}_{line_type}')
+    compare_images(
+        image_buffer,
+        'lines_random_uniform_no_corner_mask.png',
+        f'{name}_{line_type}',
+    )
 
 
 @pytest.mark.parametrize(
@@ -119,8 +117,7 @@ def test_lines_random_uniform_no_corner_mask_chunk(name, line_type):
 
     x, y, z = random_uniform((30, 40), mask_fraction=0.05)
     cont_gen = contour_generator(
-        x, y, z, name=name, line_type=line_type, corner_mask=False,
-        chunk_size=2)
+        x, y, z, name=name, line_type=line_type, corner_mask=False, chunk_size=2)
     levels = np.arange(0.0, 1.01, 0.2)
 
     renderer = MplTestRenderer()
@@ -128,17 +125,18 @@ def test_lines_random_uniform_no_corner_mask_chunk(name, line_type):
         renderer.lines(cont_gen.lines(levels[i]), line_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
 
-    compare_images(image_buffer,
-                   'lines_random_uniform_no_corner_mask_chunk.png',
-                   f'{name}_{line_type}')
+    compare_images(
+        image_buffer,
+        'lines_random_uniform_no_corner_mask_chunk.png',
+        f'{name}_{line_type}',
+    )
 
 
 @pytest.mark.parametrize('name', util_test.corner_mask_names())
 def test_lines_random_uniform_corner_mask(name):
     x, y, z = random_uniform((30, 40), mask_fraction=0.05)
     line_type = LineType.SeparateCodes
-    cont_gen = contour_generator(
-        x, y, z, name=name, corner_mask=True, line_type=line_type)
+    cont_gen = contour_generator(x, y, z, name=name, corner_mask=True, line_type=line_type)
     levels = np.arange(0.0, 1.01, 0.2)
 
     renderer = MplTestRenderer()
@@ -146,16 +144,18 @@ def test_lines_random_uniform_corner_mask(name):
         renderer.lines(cont_gen.lines(levels[i]), line_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
 
-    compare_images(image_buffer, 'lines_random_uniform_corner_mask.png',
-                   f'{name}_{line_type}')
+    compare_images(
+        image_buffer,
+        'lines_random_uniform_corner_mask.png',
+        f'{name}_{line_type}',
+    )
 
 
 @pytest.mark.parametrize('name', util_test.corner_mask_names())
 def test_lines_random_uniform_corner_mask_chunk(name):
     x, y, z = random_uniform((30, 40), mask_fraction=0.05)
     line_type = LineType.SeparateCodes
-    cont_gen = contour_generator(
-        x, y, z, name=name, corner_mask=True, line_type=line_type)
+    cont_gen = contour_generator(x, y, z, name=name, corner_mask=True, line_type=line_type)
     levels = np.arange(0.0, 1.01, 0.2)
 
     renderer = MplTestRenderer()
@@ -163,8 +163,11 @@ def test_lines_random_uniform_corner_mask_chunk(name):
         renderer.lines(cont_gen.lines(levels[i]), line_type, color=f'C{i}')
     image_buffer = renderer.save_to_buffer()
 
-    compare_images(image_buffer, 'lines_random_uniform_corner_mask_chunk.png',
-                   f'{name}_{line_type}')
+    compare_images(
+        image_buffer,
+        'lines_random_uniform_corner_mask_chunk.png',
+        f'{name}_{line_type}',
+    )
 
 
 @pytest.mark.parametrize('line_type', LineType.__members__.values())

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,5 +1,4 @@
 from contourpy import max_threads
-import pytest
 
 
 def test_max_threads():

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,6 +1,7 @@
 from contourpy import (
-    FillType, LineType, Mpl2005ContourGenerator, Mpl2014ContourGenerator,
-    SerialContourGenerator, ThreadedContourGenerator)
+    FillType, LineType, Mpl2005ContourGenerator, Mpl2014ContourGenerator, SerialContourGenerator,
+    ThreadedContourGenerator,
+)
 import pytest
 import util_test
 
@@ -45,8 +46,7 @@ def test_supports_fill_type(class_name):
     assert supports == expect
     supports = cls.supports_fill_type(FillType.ChunkCombinedOffsets2)
     assert isinstance(supports, bool)
-    expect = class_name not in (
-        'Mpl2005ContourGenerator', 'Mpl2014ContourGenerator')
+    expect = class_name not in ('Mpl2005ContourGenerator', 'Mpl2014ContourGenerator')
     assert supports == expect
 
 
@@ -55,8 +55,7 @@ def test_supports_interp(class_name):
     cls = get_class_from_name(class_name)
     supports = cls.supports_interp()
     assert isinstance(supports, bool)
-    expect = class_name not in (
-        'Mpl2005ContourGenerator', 'Mpl2014ContourGenerator')
+    expect = class_name not in ('Mpl2005ContourGenerator', 'Mpl2014ContourGenerator')
     assert supports == expect
 
 
@@ -69,8 +68,7 @@ def test_supports_line_type(class_name):
     assert supports == expect
     supports = cls.supports_line_type(LineType.ChunkCombinedOffsets)
     assert isinstance(supports, bool)
-    expect = class_name not in (
-        'Mpl2005ContourGenerator', 'Mpl2014ContourGenerator')
+    expect = class_name not in ('Mpl2005ContourGenerator', 'Mpl2014ContourGenerator')
     assert supports == expect
 
 

--- a/tests/util_config.py
+++ b/tests/util_config.py
@@ -7,7 +7,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-
 class PointType(Enum):
     CORNER = 0,
     LOWER = 1,
@@ -57,10 +56,9 @@ class Config:
             mid - (along*0.5 - right)*self.arrowsize,
             mid + along*0.5*self.arrowsize,
             mid - (along*0.5 + right)*self.arrowsize))
-        ax.plot(arrow[:,0], arrow[:, 1], '-', c=color)
+        ax.plot(arrow[:, 0], arrow[:, 1], '-', c=color)
 
-    def _next_quad(self, config, corner=None, suffix='', zlower=None,
-                   zupper=None):
+    def _next_quad(self, config, corner=None, suffix='', zlower=None, zupper=None):
         if zlower is None:
             zlower = self.default_zlower
         if zupper is None:
@@ -105,13 +103,12 @@ class Config:
         if corner != Corner.SE:
             ax.text(-self.text_gap, 1, nw, va='center', size=fontsize, ha='right')
         if suffix:  # Suffix (without brackets) is the z-level of quad middle.
-            ax.text(0.5, 0.5, suffix[1:-1], va='center', size=fontsize,
-                    ha='center')
+            ax.text(0.5, 0.5, suffix[1:-1], va='center', size=fontsize, ha='center')
 
         z = np.asarray([[sw, se], [nw, ne]], dtype=np.float64)
         z = np.ma.array(z, mask=self.mask)
-        cont_gen = contour_generator(self.x, self.y, z, name=self.name,
-                                     corner_mask=self.corner_mask)
+        cont_gen = contour_generator(
+            self.x, self.y, z, name=self.name, corner_mask=self.corner_mask)
         if self.is_filled:
             filled = cont_gen.filled(zlower, zupper)
             lines = filled[0]
@@ -145,8 +142,7 @@ class Config:
                     s = points[i]
                     e = points[i+1]
                     c = 'C2'
-                    if (point_types[i] == point_types[i+1] and
-                        point_types[i] != PointType.CORNER):
+                    if point_types[i] == point_types[i+1] and point_types[i] != PointType.CORNER:
                         c = 'C3' if point_types[i] == PointType.LOWER else 'C0'
                     ax.plot([s[0], e[0]], [s[1], e[1]], '-', c=c)
 
@@ -157,11 +153,9 @@ class Config:
                 for i in range(n-1):
                     if point_types[i] != PointType.CORNER:
                         c = 'C3' if point_types[i] == PointType.LOWER else 'C0'
-                        ax.plot(points[i][0], points[i][1], 'o', c=c,
-                                ms=self.marker_size)
+                        ax.plot(points[i][0], points[i][1], 'o', c=c, ms=self.marker_size)
             else:
-                ax.plot(points[:, 0], points[:, 1], 'o-', c='C3',
-                        ms=self.marker_size)
+                ax.plot(points[:, 0], points[:, 1], 'o-', c='C3', ms=self.marker_size)
 
                 for i in range(n-1):
                     self._arrow(ax, points[i], points[i+1], 'C3')
@@ -238,8 +232,7 @@ class ConfigFilled(ConfigFilledCommon):
     def __init__(self, name):
         super().__init__(name, False)
 
-        self.fig, axes = plt.subplots(8, 12, figsize=(13, 9.8),
-                                      subplot_kw={'aspect': 'equal'})
+        self.fig, axes = plt.subplots(8, 12, figsize=(13, 9.8), subplot_kw={'aspect': 'equal'})
         self.axes = axes.flatten()
 
         self.axes_index = 0
@@ -284,8 +277,7 @@ class ConfigFilledCorner(ConfigFilledCommon):
     def __init__(self, name):
         super().__init__(name, True)
 
-        self.fig, axes = plt.subplots(8, 14, figsize=(15, 9.8),
-                                      subplot_kw={'aspect': 'equal'})
+        self.fig, axes = plt.subplots(8, 14, figsize=(15, 9.8), subplot_kw={'aspect': 'equal'})
         self.axes = axes.flatten()
 
         corners = [Corner.NW, Corner.NE, Corner.SW, Corner.SE]
@@ -336,8 +328,7 @@ class ConfigLines(ConfigLinesCommon):
     def __init__(self, name):
         super().__init__(name, False)
 
-        self.fig, axes = plt.subplots(3, 6, figsize=(6.6, 3.6),
-                                      subplot_kw={'aspect': 'equal'})
+        self.fig, axes = plt.subplots(3, 6, figsize=(6.6, 3.6), subplot_kw={'aspect': 'equal'})
         self.axes = axes.flatten()
 
         self.axes_index = 0
@@ -364,8 +355,7 @@ class ConfigLinesCorner(ConfigLinesCommon):
     def __init__(self, name):
         super().__init__(name, True)
 
-        self.fig, axes = plt.subplots(4, 8, figsize=(8.8, 4.9),
-                                      subplot_kw={'aspect': 'equal'})
+        self.fig, axes = plt.subplots(4, 8, figsize=(8.8, 4.9), subplot_kw={'aspect': 'equal'})
         self.axes = axes.flatten()
 
         self.axes_index = 0


### PR DESCRIPTION
This PR adds flake8 linting as part of pytest.  Python line length is increased to 120, and various linting errors fixed. 