### PR TITLE
Lint cpp

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,11 @@ jobs:
         run: |
           python -m pip install --no-deps -ve .
 
+      - name: Install cppcheck
+        if: startsWith(runner.os, 'Linux')
+        run: |
+          sudo apt install -y cppcheck
+
       - name: Run tests
         run: |
           python -m pytest -v
@@ -55,4 +60,3 @@ jobs:
         with:
           name: test-artifacts
           path: test-artifacts/
-          

--- a/lib/contourpy/mpl2005.py
+++ b/lib/contourpy/mpl2005.py
@@ -26,6 +26,10 @@ class Mpl2005ContourGenerator(Cntr):
         return self._get_chunk_size()
 
     @property
+    def corner_mask(self):
+        return False
+
+    @property
     def fill_type(self):
         return self.default_fill_type
 

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -66,6 +66,7 @@ CodeArray Converter::convert_codes_check_closed_single(size_t point_count, const
     bool closed = *start == *(end-2) && *(start+1) == *(end-1);
     if (closed) {
         std::fill(py_ptr + 1, py_ptr + point_count - 1, LINETO);
+        // cppcheck-suppress unreadVariable
         py_ptr[point_count-1] = CLOSEPOLY;
     }
     else

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -5,12 +5,12 @@
 void Converter::check_max_offset(size_t max_offset)
 {
     if (max_offset > std::numeric_limits<OffsetArray::value_type>::max())
-        throw std::range_error("Max offset too large to fit in NumPy array of dtype npy_intp. Use smaller chunks.");
+        throw std::range_error(
+            "Max offset too large to fit in NumPy array of dtype npy_intp. Use smaller chunks.");
 }
 
 CodeArray Converter::convert_codes(
-    size_t point_count, size_t cut_count, const size_t* cut_start,
-    size_t subtract)
+    size_t point_count, size_t cut_count, const size_t* cut_start, size_t subtract)
 {
     assert(point_count > 0);
     assert(cut_count > 0);
@@ -29,8 +29,7 @@ CodeArray Converter::convert_codes(
 }
 
 CodeArray Converter::convert_codes_check_closed(
-    size_t point_count, size_t cut_count, const size_t* cut_start,
-    const double* check_closed)
+    size_t point_count, size_t cut_count, const size_t* cut_start, const double* check_closed)
 {
     assert(point_count > 0);
     assert(cut_count > 0);
@@ -53,8 +52,7 @@ CodeArray Converter::convert_codes_check_closed(
     return py_codes;
 }
 
-CodeArray Converter::convert_codes_check_closed_single(
-    size_t point_count, const double* points)
+CodeArray Converter::convert_codes_check_closed_single(size_t point_count, const double* points)
 {
     assert(point_count > 0);
 
@@ -76,8 +74,7 @@ CodeArray Converter::convert_codes_check_closed_single(
     return py_codes;
 }
 
-OffsetArray Converter::convert_offsets(
-    size_t offset_count, const size_t* start, size_t subtract)
+OffsetArray Converter::convert_offsets(size_t offset_count, const size_t* start, size_t subtract)
 {
     assert(offset_count > 0);
 

--- a/src/converter.h
+++ b/src/converter.h
@@ -8,15 +8,12 @@ class Converter
 {
 public:
     static CodeArray convert_codes(
-        size_t point_count, size_t cut_count, const size_t* cut_start,
-        size_t subtract = 0);
+        size_t point_count, size_t cut_count, const size_t* cut_start, size_t subtract = 0);
 
     static CodeArray convert_codes_check_closed(
-        size_t point_count, size_t cut_count, const size_t* cut_start,
-        const double* points);
+        size_t point_count, size_t cut_count, const size_t* cut_start, const double* points);
 
-    static CodeArray convert_codes_check_closed_single(
-        size_t point_count, const double* points);
+    static CodeArray convert_codes_check_closed_single(size_t point_count, const double* points);
 
     static OffsetArray convert_offsets(
         size_t offset_count, const size_t* start, size_t subtract = 0);

--- a/src/mpl2014.cpp
+++ b/src/mpl2014.cpp
@@ -797,8 +797,8 @@ void Mpl2014ContourGenerator::follow_interior(
                 default: assert(0 && "Invalid edge"); break;
             }
 
-            unsigned int config = (Z_LEVEL(point_left) >= level_index) << 1 |
-                                  (Z_LEVEL(point_right) >= level_index);
+            unsigned int config = ((Z_LEVEL(point_left) >= level_index) << 1) |
+                                   (Z_LEVEL(point_right) >= level_index);
 
             // Upper level (level_index == 2) polygons are reversed compared to
             // lower level ones, i.e. higher values on the right rather than
@@ -931,9 +931,9 @@ Edge Mpl2014ContourGenerator::get_corner_start_edge(
             return Edge_None;
     }
 
-    unsigned int config = (Z_LEVEL(point1) >= level_index) << 2 |
-                          (Z_LEVEL(point2) >= level_index) << 1 |
-                          (Z_LEVEL(point3) >= level_index);
+    unsigned int config = ((Z_LEVEL(point1) >= level_index) << 2) |
+                          ((Z_LEVEL(point2) >= level_index) << 1) |
+                          ((Z_LEVEL(point3) >= level_index) << 0);
 
     // Upper level (level_index == 2) polygons are reversed compared to lower
     // level ones, i.e. higher values on the right rather than the left.
@@ -1081,10 +1081,10 @@ Edge Mpl2014ContourGenerator::get_quad_start_edge(
     assert((level_index == 1 || level_index == 2) && "level index must be 1 or 2");
     assert(EXISTS_QUAD(quad) && "Quad does not exist");
 
-    unsigned int config = (Z_NW >= level_index) << 3 |
-                          (Z_NE >= level_index) << 2 |
-                          (Z_SW >= level_index) << 1 |
-                          (Z_SE >= level_index);
+    unsigned int config = ((Z_NW >= level_index) << 3) |
+                          ((Z_NE >= level_index) << 2) |
+                          ((Z_SW >= level_index) << 1) |
+                          ((Z_SE >= level_index) << 0);
 
     // Upper level (level_index == 2) polygons are reversed compared to lower
     // level ones, i.e. higher values on the right rather than the left.
@@ -1166,10 +1166,10 @@ void Mpl2014ContourGenerator::init_cache_grid(const MaskArray& mask)
                 _cache[quad] = 0;
 
                 if (i < _nx-1 && j < _ny-1) {
-                    unsigned int config = mask_ptr[POINT_NW] << 3 |
-                                          mask_ptr[POINT_NE] << 2 |
-                                          mask_ptr[POINT_SW] << 1 |
-                                          mask_ptr[POINT_SE];
+                    unsigned int config = (mask_ptr[POINT_NW] << 3) |
+                                          (mask_ptr[POINT_NE] << 2) |
+                                          (mask_ptr[POINT_SW] << 1) |
+                                          (mask_ptr[POINT_SE] << 0);
 
                     if (_corner_mask) {
                          switch (config) {

--- a/src/mpl2014.cpp
+++ b/src/mpl2014.cpp
@@ -885,6 +885,11 @@ py::tuple Mpl2014ContourGenerator::get_chunk_size() const
     return py::make_tuple(_y_chunk_size, _x_chunk_size);
 }
 
+bool Mpl2014ContourGenerator::get_corner_mask() const
+{
+    return _corner_mask;
+}
+
 Edge Mpl2014ContourGenerator::get_corner_start_edge(
     index_t quad, unsigned int level_index) const
 {

--- a/src/mpl2014.cpp
+++ b/src/mpl2014.cpp
@@ -266,8 +266,7 @@ void Contour::write() const
 
 
 
-ParentCache::ParentCache(
-    index_t nx, index_t x_chunk_points, index_t y_chunk_points)
+ParentCache::ParentCache(index_t nx, index_t x_chunk_points, index_t y_chunk_points)
     : _nx(nx),
       _x_chunk_points(x_chunk_points),
       _y_chunk_points(y_chunk_points),
@@ -275,8 +274,7 @@ ParentCache::ParentCache(
       _istart(0),
       _jstart(0)
 {
-    assert(_x_chunk_points > 0 && _y_chunk_points > 0 &&
-           "Chunk sizes must be positive");
+    assert(_x_chunk_points > 0 && _y_chunk_points > 0 && "Chunk sizes must be positive");
 }
 
 ContourLine* ParentCache::get_parent(index_t quad)
@@ -298,10 +296,8 @@ index_t ParentCache::index_to_index(index_t quad) const
     index_t j = quad / _nx;
     index_t index = (i-_istart) + (j-_jstart)*_x_chunk_points;
 
-    assert(i >= _istart && i < _istart + _x_chunk_points &&
-           "i-index outside chunk");
-    assert(j >= _jstart && j < _jstart + _y_chunk_points &&
-           "j-index outside chunk");
+    assert(i >= _istart && i < _istart + _x_chunk_points && "i-index outside chunk");
+    assert(j >= _jstart && j < _jstart + _y_chunk_points && "j-index outside chunk");
     assert(index >= 0 && index < static_cast<index_t>(_lines.size()) &&
            "ParentCache index outside chunk");
 
@@ -310,8 +306,7 @@ index_t ParentCache::index_to_index(index_t quad) const
 
 void ParentCache::set_chunk_starts(index_t istart, index_t jstart)
 {
-    assert(istart >= 0 && jstart >= 0 &&
-           "Chunk start indices cannot be negative");
+    assert(istart >= 0 && jstart >= 0 && "Chunk start indices cannot be negative");
     _istart = istart;
     _jstart = jstart;
     if (_lines.empty())
@@ -322,25 +317,18 @@ void ParentCache::set_chunk_starts(index_t istart, index_t jstart)
 
 void ParentCache::set_parent(index_t quad, ContourLine& contour_line)
 {
-    assert(!_lines.empty() &&
-           "Accessing ParentCache before it has been initialised");
+    assert(!_lines.empty() && "Accessing ParentCache before it has been initialised");
     index_t index = index_to_index(quad);
     if (_lines[index] == 0)
-        _lines[index] = (contour_line.is_hole() ? contour_line.get_parent()
-                                                : &contour_line);
+        _lines[index] = contour_line.is_hole() ? contour_line.get_parent() : &contour_line;
 }
 
 
 
-Mpl2014ContourGenerator::Mpl2014ContourGenerator(const CoordinateArray& x,
-                                                 const CoordinateArray& y,
-                                                 const CoordinateArray& z,
-                                                 const MaskArray& mask,
-                                                 bool corner_mask,
-                                                 LineType line_type,
-                                                 FillType fill_type,
-                                                 index_t x_chunk_size,
-                                                 index_t y_chunk_size)
+Mpl2014ContourGenerator::Mpl2014ContourGenerator(
+    const CoordinateArray& x, const CoordinateArray& y, const CoordinateArray& z,
+    const MaskArray& mask, bool corner_mask, LineType line_type, FillType fill_type,
+    index_t x_chunk_size, index_t y_chunk_size)
     : _x(x),
       _y(y),
       _z(z),
@@ -373,7 +361,8 @@ Mpl2014ContourGenerator::Mpl2014ContourGenerator(const CoordinateArray& x,
             throw std::invalid_argument("mask array must be a 2D array");
 
         if (mask.shape(1) != _nx || mask.shape(0) != _ny)
-            throw std::invalid_argument("If mask is set it must be a 2D array with the same shape as z");
+            throw std::invalid_argument(
+                "If mask is set it must be a 2D array with the same shape as z");
     }
 
     if (!supports_line_type(line_type))
@@ -394,9 +383,7 @@ Mpl2014ContourGenerator::~Mpl2014ContourGenerator()
 }
 
 void Mpl2014ContourGenerator::append_contour_line_to_vertices_and_codes(
-    ContourLine& contour_line,
-    py::list& vertices_list,
-    py::list& codes_list) const
+    ContourLine& contour_line, py::list& vertices_list, py::list& codes_list) const
 {
     // Convert ContourLine to Python equivalent, and clear it for reuse.
     // This function is called once for each line generated in create_contour().
@@ -438,9 +425,7 @@ void Mpl2014ContourGenerator::append_contour_line_to_vertices_and_codes(
 }
 
 void Mpl2014ContourGenerator::append_contour_to_vertices_and_codes(
-    Contour& contour,
-    py::list& vertices_list,
-    py::list& codes_list) const
+    Contour& contour, py::list& vertices_list, py::list& codes_list) const
 {
     // Convert Contour to Python equivalent, and clear it for reuse.
     // This function is called once for each polygon generated in
@@ -474,8 +459,7 @@ void Mpl2014ContourGenerator::append_contour_to_vertices_and_codes(
 
             const ContourLine::Children& children = line.get_children();
             py::ssize_t npoints = static_cast<py::ssize_t>(line.size() + 1);
-            for (children_it = children.begin(); children_it != children.end();
-                 ++children_it)
+            for (children_it = children.begin(); children_it != children.end(); ++children_it)
                  npoints += static_cast<py::ssize_t>((*children_it)->size() + 1);
 
             py::ssize_t vertices_dims[2] = {npoints, 2};
@@ -496,8 +480,7 @@ void Mpl2014ContourGenerator::append_contour_to_vertices_and_codes(
             *vertices_ptr++ = point->y;
             *codes_ptr++ = CLOSEPOLY;
 
-            for (children_it = children.begin(); children_it != children.end();
-                 ++children_it) {
+            for (children_it = children.begin(); children_it != children.end(); ++children_it) {
                 ContourLine& child = **children_it;
                 for (point = child.begin(); point != child.end(); ++point) {
                     *vertices_ptr++ = point->x;
@@ -552,12 +535,10 @@ LineType Mpl2014ContourGenerator::default_line_type()
     return LineType::SeparateCodes;
 }
 
-void Mpl2014ContourGenerator::edge_interp(const QuadEdge& quad_edge,
-                                          const double& level,
-                                          ContourLine& contour_line)
+void Mpl2014ContourGenerator::edge_interp(
+    const QuadEdge& quad_edge, const double& level, ContourLine& contour_line)
 {
-    assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-           "Quad index out of bounds");
+    assert(quad_edge.quad >= 0 && quad_edge.quad < _n && "Quad index out of bounds");
     assert(quad_edge.edge != Edge_None && "Invalid edge");
     interp(get_edge_point_index(quad_edge, true),
            get_edge_point_index(quad_edge, false),
@@ -610,19 +591,13 @@ py::tuple Mpl2014ContourGenerator::filled(
 }
 
 unsigned int Mpl2014ContourGenerator::follow_boundary(
-    ContourLine& contour_line,
-    QuadEdge& quad_edge,
-    const double& lower_level,
-    const double& upper_level,
-    unsigned int level_index,
-    const QuadEdge& start_quad_edge)
+    ContourLine& contour_line, QuadEdge& quad_edge, const double& lower_level,
+    const double& upper_level, unsigned int level_index, const QuadEdge& start_quad_edge)
 {
-    assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-           "Quad index out of bounds");
+    assert(quad_edge.quad >= 0 && quad_edge.quad < _n && "Quad index out of bounds");
     assert(quad_edge.edge != Edge_None && "Invalid edge");
     assert(is_edge_a_boundary(quad_edge) && "Not a boundary edge");
-    assert((level_index == 1 || level_index == 2) &&
-           "level index must be 1 or 2");
+    assert((level_index == 1 || level_index == 2) && "level index must be 1 or 2");
     assert(start_quad_edge.quad >= 0 && start_quad_edge.quad < _n &&
            "Start quad index out of bounds");
     assert(start_quad_edge.edge != Edge_None && "Invalid start edge");
@@ -636,8 +611,7 @@ unsigned int Mpl2014ContourGenerator::follow_boundary(
     while (true) {
         // Levels of start and end points of quad_edge.
         unsigned int start_level =
-            (first_edge ? Z_LEVEL(get_edge_point_index(quad_edge, true))
-                        : end_level);
+            (first_edge ? Z_LEVEL(get_edge_point_index(quad_edge, true)) : end_level);
         index_t end_point = get_edge_point_index(quad_edge, false);
         end_level = Z_LEVEL(end_point);
 
@@ -701,9 +675,7 @@ unsigned int Mpl2014ContourGenerator::follow_boundary(
 
         if (stop) {
             // Exiting boundary to enter interior.
-            edge_interp(quad_edge,
-                        level_index == 1 ? lower_level : upper_level,
-                        contour_line);
+            edge_interp(quad_edge, level_index == 1 ? lower_level : upper_level, contour_line);
             break;
         }
 
@@ -741,25 +713,17 @@ unsigned int Mpl2014ContourGenerator::follow_boundary(
 }
 
 void Mpl2014ContourGenerator::follow_interior(
-    ContourLine& contour_line,
-    QuadEdge& quad_edge,
-    unsigned int level_index,
-    const double& level,
-    bool want_initial_point,
-    const QuadEdge* start_quad_edge,
-    unsigned int start_level_index,
+    ContourLine& contour_line, QuadEdge& quad_edge, unsigned int level_index, const double& level,
+    bool want_initial_point, const QuadEdge* start_quad_edge, unsigned int start_level_index,
     bool set_parents)
 {
-    assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-           "Quad index out of bounds.");
+    assert(quad_edge.quad >= 0 && quad_edge.quad < _n && "Quad index out of bounds.");
     assert(quad_edge.edge != Edge_None && "Invalid edge");
-    assert((level_index == 1 || level_index == 2) &&
-           "level index must be 1 or 2");
+    assert((level_index == 1 || level_index == 2) && "level index must be 1 or 2");
     assert((start_quad_edge == 0 ||
             (start_quad_edge->quad >= 0 && start_quad_edge->quad < _n)) &&
            "Start quad index out of bounds.");
-    assert((start_quad_edge == 0 || start_quad_edge->edge != Edge_None) &&
-           "Invalid start edge");
+    assert((start_quad_edge == 0 || start_quad_edge->edge != Edge_None) && "Invalid start edge");
     assert((start_level_index == 1 || start_level_index == 2) &&
            "start level index must be 1 or 2");
 
@@ -793,20 +757,16 @@ void Mpl2014ContourGenerator::follow_interior(
             index_t point_opposite = -1;
             switch (edge) {
                 case Edge_E:
-                    point_opposite = (EXISTS_SE_CORNER(quad) ? POINT_SW
-                                                             : POINT_NW);
+                    point_opposite = (EXISTS_SE_CORNER(quad) ? POINT_SW : POINT_NW);
                     break;
                 case Edge_N:
-                    point_opposite = (EXISTS_NW_CORNER(quad) ? POINT_SW
-                                                             : POINT_SE);
+                    point_opposite = (EXISTS_NW_CORNER(quad) ? POINT_SW : POINT_SE);
                     break;
                 case Edge_W:
-                    point_opposite = (EXISTS_SW_CORNER(quad) ? POINT_SE
-                                                             : POINT_NE);
+                    point_opposite = (EXISTS_SW_CORNER(quad) ? POINT_SE : POINT_NE);
                     break;
                 case Edge_S:
-                    point_opposite = (EXISTS_SW_CORNER(quad) ? POINT_NW
-                                                             : POINT_NE);
+                    point_opposite = (EXISTS_SW_CORNER(quad) ? POINT_NW : POINT_NE);
                     break;
                 case Edge_NE: point_opposite = POINT_SW; break;
                 case Edge_NW: point_opposite = POINT_SE; break;
@@ -859,19 +819,17 @@ void Mpl2014ContourGenerator::follow_interior(
                 }
                 else {
                     dir = Dir_Left;
-                    _cache[quad] |= (level_index == 1 ? MASK_SADDLE_LEFT_1
-                                                      : MASK_SADDLE_LEFT_2);
+                    _cache[quad] |= (level_index == 1 ? MASK_SADDLE_LEFT_1 : MASK_SADDLE_LEFT_2);
                 }
                 if (edge == Edge_N || edge == Edge_E) {
                     // Next visit to this quad must start on S or W.
-                    _cache[quad] |= (level_index == 1 ? MASK_SADDLE_START_SW_1
-                                                      : MASK_SADDLE_START_SW_2);
+                    _cache[quad] |=
+                        (level_index == 1 ? MASK_SADDLE_START_SW_1 : MASK_SADDLE_START_SW_2);
                 }
             }
             else {
                 // Normal (non-saddle) quad.
-                dir = (config == 0 ? Dir_Left
-                                   : (config == 3 ? Dir_Right : Dir_Straight));
+                dir = (config == 0 ? Dir_Left : (config == 3 ? Dir_Right : Dir_Straight));
                 _cache[quad] |= visited_mask;
             }
         }
@@ -894,8 +852,7 @@ void Mpl2014ContourGenerator::follow_interior(
             break;
 
         move_to_next_quad(quad_edge);
-        assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-               "Quad index out of bounds");
+        assert(quad_edge.quad >= 0 && quad_edge.quad < _n && "Quad index out of bounds");
 
         // Return if reached start point of contour line.
         if (start_quad_edge != 0 &&
@@ -910,13 +867,9 @@ py::tuple Mpl2014ContourGenerator::get_chunk_count() const
     return py::make_tuple(_nychunk, _nxchunk);
 }
 
-void Mpl2014ContourGenerator::get_chunk_limits(index_t ijchunk,
-                                               index_t& ichunk,
-                                               index_t& jchunk,
-                                               index_t& istart,
-                                               index_t& iend,
-                                               index_t& jstart,
-                                               index_t& jend)
+void Mpl2014ContourGenerator::get_chunk_limits(
+    index_t ijchunk, index_t& ichunk, index_t& jchunk, index_t& istart, index_t& iend,
+    index_t& jstart, index_t& jend)
 {
     assert(ijchunk >= 0 && ijchunk < _chunk_count && "ijchunk out of bounds");
     ichunk = ijchunk % _nxchunk;
@@ -933,12 +886,10 @@ py::tuple Mpl2014ContourGenerator::get_chunk_size() const
 }
 
 Edge Mpl2014ContourGenerator::get_corner_start_edge(
-    index_t quad,
-    unsigned int level_index) const
+    index_t quad, unsigned int level_index) const
 {
     assert(quad >= 0 && quad < _n && "Quad index out of bounds");
-    assert((level_index == 1 || level_index == 2) &&
-           "level index must be 1 or 2");
+    assert((level_index == 1 || level_index == 2) && "level index must be 1 or 2");
     assert(EXISTS_ANY_CORNER(quad) && "Quad is not a corner");
 
     // Diagram for NE corner.  Rotate for other corners.
@@ -998,11 +949,9 @@ Edge Mpl2014ContourGenerator::get_corner_start_edge(
 }
 
 index_t Mpl2014ContourGenerator::get_edge_point_index(
-    const QuadEdge& quad_edge,
-    bool start) const
+    const QuadEdge& quad_edge, bool start) const
 {
-    assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-           "Quad index out of bounds");
+    assert(quad_edge.quad >= 0 && quad_edge.quad < _n && "Quad index out of bounds");
     assert(quad_edge.edge != Edge_None && "Invalid edge");
 
     // Edges are ordered anticlockwise around their quad, as indicated by
@@ -1033,11 +982,9 @@ index_t Mpl2014ContourGenerator::get_edge_point_index(
     }
 }
 
-Edge Mpl2014ContourGenerator::get_exit_edge(const QuadEdge& quad_edge,
-                                            Dir dir) const
+Edge Mpl2014ContourGenerator::get_exit_edge(const QuadEdge& quad_edge, Dir dir) const
 {
-    assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-           "Quad index out of bounds");
+    assert(quad_edge.quad >= 0 && quad_edge.quad < _n && "Quad index out of bounds");
     assert(quad_edge.edge != Edge_None && "Invalid edge");
 
     const index_t& quad = quad_edge.quad;
@@ -1075,17 +1022,13 @@ Edge Mpl2014ContourGenerator::get_exit_edge(const QuadEdge& quad_edge,
         // edges correspond to left, straight and right directions.
         switch (edge) {
             case Edge_E:
-                return (dir == Dir_Left ? Edge_S :
-                            (dir == Dir_Right ? Edge_N : Edge_W));
+                return (dir == Dir_Left ? Edge_S : (dir == Dir_Right ? Edge_N : Edge_W));
             case Edge_N:
-                return (dir == Dir_Left ? Edge_E :
-                            (dir == Dir_Right ? Edge_W : Edge_S));
+                return (dir == Dir_Left ? Edge_E : (dir == Dir_Right ? Edge_W : Edge_S));
             case Edge_W:
-                return (dir == Dir_Left ? Edge_N :
-                            (dir == Dir_Right ? Edge_S : Edge_E));
+                return (dir == Dir_Left ? Edge_N : (dir == Dir_Right ? Edge_S : Edge_E));
             case Edge_S:
-                return (dir == Dir_Left ? Edge_W :
-                            (dir == Dir_Right ? Edge_E : Edge_N));
+                return (dir == Dir_Left ? Edge_W : (dir == Dir_Right ? Edge_E : Edge_N));
             default: assert(0 && "Invalid edge"); return Edge_None;
         }
     }
@@ -1113,8 +1056,8 @@ const double& Mpl2014ContourGenerator::get_point_y(index_t point) const
     return _y.data()[point];
 }
 
-void Mpl2014ContourGenerator::get_point_xy(index_t point,
-                                           ContourLine& contour_line) const
+void Mpl2014ContourGenerator::get_point_xy(
+    index_t point, ContourLine& contour_line) const
 {
     assert(point >= 0 && point < _n && "Point index out of bounds.");
     contour_line.emplace_back(_x.data()[point], _y.data()[point]);
@@ -1127,12 +1070,10 @@ const double& Mpl2014ContourGenerator::get_point_z(index_t point) const
 }
 
 Edge Mpl2014ContourGenerator::get_quad_start_edge(
-    index_t quad,
-    unsigned int level_index) const
+    index_t quad, unsigned int level_index) const
 {
     assert(quad >= 0 && quad < _n && "Quad index out of bounds");
-    assert((level_index == 1 || level_index == 2) &&
-           "level index must be 1 or 2");
+    assert((level_index == 1 || level_index == 2) && "level index must be 1 or 2");
     assert(EXISTS_QUAD(quad) && "Quad does not exist");
 
     unsigned int config = (Z_NW >= level_index) << 3 |
@@ -1179,8 +1120,7 @@ Edge Mpl2014ContourGenerator::get_quad_start_edge(
     }
 }
 
-Edge Mpl2014ContourGenerator::get_start_edge(index_t quad,
-                                             unsigned int level_index) const
+Edge Mpl2014ContourGenerator::get_start_edge(index_t quad, unsigned int level_index) const
 {
     if (EXISTS_ANY_CORNER(quad))
         return get_corner_start_edge(quad, level_index);
@@ -1260,28 +1200,24 @@ void Mpl2014ContourGenerator::init_cache_grid(const MaskArray& mask)
 
                     if ((EXISTS_W_EDGE(quad) && W_exists_none) ||
                         (EXISTS_NONE(quad) && W_exists_E_edge) ||
-                        (i % _x_chunk_size == 0 && EXISTS_W_EDGE(quad) &&
-                                                 W_exists_E_edge))
-                         _cache[quad] |= MASK_BOUNDARY_W;
+                        (i % _x_chunk_size == 0 && EXISTS_W_EDGE(quad) && W_exists_E_edge))
+                        _cache[quad] |= MASK_BOUNDARY_W;
 
                     if ((EXISTS_S_EDGE(quad) && S_exists_none) ||
                         (EXISTS_NONE(quad) && S_exists_N_edge) ||
-                        (j % _y_chunk_size == 0 && EXISTS_S_EDGE(quad) &&
-                                                 S_exists_N_edge))
-                         _cache[quad] |= MASK_BOUNDARY_S;
+                        (j % _y_chunk_size == 0 && EXISTS_S_EDGE(quad) && S_exists_N_edge))
+                        _cache[quad] |= MASK_BOUNDARY_S;
                 }
                 else {
                     bool W_exists_quad = (i > 0 && EXISTS_QUAD(quad-1));
                     bool S_exists_quad = (j > 0 && EXISTS_QUAD(quad-_nx));
 
                     if ((EXISTS_QUAD(quad) != W_exists_quad) ||
-                        (i % _x_chunk_size == 0 && EXISTS_QUAD(quad) &&
-                                                 W_exists_quad))
+                        (i % _x_chunk_size == 0 && EXISTS_QUAD(quad) && W_exists_quad))
                         _cache[quad] |= MASK_BOUNDARY_W;
 
                     if ((EXISTS_QUAD(quad) != S_exists_quad) ||
-                        (j % _y_chunk_size == 0 && EXISTS_QUAD(quad) &&
-                                                 S_exists_quad))
+                        (j % _y_chunk_size == 0 && EXISTS_QUAD(quad) && S_exists_quad))
                         _cache[quad] |= MASK_BOUNDARY_S;
                 }
             }
@@ -1289,11 +1225,10 @@ void Mpl2014ContourGenerator::init_cache_grid(const MaskArray& mask)
     }
 }
 
-void Mpl2014ContourGenerator::init_cache_levels(const double& lower_level,
-                                                const double& upper_level)
+void Mpl2014ContourGenerator::init_cache_levels(
+    const double& lower_level, const double& upper_level)
 {
-    assert(!(upper_level < lower_level) &&
-           "upper and lower levels are wrong way round");
+    assert(!(upper_level < lower_level) && "upper and lower levels are wrong way round");
 
     bool two_levels = (lower_level != upper_level);
     CacheItem keep_mask =
@@ -1320,16 +1255,13 @@ void Mpl2014ContourGenerator::init_cache_levels(const double& lower_level,
    }
 }
 
-void Mpl2014ContourGenerator::interp(index_t point1,
-                                     index_t point2,
-                                     const double& level,
-                                     ContourLine& contour_line) const
+void Mpl2014ContourGenerator::interp(
+    index_t point1, index_t point2, const double& level, ContourLine& contour_line) const
 {
     assert(point1 >= 0 && point1 < _n && "Point index 1 out of bounds.");
     assert(point2 >= 0 && point2 < _n && "Point index 2 out of bounds.");
     assert(point1 != point2 && "Identical points");
-    double fraction = (get_point_z(point2) - level) /
-                          (get_point_z(point2) - get_point_z(point1));
+    double fraction = (get_point_z(point2) - level) / (get_point_z(point2) - get_point_z(point1));
     contour_line.emplace_back(
         get_point_x(point1)*fraction + get_point_x(point2)*(1.0 - fraction),
         get_point_y(point1)*fraction + get_point_y(point2)*(1.0 - fraction));
@@ -1338,8 +1270,7 @@ void Mpl2014ContourGenerator::interp(index_t point1,
 bool Mpl2014ContourGenerator::is_edge_a_boundary(
     const QuadEdge& quad_edge) const
 {
-    assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-           "Quad index out of bounds");
+    assert(quad_edge.quad >= 0 && quad_edge.quad < _n && "Quad index out of bounds");
     assert(quad_edge.edge != Edge_None && "Invalid edge");
 
     switch (quad_edge.edge) {
@@ -1426,12 +1357,11 @@ py::tuple Mpl2014ContourGenerator::lines(const double& level)
                 // sometimes need to ignore the first point and add it on the
                 // end instead.
                 bool ignore_first = (start_edge == Edge_N);
-                follow_interior(contour_line, quad_edge, 1, level,
-                                !ignore_first, &start_quad_edge, 1, false);
+                follow_interior(
+                    contour_line, quad_edge, 1, level, !ignore_first, &start_quad_edge, 1, false);
                 if (ignore_first && !contour_line.empty())
                     contour_line.push_back(contour_line.front());
-                append_contour_line_to_vertices_and_codes(
-                    contour_line, vertices_list, codes_list);
+                append_contour_line_to_vertices_and_codes(contour_line, vertices_list, codes_list);
 
                 // Repeat if saddle point but not visited.
                 if (SADDLE(quad,1) && !VISITED(quad,1))
@@ -1551,8 +1481,7 @@ void Mpl2014ContourGenerator::move_to_next_boundary_edge(
 
 void Mpl2014ContourGenerator::move_to_next_quad(QuadEdge& quad_edge) const
 {
-    assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-           "Quad index out of bounds");
+    assert(quad_edge.quad >= 0 && quad_edge.quad < _n && "Quad index out of bounds");
     assert(quad_edge.edge != Edge_None && "Invalid edge");
 
     // Move from quad_edge.quad to the neighbouring quad in the direction
@@ -1567,10 +1496,7 @@ void Mpl2014ContourGenerator::move_to_next_quad(QuadEdge& quad_edge) const
 }
 
 void Mpl2014ContourGenerator::single_quad_filled(
-    Contour& contour,
-    index_t quad,
-    const double& lower_level,
-    const double& upper_level)
+    Contour& contour, index_t quad, const double& lower_level, const double& upper_level)
 {
     assert(quad >= 0 && quad < _n && "Quad index out of bounds");
 
@@ -1583,23 +1509,23 @@ void Mpl2014ContourGenerator::single_quad_filled(
 
         // Lower-level start from S boundary into interior.
         if (!VISITED_S(quad) && Z_SW >= 1 && Z_SE == 0)
-            contour.push_back(start_filled(quad, Edge_S, 1, NotHole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_S, 1, NotHole, Interior, lower_level, upper_level));
 
         // Upper-level start from S boundary into interior.
         if (!VISITED_S(quad) && Z_SW < 2 && Z_SE == 2)
-            contour.push_back(start_filled(quad, Edge_S, 2, NotHole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_S, 2, NotHole, Interior, lower_level, upper_level));
 
         // Lower-level start following S boundary from W to E.
         if (!VISITED_S(quad) && Z_SW <= 1 && Z_SE == 1)
-            contour.push_back(start_filled(quad, Edge_S, 1, NotHole, Boundary,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_S, 1, NotHole, Boundary, lower_level, upper_level));
 
         // Upper-level start following S boundary from W to E.
         if (!VISITED_S(quad) && Z_SW == 2 && Z_SE == 1)
-            contour.push_back(start_filled(quad, Edge_S, 2, NotHole, Boundary,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_S, 2, NotHole, Boundary, lower_level, upper_level));
     }
 
     // Possible starts from W boundary.
@@ -1607,23 +1533,23 @@ void Mpl2014ContourGenerator::single_quad_filled(
 
         // Lower-level start from W boundary into interior.
         if (!VISITED_W(quad) && Z_NW >= 1 && Z_SW == 0)
-            contour.push_back(start_filled(quad, Edge_W, 1, NotHole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_W, 1, NotHole, Interior, lower_level, upper_level));
 
         // Upper-level start from W boundary into interior.
         if (!VISITED_W(quad) && Z_NW < 2 && Z_SW == 2)
-            contour.push_back(start_filled(quad, Edge_W, 2, NotHole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_W, 2, NotHole, Interior, lower_level, upper_level));
 
         // Lower-level start following W boundary from N to S.
         if (!VISITED_W(quad) && Z_NW <= 1 && Z_SW == 1)
-            contour.push_back(start_filled(quad, Edge_W, 1, NotHole, Boundary,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_W, 1, NotHole, Boundary, lower_level, upper_level));
 
         // Upper-level start following W boundary from N to S.
         if (!VISITED_W(quad) && Z_NW == 2 && Z_SW == 1)
-            contour.push_back(start_filled(quad, Edge_W, 2, NotHole, Boundary,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_W, 2, NotHole, Boundary, lower_level, upper_level));
     }
 
     // Possible starts from NE boundary.
@@ -1631,77 +1557,77 @@ void Mpl2014ContourGenerator::single_quad_filled(
 
         // Lower-level start following NE boundary from SE to NW, hole.
         if (!VISITED_CORNER(quad) && Z_NW == 1 && Z_SE == 1)
-            contour.push_back(start_filled(quad, Edge_NE, 1, Hole, Boundary,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_NE, 1, Hole, Boundary, lower_level, upper_level));
     }
     // Possible starts from SE boundary.
     else if (EXISTS_NW_CORNER(quad)) {  // i.e. BOUNDARY_SE
 
         // Lower-level start from N to SE.
         if (!VISITED(quad,1) && Z_NW == 0 && Z_SW == 0 && Z_NE >= 1)
-            contour.push_back(start_filled(quad, Edge_N, 1, NotHole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_N, 1, NotHole, Interior, lower_level, upper_level));
 
         // Upper-level start from SE to N, hole.
         if (!VISITED(quad,2) && Z_NW <  2 && Z_SW < 2 && Z_NE == 2)
-            contour.push_back(start_filled(quad, Edge_SE, 2, Hole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_SE, 2, Hole, Interior, lower_level, upper_level));
 
         // Upper-level start from N to SE.
         if (!VISITED(quad,2) && Z_NW == 2 && Z_SW == 2 && Z_NE < 2)
-            contour.push_back(start_filled(quad, Edge_N, 2, NotHole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_N, 2, NotHole, Interior, lower_level, upper_level));
 
         // Lower-level start from SE to N, hole.
         if (!VISITED(quad,1) && Z_NW >= 1 && Z_SW >= 1 && Z_NE == 0)
-            contour.push_back(start_filled(quad, Edge_SE, 1, Hole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_SE, 1, Hole, Interior, lower_level, upper_level));
     }
     // Possible starts from NW boundary.
     else if (EXISTS_SE_CORNER(quad)) {  // i.e. BOUNDARY_NW
 
         // Lower-level start from NW to E.
         if (!VISITED(quad,1) && Z_SW == 0 && Z_SE == 0 && Z_NE >= 1)
-            contour.push_back(start_filled(quad, Edge_NW, 1, NotHole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_NW, 1, NotHole, Interior, lower_level, upper_level));
 
         // Upper-level start from E to NW, hole.
         if (!VISITED(quad,2) && Z_SW < 2 && Z_SE < 2 && Z_NE == 2)
-            contour.push_back(start_filled(quad, Edge_E, 2, Hole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_E, 2, Hole, Interior, lower_level, upper_level));
 
         // Upper-level start from NW to E.
         if (!VISITED(quad,2) && Z_SW == 2 && Z_SE == 2 && Z_NE < 2)
-            contour.push_back(start_filled(quad, Edge_NW, 2, NotHole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_NW, 2, NotHole, Interior, lower_level, upper_level));
 
         // Lower-level start from E to NW, hole.
         if (!VISITED(quad,1) && Z_SW >= 1 && Z_SE >= 1 && Z_NE == 0)
-            contour.push_back(start_filled(quad, Edge_E, 1, Hole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_E, 1, Hole, Interior, lower_level, upper_level));
     }
     // Possible starts from SW boundary.
     else if (EXISTS_NE_CORNER(quad)) {  // i.e. BOUNDARY_SW
 
         // Lower-level start from SW boundary into interior.
         if (!VISITED_CORNER(quad) && Z_NW >= 1 && Z_SE == 0)
-            contour.push_back(start_filled(quad, Edge_SW, 1, NotHole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_SW, 1, NotHole, Interior, lower_level, upper_level));
 
         // Upper-level start from SW boundary into interior.
         if (!VISITED_CORNER(quad) && Z_NW < 2 && Z_SE == 2)
-            contour.push_back(start_filled(quad, Edge_SW, 2, NotHole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_SW, 2, NotHole, Interior, lower_level, upper_level));
 
         // Lower-level start following SW boundary from NW to SE.
         if (!VISITED_CORNER(quad) && Z_NW <= 1 && Z_SE == 1)
-            contour.push_back(start_filled(quad, Edge_SW, 1, NotHole, Boundary,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_SW, 1, NotHole, Boundary, lower_level, upper_level));
 
         // Upper-level start following SW boundary from NW to SE.
         if (!VISITED_CORNER(quad) && Z_NW == 2 && Z_SE == 1)
-            contour.push_back(start_filled(quad, Edge_SW, 2, NotHole, Boundary,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_SW, 2, NotHole, Boundary, lower_level, upper_level));
     }
 
     // A full (unmasked) quad can only have a start on the NE corner, i.e. from
@@ -1719,26 +1645,26 @@ void Mpl2014ContourGenerator::single_quad_filled(
         // Lower-level start from N to E.
         if (!VISITED(quad,1) && Z_NW == 0 && Z_SE == 0 && Z_NE >= 1 &&
             (!SADDLE(quad,1) || SADDLE_LEFT(quad,1)))
-            contour.push_back(start_filled(quad, Edge_N, 1, NotHole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_N, 1, NotHole, Interior, lower_level, upper_level));
 
         // Upper-level start from E to N, hole.
         if (!VISITED(quad,2) && Z_NW < 2 && Z_SE <  2 && Z_NE == 2 &&
             (!SADDLE(quad,2) || !SADDLE_LEFT(quad,2)))
-            contour.push_back(start_filled(quad, Edge_E, 2, Hole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_E, 2, Hole, Interior, lower_level, upper_level));
 
         // Upper-level start from N to E.
         if (!VISITED(quad,2) && Z_NW == 2 && Z_SE == 2 && Z_NE < 2 &&
             (!SADDLE(quad,2) || SADDLE_LEFT(quad,2)))
-            contour.push_back(start_filled(quad, Edge_N, 2, NotHole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_N, 2, NotHole, Interior, lower_level, upper_level));
 
         // Lower-level start from E to N, hole.
         if (!VISITED(quad,1) && Z_NW >= 1 && Z_SE >= 1 && Z_NE == 0 &&
             (!SADDLE(quad,1) || !SADDLE_LEFT(quad,1)))
-            contour.push_back(start_filled(quad, Edge_E, 1, Hole, Interior,
-                                           lower_level, upper_level));
+            contour.push_back(start_filled(
+                quad, Edge_E, 1, Hole, Interior, lower_level, upper_level));
 
         // All possible contours passing through the interior of this quad
         // should have already been created, so assert this.
@@ -1753,18 +1679,13 @@ void Mpl2014ContourGenerator::single_quad_filled(
     // surrounding contour line.
     if (BOUNDARY_N(quad) && EXISTS_N_EDGE(quad) &&
         !VISITED_S(quad+_nx) && Z_NW == 1 && Z_NE == 1)
-        contour.push_back(start_filled(quad, Edge_N, 1, Hole, Boundary,
-                                       lower_level, upper_level));
+        contour.push_back(start_filled(
+            quad, Edge_N, 1, Hole, Boundary, lower_level, upper_level));
 }
 
 ContourLine* Mpl2014ContourGenerator::start_filled(
-    index_t quad,
-    Edge edge,
-    unsigned int start_level_index,
-    HoleOrNot hole_or_not,
-    BoundaryOrInterior boundary_or_interior,
-    const double& lower_level,
-    const double& upper_level)
+    index_t quad, Edge edge, unsigned int start_level_index, HoleOrNot hole_or_not,
+    BoundaryOrInterior boundary_or_interior, const double& lower_level, const double& upper_level)
 {
     assert(quad >= 0 && quad < _n && "Quad index out of bounds");
     assert(edge != Edge_None && "Invalid edge");
@@ -1790,13 +1711,13 @@ ContourLine* Mpl2014ContourGenerator::start_filled(
     while (true) {
         if (boundary_or_interior == Interior) {
             double level = (level_index == 1 ? lower_level : upper_level);
-            follow_interior(*contour_line, quad_edge, level_index, level,
-                            false, &start_quad_edge, start_level_index, true);
+            follow_interior(
+                *contour_line, quad_edge, level_index, level, false, &start_quad_edge,
+                start_level_index, true);
         }
         else {
             level_index = follow_boundary(
-                                *contour_line, quad_edge, lower_level,
-                                upper_level, level_index, start_quad_edge);
+                *contour_line, quad_edge, lower_level, upper_level, level_index, start_quad_edge);
         }
 
         if (quad_edge == start_quad_edge && (boundary_or_interior == Boundary ||
@@ -1813,21 +1734,15 @@ ContourLine* Mpl2014ContourGenerator::start_filled(
 }
 
 bool Mpl2014ContourGenerator::start_line(
-    py::list& vertices_list,
-    py::list& codes_list,
-    index_t quad,
-    Edge edge,
-    const double& level)
+    py::list& vertices_list, py::list& codes_list, index_t quad, Edge edge, const double& level)
 {
-    assert(is_edge_a_boundary(QuadEdge(quad, edge)) &&
-           "QuadEdge is not a boundary");
+    assert(is_edge_a_boundary(QuadEdge(quad, edge)) && "QuadEdge is not a boundary");
 
     QuadEdge quad_edge(quad, edge);
     ContourLine contour_line(false);
     follow_interior(contour_line, quad_edge, 1, level, true, 0, 1, false);
 
-    append_contour_line_to_vertices_and_codes(
-        contour_line, vertices_list, codes_list);
+    append_contour_line_to_vertices_and_codes(contour_line, vertices_list, codes_list);
 
     return VISITED(quad,1);
 }
@@ -1855,8 +1770,7 @@ void Mpl2014ContourGenerator::write_cache_quad(
 {
     index_t j = quad / _nx;
     index_t i = quad - j*_nx;
-    std::cout << quad << ": i=" << i << " j=" << j
-        << " EXISTS=" << EXISTS_QUAD(quad);
+    std::cout << quad << ": i=" << i << " j=" << j << " EXISTS=" << EXISTS_QUAD(quad);
     if (_corner_mask)
         std::cout << " CORNER=" << EXISTS_SW_CORNER(quad) << EXISTS_SE_CORNER(quad)
             << EXISTS_NW_CORNER(quad) << EXISTS_NE_CORNER(quad);

--- a/src/mpl2014.h
+++ b/src/mpl2014.h
@@ -177,8 +177,7 @@ struct QuadEdge
     bool operator<(const QuadEdge& other) const;
     bool operator==(const QuadEdge& other) const;
     bool operator!=(const QuadEdge& other) const;
-    friend std::ostream& operator<<(std::ostream& os,
-                                    const QuadEdge& quad_edge);
+    friend std::ostream& operator<<(std::ostream& os, const QuadEdge& quad_edge);
 
     index_t quad;
     Edge edge;
@@ -276,15 +275,10 @@ public:
     //     the x-direction is subdivided into.
     //   y_chunk_size: 0 for no chunking, or +ve integer for size of chunks that
     //     the y-direction is subdivided into.
-    Mpl2014ContourGenerator(const CoordinateArray& x,
-                            const CoordinateArray& y,
-                            const CoordinateArray& z,
-                            const MaskArray& mask,
-                            bool corner_mask,
-                            LineType line_type,
-                            FillType fill_type,
-                            index_t x_chunk_size,
-                            index_t y_chunk_size);
+    Mpl2014ContourGenerator(
+        const CoordinateArray& x, const CoordinateArray& y, const CoordinateArray& z,
+        const MaskArray& mask, bool corner_mask, LineType line_type, FillType fill_type,
+        index_t x_chunk_size, index_t y_chunk_size);
 
     // Destructor.
     ~Mpl2014ContourGenerator();
@@ -337,9 +331,8 @@ private:
     // contours where each ContourLine is converted to a separate numpy array
     // of (x,y) points and a second numpy array of 'kinds' or 'codes'.
     // Clears the ContourLine too.
-    void append_contour_line_to_vertices_and_codes(ContourLine& contour_line,
-                                                   py::list& vertices_list,
-                                                   py::list& codes_list) const;
+    void append_contour_line_to_vertices_and_codes(
+        ContourLine& contour_line, py::list& vertices_list, py::list& codes_list) const;
 
     // Append a C++ Contour to the end of two python lists.  Used for filled
     // contours where each non-hole ContourLine and its child holes are
@@ -348,17 +341,15 @@ private:
     // individual polygons.
     // Clears the Contour too, freeing each ContourLine as soon as possible
     // for minimum RAM usage.
-    void append_contour_to_vertices_and_codes(Contour& contour,
-                                              py::list& vertices_list,
-                                              py::list& codes_list) const;
+    void append_contour_to_vertices_and_codes(
+        Contour& contour, py::list& vertices_list, py::list& codes_list) const;
 
     // Return number of chunks that fit in the specified point_count.
     index_t calc_chunk_count(index_t point_count, index_t chunk_size) const;
 
     // Append the point on the specified QuadEdge that intersects the specified
     // level to the specified ContourLine.
-    void edge_interp(const QuadEdge& quad_edge, const double& level,
-                     ContourLine& contour_line);
+    void edge_interp(const QuadEdge& quad_edge, const double& level, ContourLine& contour_line);
 
     // Follow a contour along a boundary, appending points to the ContourLine
     // as it progresses.  Only called for filled contours.  Stops when the
@@ -377,12 +368,9 @@ private:
     //   start_quad_edge: QuadEdge that the ContourLine started from, which is
     //     used to check if the ContourLine is finished.
     // Returns the end level_index.
-    unsigned int follow_boundary(ContourLine& contour_line,
-                                 QuadEdge& quad_edge,
-                                 const double& lower_level,
-                                 const double& upper_level,
-                                 unsigned int level_index,
-                                 const QuadEdge& start_quad_edge);
+    unsigned int follow_boundary(
+        ContourLine& contour_line, QuadEdge& quad_edge, const double& lower_level,
+        const double& upper_level, unsigned int level_index, const QuadEdge& start_quad_edge);
 
     // Follow a contour across the interior of the domain, appending points to
     // the ContourLine as it progresses.  Called for both line and filled
@@ -403,23 +391,15 @@ private:
     //   start_level_index: the level_index that the ContourLine started from.
     //   set_parents: whether should set ParentCache as it progresses or not.
     //     This is true for filled contours, false for line contours.
-    void follow_interior(ContourLine& contour_line,
-                         QuadEdge& quad_edge,
-                         unsigned int level_index,
-                         const double& level,
-                         bool want_initial_point,
-                         const QuadEdge* start_quad_edge,
-                         unsigned int start_level_index,
-                         bool set_parents);
+    void follow_interior(
+        ContourLine& contour_line, QuadEdge& quad_edge, unsigned int level_index,
+        const double& level, bool want_initial_point, const QuadEdge* start_quad_edge,
+        unsigned int start_level_index, bool set_parents);
 
     // Return the index limits of a particular chunk.
-    void get_chunk_limits(index_t ijchunk,
-                          index_t& ichunk,
-                          index_t& jchunk,
-                          index_t& istart,
-                          index_t& iend,
-                          index_t& jstart,
-                          index_t& jend);
+    void get_chunk_limits(
+        index_t ijchunk, index_t& ichunk, index_t& jchunk, index_t& istart, index_t& iend,
+        index_t& jstart, index_t& jend);
 
     // Check if a contour starts within the specified corner quad on the
     // specified level_index, and if so return the start edge.  Otherwise
@@ -462,13 +442,12 @@ private:
     // Initialise the cache with information that is specific to contouring the
     // specified two levels.  The levels are the same for contour lines,
     // different for filled contours.
-    void init_cache_levels(const double& lower_level,
-                           const double& upper_level);
+    void init_cache_levels(const double& lower_level, const double& upper_level);
 
     // Append the (x,y) point at which the level intersects the line connecting
     // the two specified point indices to the specified ContourLine.
-    void interp(index_t point1, index_t point2, const double& level,
-                ContourLine& contour_line) const;
+    void interp(
+        index_t point1, index_t point2, const double& level, ContourLine& contour_line) const;
 
     // Return true if the specified QuadEdge is a boundary, i.e. is either an
     // edge between a masked and non-masked quad/corner or is a chunk boundary.
@@ -484,10 +463,8 @@ private:
 
     // Check for filled contours starting within the specified quad and
     // complete any that are found, appending them to the specified Contour.
-    void single_quad_filled(Contour& contour,
-                            index_t quad,
-                            const double& lower_level,
-                            const double& upper_level);
+    void single_quad_filled(
+        Contour& contour, index_t quad, const double& lower_level, const double& upper_level);
 
     // Start and complete a filled contour line.
     //   quad: index of quad to start ContourLine in.
@@ -499,13 +476,10 @@ private:
     //   lower_level: lower contour z-value.
     //   upper_level: upper contour z-value.
     // Returns newly created ContourLine.
-    ContourLine* start_filled(index_t quad,
-                              Edge edge,
-                              unsigned int start_level_index,
-                              HoleOrNot hole_or_not,
-                              BoundaryOrInterior boundary_or_interior,
-                              const double& lower_level,
-                              const double& upper_level);
+    ContourLine* start_filled(
+        index_t quad, Edge edge, unsigned int start_level_index, HoleOrNot hole_or_not,
+        BoundaryOrInterior boundary_or_interior, const double& lower_level,
+        const double& upper_level);
 
     // Start and complete a line contour that both starts and end on a
     // boundary, traversing the interior of the domain.
@@ -516,11 +490,9 @@ private:
     //   level: contour z-value.
     // Returns true if the start quad does not need to be visited again, i.e.
     // VISITED(quad,1).
-    bool start_line(py::list& vertices_list,
-                    py::list& codes_list,
-                    index_t quad,
-                    Edge edge,
-                    const double& level);
+    bool start_line(
+        py::list& vertices_list, py::list& codes_list, index_t quad, Edge edge,
+        const double& level);
 
     // Debug function that writes the cache status to stdout.
     void write_cache(bool grid_only = false) const;

--- a/src/mpl2014.h
+++ b/src/mpl2014.h
@@ -211,7 +211,7 @@ class ContourLine : public std::vector<XY>
 public:
     typedef std::list<ContourLine*> Children;
 
-    ContourLine(bool is_hole);
+    explicit ContourLine(bool is_hole);
     void add_child(ContourLine* child);
     void clear_parent();
     const Children& get_children() const;
@@ -279,6 +279,10 @@ public:
         const CoordinateArray& x, const CoordinateArray& y, const CoordinateArray& z,
         const MaskArray& mask, bool corner_mask, LineType line_type, FillType fill_type,
         index_t x_chunk_size, index_t y_chunk_size);
+
+    // Non-copyable.
+    Mpl2014ContourGenerator(const Mpl2014ContourGenerator& other) = delete;
+    const Mpl2014ContourGenerator& operator=(const Mpl2014ContourGenerator& other) = delete;
 
     // Destructor.
     ~Mpl2014ContourGenerator();

--- a/src/mpl2014.h
+++ b/src/mpl2014.h
@@ -293,6 +293,8 @@ public:
     py::tuple get_chunk_count() const;  // Return (y_chunk_count, x_chunk_count)
     py::tuple get_chunk_size() const;   // Return (y_chunk_size, x_chunk_size)
 
+    bool get_corner_mask() const;
+
     FillType get_fill_type() const;
     LineType get_line_type() const;
 

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -938,7 +938,7 @@ py::tuple SerialContourGenerator::get_chunk_size() const
 
 bool SerialContourGenerator::get_corner_mask() const
 {
-    return false;
+    return _corner_mask;
 }
 
 FillType SerialContourGenerator::get_fill_type() const

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -679,9 +679,8 @@ bool SerialContourGenerator::follow_interior(
     auto right_point = left_point - left;
     bool want_look_N = _identify_holes && pass > 0;
 
-    bool abort = false;     // Whether to about the loop.
     bool finished = false;  // Whether finished line, i.e. returned to start.
-    while (!abort) {
+    while (true) {
         assert(is_quad_in_chunk(quad, local));
         assert(is_point_in_chunk(left_point, local));
         assert(is_point_in_chunk(right_point, local));
@@ -1069,7 +1068,7 @@ void SerialContourGenerator::init_cache_grid(const MaskArray& mask)
     }
 }
 
-void SerialContourGenerator::init_cache_levels_and_starts(ChunkLocal& local)
+void SerialContourGenerator::init_cache_levels_and_starts(const ChunkLocal& local)
 {
     CacheItem keep_mask =
         (_corner_mask ? MASK_EXISTS_ANY | MASK_BOUNDARY_N | MASK_BOUNDARY_E

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -89,10 +89,9 @@
 
 
 SerialContourGenerator::SerialContourGenerator(
-    const CoordinateArray& x, const CoordinateArray& y,
-    const CoordinateArray& z, const MaskArray& mask, bool corner_mask,
-    LineType line_type, FillType fill_type, Interp interp, index_t x_chunk_size,
-    index_t y_chunk_size)
+    const CoordinateArray& x, const CoordinateArray& y, const CoordinateArray& z,
+    const MaskArray& mask, bool corner_mask, LineType line_type, FillType fill_type, Interp interp,
+    index_t x_chunk_size, index_t y_chunk_size)
     : _x(x),
       _y(y),
       _z(z),
@@ -175,8 +174,7 @@ SerialContourGenerator::ZLevel SerialContourGenerator::calc_z_level_mid(
 }
 
 void SerialContourGenerator::closed_line(
-    const Location& start_location, OuterOrHole outer_or_hole,
-    ChunkLocal& local)
+    const Location& start_location, OuterOrHole outer_or_hole, ChunkLocal& local)
 {
     assert(is_quad_in_chunk(start_location.quad, local));
 
@@ -189,11 +187,9 @@ void SerialContourGenerator::closed_line(
 
     while (!finished) {
         if (location.on_boundary)
-            finished = follow_boundary(
-                location, start_location, local, point_count);
+            finished = follow_boundary(location, start_location, local, point_count);
         else
-            finished = follow_interior(
-                location, start_location, local, point_count);
+            finished = follow_interior(location, start_location, local, point_count);
         location.on_boundary = !location.on_boundary;
     }
 
@@ -212,8 +208,7 @@ void SerialContourGenerator::closed_line(
 }
 
 void SerialContourGenerator::closed_line_wrapper(
-    const Location& start_location, OuterOrHole outer_or_hole,
-    ChunkLocal& local)
+    const Location& start_location, OuterOrHole outer_or_hole, ChunkLocal& local)
 {
     assert(is_quad_in_chunk(start_location.quad, local));
 
@@ -267,8 +262,7 @@ LineType SerialContourGenerator::default_line_type()
 }
 
 void SerialContourGenerator::export_filled(
-    ChunkLocal& local, const std::vector<double>& all_points,
-    std::vector<py::list>& return_lists)
+    ChunkLocal& local, const std::vector<double>& all_points, std::vector<py::list>& return_lists)
 {
     // all_points is only used for fill_types OuterCodes and OuterOffsets.
 
@@ -292,12 +286,10 @@ void SerialContourGenerator::export_filled(
                     if (_fill_type == FillType::OuterCodes)
                         return_lists[1].append(Converter::convert_codes(
                             point_count, outer_end - outer_start + 1,
-                            local.line_offsets.data() + outer_start,
-                            point_start));
+                            local.line_offsets.data() + outer_start, point_start));
                     else
                         return_lists[1].append(Converter::convert_offsets(
-                            outer_end - outer_start + 1,
-                            local.line_offsets.data() + outer_start,
+                            outer_end - outer_start + 1, local.line_offsets.data() + outer_start,
                             point_start));
                 }
             }
@@ -308,14 +300,12 @@ void SerialContourGenerator::export_filled(
                 // return_lists[0] already set.
                 assert(!local.line_offsets.empty());
                 return_lists[1][local.chunk] = Converter::convert_codes(
-                    local.total_point_count, local.line_offsets.size(),
-                    local.line_offsets.data());
+                    local.total_point_count, local.line_offsets.size(), local.line_offsets.data());
 
                 if (_fill_type == FillType::ChunkCombinedCodesOffsets)
                     return_lists[2][local.chunk] =
                         Converter::convert_offsets_nested(
-                            local.outer_offsets.size(),
-                            local.outer_offsets.data(),
+                            local.outer_offsets.size(), local.outer_offsets.data(),
                             local.line_offsets.data());
             }
             else {
@@ -344,8 +334,7 @@ void SerialContourGenerator::export_filled(
 }
 
 void SerialContourGenerator::export_lines(
-    ChunkLocal& local, const double* all_points_ptr,
-    std::vector<py::list>& return_lists)
+    ChunkLocal& local, const double* all_points_ptr, std::vector<py::list>& return_lists)
 {
     switch (_line_type)
     {
@@ -445,8 +434,7 @@ index_t SerialContourGenerator::find_look_S(index_t look_N_quad) const
 }
 
 bool SerialContourGenerator::follow_boundary(
-    Location& location, const Location& start_location, ChunkLocal& local,
-    size_t& point_count)
+    Location& location, const Location& start_location, ChunkLocal& local, size_t& point_count)
 {
     // forward values for boundaries:
     //     -1 = N boundary, E to W.
@@ -627,11 +615,9 @@ bool SerialContourGenerator::follow_boundary(
 }
 
 bool SerialContourGenerator::follow_interior(
-    Location& location, const Location& start_location, ChunkLocal& local,
-    size_t& point_count)
+    Location& location, const Location& start_location, ChunkLocal& local, size_t& point_count)
 {
-    // Adds the start point in each quad visited, but not the end point unless
-    // closing the polygon.
+    // Adds the start point in each quad visited, but not the end point unless closing the polygon.
     // Only need to consider a single level of course.
     assert(is_quad_in_chunk(start_location.quad, local));
     assert(is_quad_in_chunk(location.quad, local));
@@ -788,18 +774,17 @@ bool SerialContourGenerator::follow_interior(
         }
 
         // Clear unwanted start locations.
-        if (pass == 0 && !(quad == start_quad && forward == start_forward &&
-                           left == start_left)) {
-            if (START_E(quad) && forward == -1 && left == -_nx &&
-                turn_left == -1 && (is_upper ? Z_NE > 0 : Z_NE < 2)) {
+        if (pass == 0 && !(quad == start_quad && forward == start_forward && left == start_left)) {
+            if (START_E(quad) && forward == -1 && left == -_nx && turn_left == -1 &&
+                (is_upper ? Z_NE > 0 : Z_NE < 2)) {
                 _cache[quad] &= ~MASK_START_E;  // E high if is_upper else low.
 
                 if (!_filled && quad < start_location.quad)
                     // Already counted points from here onwards.
                     break;
             }
-            else if (START_N(quad) && forward == -_nx && left == 1 &&
-                     turn_left == 1 && (is_upper ? Z_NW > 0 : Z_NW < 2)) {
+            else if (START_N(quad) && forward == -_nx && left == 1 && turn_left == 1 &&
+                     (is_upper ? Z_NW > 0 : Z_NW < 2)) {
                 _cache[quad] &= ~MASK_START_N;  // E high if is_upper else low.
 
                 if (!_filled && quad < start_location.quad)
@@ -930,8 +915,7 @@ py::tuple SerialContourGenerator::get_chunk_count() const
     return py::make_tuple(_ny_chunks, _nx_chunks);
 }
 
-void SerialContourGenerator::get_chunk_limits(
-    index_t chunk, ChunkLocal& local) const
+void SerialContourGenerator::get_chunk_limits(index_t chunk, ChunkLocal& local) const
 {
     assert(chunk >= 0 && chunk < _n_chunks && "chunk index out of bounds");
 
@@ -967,8 +951,7 @@ LineType SerialContourGenerator::get_line_type() const
     return _line_type;
 }
 
-void SerialContourGenerator::get_point_xy(
-    index_t point, double*& points) const
+void SerialContourGenerator::get_point_xy(index_t point, double*& points) const
 {
     assert(point >= 0 && point < _n && "point index out of bounds");
     *points++ = _x.data()[point];
@@ -1075,12 +1058,10 @@ void SerialContourGenerator::init_cache_grid(const MaskArray& mask)
                     bool N_exists_quad = (j < _ny-1 && EXISTS_QUAD(quad+_nx));
                     bool exists = EXISTS_QUAD(quad);
 
-                    if (exists != E_exists_quad ||
-                        (i_chunk_boundary && exists && E_exists_quad))
+                    if (exists != E_exists_quad || (i_chunk_boundary && exists && E_exists_quad))
                         _cache[quad] |= MASK_BOUNDARY_E;
 
-                    if (exists != N_exists_quad ||
-                        (j_chunk_boundary && exists && N_exists_quad))
+                    if (exists != N_exists_quad || (j_chunk_boundary && exists && N_exists_quad))
                         _cache[quad] |= MASK_BOUNDARY_N;
                 }
             }
@@ -1131,35 +1112,31 @@ void SerialContourGenerator::init_cache_levels_and_starts(ChunkLocal& local)
                 if (_filled) {
                     if (EXISTS_N_AND_E_EDGES(quad)) {
                         if (z_nw == 0 && z_se == 0 && z_ne > 0 &&
-                            (EXISTS_NE_CORNER(quad) ||
-                             z_sw == 0 || SADDLE_Z_LEVEL(quad) == 0)) {
+                            (EXISTS_NE_CORNER(quad) || z_sw == 0 || SADDLE_Z_LEVEL(quad) == 0)) {
                             _cache[quad] |= MASK_START_N;  // N to E low.
                             start_in_row = true;
                         }
                         else if (z_nw == 2 && z_se == 2 && z_ne < 2 &&
-                                 (EXISTS_NE_CORNER(quad) ||
-                                  z_sw == 2 || SADDLE_Z_LEVEL(quad) == 2)) {
+                                 (EXISTS_NE_CORNER(quad) || z_sw == 2 ||
+                                  SADDLE_Z_LEVEL(quad) == 2)) {
                             _cache[quad] |= MASK_START_N;  // N to E high.
                             start_in_row = true;
                         }
 
                         if (z_ne == 0 && z_nw > 0 && z_se > 0 &&
-                            (EXISTS_NE_CORNER(quad) ||
-                             z_sw > 0 || SADDLE_Z_LEVEL(quad) > 0)) {
+                            (EXISTS_NE_CORNER(quad) || z_sw > 0 || SADDLE_Z_LEVEL(quad) > 0)) {
                             _cache[quad] |= MASK_START_E;  // E to N low.
                             start_in_row = true;
                         }
                         else if (z_ne == 2 && z_nw < 2 && z_se < 2 &&
-                                 (EXISTS_NE_CORNER(quad) ||
-                                  z_sw < 2 || SADDLE_Z_LEVEL(quad) < 2)) {
+                                 (EXISTS_NE_CORNER(quad) || z_sw < 2 || SADDLE_Z_LEVEL(quad) < 2)) {
                             _cache[quad] |= MASK_START_E;  // E to N high.
                             start_in_row = true;
                         }
                     }
 
                     if (BOUNDARY_S(quad) &&
-                        ((z_sw == 2 && z_se < 2) || (z_sw == 0 && z_se > 0) ||
-                         z_sw == 1)) {
+                        ((z_sw == 2 && z_se < 2) || (z_sw == 0 && z_se > 0) || z_sw == 1)) {
                         _cache[quad] |= MASK_START_BOUNDARY_S;
                         start_in_row = true;
                     }
@@ -1173,25 +1150,21 @@ void SerialContourGenerator::init_cache_levels_and_starts(ChunkLocal& local)
 
                     if (EXISTS_ANY_CORNER(quad)) {
                         if (EXISTS_NE_CORNER(quad) &&
-                            ((z_nw == 2 && z_se < 2) ||
-                             (z_nw == 0 && z_se > 0) || z_nw == 1)) {
+                            ((z_nw == 2 && z_se < 2) || (z_nw == 0 && z_se > 0) || z_nw == 1)) {
                             _cache[quad] |= MASK_START_CORNER;
                             start_in_row = true;
                         }
                         else if (EXISTS_NW_CORNER(quad) &&
-                                 ((z_sw == 2 && z_ne < 2) ||
-                                  (z_sw == 0 && z_ne > 0))) {
+                                 ((z_sw == 2 && z_ne < 2) || (z_sw == 0 && z_ne > 0))) {
                             _cache[quad] |= MASK_START_CORNER;
                             start_in_row = true;
                         }
-                        else if (EXISTS_SE_CORNER(quad) &&
-                                 ((z_sw == 0 && z_se == 0 && z_ne > 0) ||
-                                  (z_sw == 2 && z_se == 2 && z_ne < 2))) {
+                        else if (EXISTS_SE_CORNER(quad) && ((z_sw == 0 && z_se == 0 && z_ne > 0) ||
+                                                            (z_sw == 2 && z_se == 2 && z_ne < 2))) {
                             _cache[quad] |= MASK_START_CORNER;
                             start_in_row = true;
                         }
-                        else if (EXISTS_SW_CORNER(quad) &&
-                                 z_nw == 1 && z_se == 1) {
+                        else if (EXISTS_SW_CORNER(quad) && z_nw == 1 && z_se == 1) {
                             _cache[quad] |= MASK_START_CORNER;
                             start_in_row = true;
                         }
@@ -1200,9 +1173,8 @@ void SerialContourGenerator::init_cache_levels_and_starts(ChunkLocal& local)
                     // Start following N boundary from E to W which is a hole.
                     // Required for an internal masked region which is a hole in
                     // a filled polygon.
-                    if (BOUNDARY_N(quad) && EXISTS_N_EDGE(quad) &&
-                        z_nw == 1 && z_ne == 1 && !START_HOLE_N(quad-1) &&
-                        j % _y_chunk_size != 0 && j != _ny-1) {
+                    if (BOUNDARY_N(quad) && EXISTS_N_EDGE(quad) && z_nw == 1 && z_ne == 1 &&
+                        !START_HOLE_N(quad-1) && j % _y_chunk_size != 0 && j != _ny-1) {
                         _cache[quad] |= MASK_START_HOLE_N;
                         start_in_row = true;
                     }
@@ -1228,11 +1200,9 @@ void SerialContourGenerator::init_cache_levels_and_starts(ChunkLocal& local)
                         start_in_row = true;
                     }
 
-                    if (EXISTS_N_AND_E_EDGES(quad) &&
-                        !BOUNDARY_N(quad) && !BOUNDARY_E(quad)) {
+                    if (EXISTS_N_AND_E_EDGES(quad) && !BOUNDARY_N(quad) && !BOUNDARY_E(quad)) {
                         if (z_ne == 0 && z_nw > 0 && z_se > 0 &&
-                            (EXISTS_NE_CORNER(quad) || z_sw > 0 ||
-                             SADDLE_Z_LEVEL(quad) > 0)) {
+                            (EXISTS_NE_CORNER(quad) || z_sw > 0 || SADDLE_Z_LEVEL(quad) > 0)) {
                             _cache[quad] |= MASK_START_E;  // E to N low.
                             start_in_row = true;
                         }
@@ -1304,36 +1274,29 @@ void SerialContourGenerator::interp(
 
     assert(frac >= 0.0 && frac <= 1.0 && "Interp fraction out of bounds");
 
-    *local.points++ =
-        get_point_x(point0)*frac + get_point_x(point1)*(1.0 - frac);
-    *local.points++ =
-        get_point_y(point0)*frac + get_point_y(point1)*(1.0 - frac);
+    *local.points++ = get_point_x(point0)*frac + get_point_x(point1)*(1.0 - frac);
+    *local.points++ = get_point_y(point0)*frac + get_point_y(point1)*(1.0 - frac);
 }
 
-bool SerialContourGenerator::is_point_in_chunk(
-    index_t point, const ChunkLocal& local) const
+bool SerialContourGenerator::is_point_in_chunk(index_t point, const ChunkLocal& local) const
 {
     return is_quad_in_bounds(
         point, local.istart-1, local.iend, local.jstart-1, local.jend);
 }
 
 bool SerialContourGenerator::is_quad_in_bounds(
-    index_t quad, index_t istart, index_t iend, index_t jstart,
-    index_t jend) const
+    index_t quad, index_t istart, index_t iend, index_t jstart, index_t jend) const
 {
     return (quad % _nx >= istart && quad % _nx <= iend &&
             quad / _nx >= jstart && quad / _nx <= jend);
 }
 
-bool SerialContourGenerator::is_quad_in_chunk(
-    index_t quad, const ChunkLocal& local) const
+bool SerialContourGenerator::is_quad_in_chunk(index_t quad, const ChunkLocal& local) const
 {
-    return is_quad_in_bounds(
-        quad, local.istart, local.iend, local.jstart, local.jend);
+    return is_quad_in_bounds(quad, local.istart, local.iend, local.jstart, local.jend);
 }
 
-void SerialContourGenerator::line(
-    const Location& start_location, ChunkLocal& local)
+void SerialContourGenerator::line(const Location& start_location, ChunkLocal& local)
 {
     // start_location.on_boundary indicates starts (and therefore also finishes)
 
@@ -1343,8 +1306,7 @@ void SerialContourGenerator::line(
     size_t point_count = 0;
 
     // finished == true indicates closed line loop.
-    bool finished = follow_interior(
-        location, start_location, local, point_count);
+    bool finished = follow_interior(location, start_location, local, point_count);
 
     if (local.pass > 0)
         local.line_offsets[local.line_count] = local.total_point_count;
@@ -1374,10 +1336,8 @@ py::sequence SerialContourGenerator::lines(const double& level)
 py::sequence SerialContourGenerator::march()
 {
     index_t list_len = _n_chunks;
-    if ((_filled && (_fill_type == FillType::OuterCodes ||
-                     _fill_type == FillType::OuterOffsets)) ||
-        (!_filled && (_line_type == LineType::Separate ||
-                      _line_type == LineType::SeparateCodes)))
+    if ((_filled && (_fill_type == FillType::OuterCodes || _fill_type == FillType::OuterOffsets)) ||
+        (!_filled && (_line_type == LineType::Separate || _line_type == LineType::SeparateCodes)))
         list_len = 0;
 
     // Prepare lists to return to python.
@@ -1439,8 +1399,7 @@ void SerialContourGenerator::march_chunk_filled(
             // Want to count number of starts in this row, so store how many
             // starts at start of row.
             size_t prev_start_count =
-                (_identify_holes ? local.line_count - local.hole_count
-                                 : local.line_count);
+                (_identify_holes ? local.line_count - local.hole_count : local.line_count);
 
             for (index_t i = local.istart; i <= local.iend; ++i, ++quad) {
                 if (!ANY_START_FILLED(quad))
@@ -1506,8 +1465,7 @@ void SerialContourGenerator::march_chunk_filled(
 
             // Number of starts at end of row.
             size_t start_count =
-                (_identify_holes ? local.line_count - local.hole_count
-                                 : local.line_count);
+                (_identify_holes ? local.line_count - local.hole_count : local.line_count);
             if (start_count - prev_start_count)
                 j_final_start = j;
             else
@@ -1518,8 +1476,7 @@ void SerialContourGenerator::march_chunk_filled(
             _cache[local.istart + (j_final_start+1)*_nx] |= MASK_NO_MORE_STARTS;
 
         if (local.pass == 0) {
-            if (_fill_type == FillType::OuterCodes ||
-                _fill_type == FillType::OuterOffsets) {
+            if (_fill_type == FillType::OuterCodes || _fill_type == FillType::OuterOffsets) {
                 all_points.resize(2*local.total_point_count);
 
                 // Where to store contour points.
@@ -1558,8 +1515,7 @@ void SerialContourGenerator::march_chunk_filled(
     assert(local.line_offsets.back() == local.total_point_count);
 
     if (_identify_holes) {
-        assert(local.outer_offsets.size() ==
-               local.line_count - local.hole_count + 1);
+        assert(local.outer_offsets.size() == local.line_count - local.hole_count + 1);
         assert(local.outer_offsets.back() == local.line_count);
     }
     else {
@@ -1661,8 +1617,7 @@ void SerialContourGenerator::march_chunk_lines(
             _cache[local.istart + (j_final_start+1)*_nx] |= MASK_NO_MORE_STARTS;
 
         if (local.pass == 0) {
-            if (_line_type == LineType::Separate ||
-                _line_type == LineType::SeparateCodes) {
+            if (_line_type == LineType::Separate || _line_type == LineType::SeparateCodes) {
                 all_points.resize(2*local.total_point_count);
 
                 // Where to store contour points.
@@ -1867,11 +1822,9 @@ void SerialContourGenerator::set_look_flags(index_t hole_start_quad)
 
     while (true) {
         assert(quad >= 0 && quad < _n);
-        assert(EXISTS_N_EDGE(quad) ||
-               (quad == hole_start_quad && EXISTS_SW_CORNER(quad)));
+        assert(EXISTS_N_EDGE(quad) || (quad == hole_start_quad && EXISTS_SW_CORNER(quad)));
 
-        if (BOUNDARY_S(quad) || EXISTS_NE_CORNER(quad) ||
-            EXISTS_NW_CORNER(quad) || Z_SE != 1) {
+        if (BOUNDARY_S(quad) || EXISTS_NE_CORNER(quad) || EXISTS_NW_CORNER(quad) || Z_SE != 1) {
             assert(!LOOK_N(quad) && "Look N already set");
             _cache[quad] |= MASK_LOOK_N;
             break;

--- a/src/serial.h
+++ b/src/serial.h
@@ -19,6 +19,10 @@ public:
         const MaskArray& mask, bool corner_mask, LineType line_type, FillType fill_type,
         Interp interp, index_t x_chunk_size, index_t y_chunk_size);
 
+    // Non-copyable.
+    SerialContourGenerator(const SerialContourGenerator& other) = delete;
+    const SerialContourGenerator& operator=(const SerialContourGenerator& other) = delete;
+
     ~SerialContourGenerator();
 
     static FillType default_fill_type();
@@ -100,7 +104,7 @@ private:
 
     void init_cache_grid(const MaskArray& mask);
 
-    void init_cache_levels_and_starts(ChunkLocal& local);
+    void init_cache_levels_and_starts(const ChunkLocal& local);
 
     // Increments local.points twice.
     void interp(index_t point0, index_t point1, bool is_upper, ChunkLocal& local) const;

--- a/src/serial.h
+++ b/src/serial.h
@@ -15,10 +15,9 @@ class SerialContourGenerator
 {
 public:
     SerialContourGenerator(
-        const CoordinateArray& x, const CoordinateArray& y,
-        const CoordinateArray& z, const MaskArray& mask, bool corner_mask,
-        LineType line_type, FillType fill_type, Interp interp,
-        index_t x_chunk_size, index_t y_chunk_size);
+        const CoordinateArray& x, const CoordinateArray& y, const CoordinateArray& z,
+        const MaskArray& mask, bool corner_mask, LineType line_type, FillType fill_type,
+        Interp interp, index_t x_chunk_size, index_t y_chunk_size);
 
     ~SerialContourGenerator();
 
@@ -47,18 +46,16 @@ private:
 
     struct Location
     {
-        Location(index_t quad_, index_t forward_, index_t left_, bool is_upper_,
-                 bool on_boundary_)
+        Location(index_t quad_, index_t forward_, index_t left_, bool is_upper_, bool on_boundary_)
             : quad(quad_), forward(forward_), left(left_), is_upper(is_upper_),
               on_boundary(on_boundary_)
         {}
 
-        friend std::ostream &operator<<(
-            std::ostream &os, const Location& location)
+        friend std::ostream &operator<<(std::ostream &os, const Location& location)
         {
-            os << "quad=" << location.quad << " forward=" << location.forward
-                << " left=" << location.left << " is_upper="
-                << location.is_upper << " on_boundary=" << location.on_boundary;
+            os << "quad=" << location.quad << " forward=" << location.forward << " left="
+                << location.left << " is_upper=" << location.is_upper << " on_boundary="
+                << location.on_boundary;
             return os;
         }
 
@@ -68,13 +65,10 @@ private:
 
     ZLevel calc_z_level_mid(index_t quad);
 
-    void closed_line(
-        const Location& start_location, OuterOrHole outer_or_hole,
-        ChunkLocal& local);
+    void closed_line(const Location& start_location, OuterOrHole outer_or_hole, ChunkLocal& local);
 
     void closed_line_wrapper(
-        const Location& start_location, OuterOrHole outer_or_hole,
-        ChunkLocal& local);
+        const Location& start_location, OuterOrHole outer_or_hole, ChunkLocal& local);
 
     // Write points and offsets/codes to output numpy arrays.
     void export_filled(
@@ -82,20 +76,17 @@ private:
         std::vector<py::list>& return_lists);
 
     void export_lines(
-        ChunkLocal& local, const double* all_points_ptr,
-        std::vector<py::list>& return_lists);
+        ChunkLocal& local, const double* all_points_ptr, std::vector<py::list>& return_lists);
 
     index_t find_look_S(index_t look_N_quad) const;
 
     // Return true if finished (i.e. back to start quad, direction and upper).
     bool follow_boundary(
-        Location& location, const Location& start_location, ChunkLocal& local,
-        size_t& point_count);
+        Location& location, const Location& start_location, ChunkLocal& local, size_t& point_count);
 
     // Return true if finished (i.e. back to start quad, direction and upper).
     bool follow_interior(
-        Location& location, const Location& start_location, ChunkLocal& local,
-        size_t& point_count);
+        Location& location, const Location& start_location, ChunkLocal& local, size_t& point_count);
 
     // These are quad chunk limits, not point chunk limits.
     // chunk is index in range 0.._n_chunks-1.
@@ -112,14 +103,12 @@ private:
     void init_cache_levels_and_starts(ChunkLocal& local);
 
     // Increments local.points twice.
-    void interp(
-        index_t point0, index_t point1, bool is_upper, ChunkLocal& local) const;
+    void interp(index_t point0, index_t point1, bool is_upper, ChunkLocal& local) const;
 
     bool is_point_in_chunk(index_t point, const ChunkLocal& local) const;
 
     bool is_quad_in_bounds(
-        index_t quad, index_t istart, index_t iend, index_t jstart,
-        index_t jend) const;
+        index_t quad, index_t istart, index_t iend, index_t jstart, index_t jend) const;
 
     bool is_quad_in_chunk(index_t quad, const ChunkLocal& local) const;
 
@@ -127,14 +116,11 @@ private:
 
     py::sequence march();
 
-    void march_chunk_filled(
-        ChunkLocal& local, std::vector<py::list>& return_lists);
+    void march_chunk_filled(ChunkLocal& local, std::vector<py::list>& return_lists);
 
-    void march_chunk_lines(
-        ChunkLocal& local, std::vector<py::list>& return_lists);
+    void march_chunk_lines(ChunkLocal& local, std::vector<py::list>& return_lists);
 
-    void move_to_next_boundary_edge(
-        index_t& quad, index_t& forward, index_t& left) const;
+    void move_to_next_boundary_edge(index_t& quad, index_t& forward, index_t& left) const;
 
     void set_look_flags(index_t hole_start_quad);
 

--- a/src/threaded.cpp
+++ b/src/threaded.cpp
@@ -91,10 +91,9 @@
 
 
 ThreadedContourGenerator::ThreadedContourGenerator(
-    const CoordinateArray& x, const CoordinateArray& y,
-    const CoordinateArray& z, const MaskArray& mask, bool corner_mask,
-    LineType line_type, FillType fill_type, Interp interp, index_t x_chunk_size,
-    index_t y_chunk_size, index_t n_threads)
+    const CoordinateArray& x, const CoordinateArray& y, const CoordinateArray& z,
+    const MaskArray& mask, bool corner_mask, LineType line_type, FillType fill_type, Interp interp,
+    index_t x_chunk_size, index_t y_chunk_size, index_t n_threads)
     : _x(x),
       _y(y),
       _z(z),
@@ -161,8 +160,7 @@ ThreadedContourGenerator::ZLevel ThreadedContourGenerator::calc_z_level(
     return (_filled && z_value > _upper_level) ? 2 : (z_value > _lower_level ? 1 : 0);
 }
 
-ThreadedContourGenerator::ZLevel ThreadedContourGenerator::calc_z_level_mid(
-    index_t quad)
+ThreadedContourGenerator::ZLevel ThreadedContourGenerator::calc_z_level_mid(index_t quad)
 {
     assert(quad >= 0 && quad < _n);
 
@@ -185,8 +183,7 @@ ThreadedContourGenerator::ZLevel ThreadedContourGenerator::calc_z_level_mid(
 }
 
 void ThreadedContourGenerator::closed_line(
-    const Location& start_location, OuterOrHole outer_or_hole,
-    ChunkLocal& local)
+    const Location& start_location, OuterOrHole outer_or_hole, ChunkLocal& local)
 {
     assert(is_quad_in_chunk(start_location.quad, local));
 
@@ -199,11 +196,9 @@ void ThreadedContourGenerator::closed_line(
 
     while (!finished) {
         if (location.on_boundary)
-            finished = follow_boundary(
-                location, start_location, local, point_count);
+            finished = follow_boundary(location, start_location, local, point_count);
         else
-            finished = follow_interior(
-                location, start_location, local, point_count);
+            finished = follow_interior(location, start_location, local, point_count);
         location.on_boundary = !location.on_boundary;
     }
 
@@ -222,8 +217,7 @@ void ThreadedContourGenerator::closed_line(
 }
 
 void ThreadedContourGenerator::closed_line_wrapper(
-    const Location& start_location, OuterOrHole outer_or_hole,
-    ChunkLocal& local)
+    const Location& start_location, OuterOrHole outer_or_hole, ChunkLocal& local)
 {
     assert(is_quad_in_chunk(start_location.quad, local));
 
@@ -277,8 +271,7 @@ LineType ThreadedContourGenerator::default_line_type()
 }
 
 void ThreadedContourGenerator::export_filled(
-    ChunkLocal& local, const std::vector<double>& all_points,
-    std::vector<py::list>& return_lists)
+    ChunkLocal& local, const std::vector<double>& all_points, std::vector<py::list>& return_lists)
 {
     // all_points is only used for fill_types OuterCodes and OuterOffsets.
 
@@ -304,12 +297,10 @@ void ThreadedContourGenerator::export_filled(
                     if (_fill_type == FillType::OuterCodes)
                         return_lists[1].append(Converter::convert_codes(
                             point_count, outer_end - outer_start + 1,
-                            local.line_offsets.data() + outer_start,
-                            point_start));
+                            local.line_offsets.data() + outer_start, point_start));
                     else
                         return_lists[1].append(Converter::convert_offsets(
-                            outer_end - outer_start + 1,
-                            local.line_offsets.data() + outer_start,
+                            outer_end - outer_start + 1, local.line_offsets.data() + outer_start,
                             point_start));
                 }
             }
@@ -320,14 +311,12 @@ void ThreadedContourGenerator::export_filled(
                 // return_lists[0] already set.
                 assert(!local.line_offsets.empty());
                 return_lists[1][local.chunk] = Converter::convert_codes(
-                    local.total_point_count, local.line_offsets.size(),
-                    local.line_offsets.data());
+                    local.total_point_count, local.line_offsets.size(), local.line_offsets.data());
 
                 if (_fill_type == FillType::ChunkCombinedCodesOffsets)
                     return_lists[2][local.chunk] =
                         Converter::convert_offsets_nested(
-                            local.outer_offsets.size(),
-                            local.outer_offsets.data(),
+                            local.outer_offsets.size(), local.outer_offsets.data(),
                             local.line_offsets.data());
             }
             else {
@@ -356,8 +345,7 @@ void ThreadedContourGenerator::export_filled(
 }
 
 void ThreadedContourGenerator::export_lines(
-    ChunkLocal& local, const double* all_points_ptr,
-    std::vector<py::list>& return_lists)
+    ChunkLocal& local, const double* all_points_ptr, std::vector<py::list>& return_lists)
 {
     std::lock_guard<std::mutex> guard(_python_mutex);
 
@@ -415,8 +403,7 @@ void ThreadedContourGenerator::export_lines(
     }
 }
 
-py::sequence ThreadedContourGenerator::filled(
-    const double& lower_level, const double& upper_level)
+py::sequence ThreadedContourGenerator::filled(const double& lower_level, const double& upper_level)
 {
     if (lower_level > upper_level)
         throw std::invalid_argument("upper and lower levels are the wrong way round");
@@ -459,8 +446,7 @@ index_t ThreadedContourGenerator::find_look_S(index_t look_N_quad) const
 }
 
 bool ThreadedContourGenerator::follow_boundary(
-    Location& location, const Location& start_location, ChunkLocal& local,
-    size_t& point_count)
+    Location& location, const Location& start_location, ChunkLocal& local, size_t& point_count)
 {
     // forward values for boundaries:
     //     -1 = N boundary, E to W.
@@ -641,11 +627,9 @@ bool ThreadedContourGenerator::follow_boundary(
 }
 
 bool ThreadedContourGenerator::follow_interior(
-    Location& location, const Location& start_location, ChunkLocal& local,
-    size_t& point_count)
+    Location& location, const Location& start_location, ChunkLocal& local, size_t& point_count)
 {
-    // Adds the start point in each quad visited, but not the end point unless
-    // closing the polygon.
+    // Adds the start point in each quad visited, but not the end point unless closing the polygon.
     // Only need to consider a single level of course.
     assert(is_quad_in_chunk(start_location.quad, local));
     assert(is_quad_in_chunk(location.quad, local));
@@ -802,18 +786,17 @@ bool ThreadedContourGenerator::follow_interior(
         }
 
         // Clear unwanted start locations.
-        if (pass == 0 && !(quad == start_quad && forward == start_forward &&
-                           left == start_left)) {
-            if (START_E(quad) && forward == -1 && left == -_nx &&
-                turn_left == -1 && (is_upper ? Z_NE > 0 : Z_NE < 2)) {
+        if (pass == 0 && !(quad == start_quad && forward == start_forward && left == start_left)) {
+            if (START_E(quad) && forward == -1 && left == -_nx && turn_left == -1 &&
+                (is_upper ? Z_NE > 0 : Z_NE < 2)) {
                 _cache[quad] &= ~MASK_START_E;  // E high if is_upper else low.
 
                 if (!_filled && quad < start_location.quad)
                     // Already counted points from here onwards.
                     break;
             }
-            else if (START_N(quad) && forward == -_nx && left == 1 &&
-                     turn_left == 1 && (is_upper ? Z_NW > 0 : Z_NW < 2)) {
+            else if (START_N(quad) && forward == -_nx && left == 1 && turn_left == 1 &&
+                     (is_upper ? Z_NW > 0 : Z_NW < 2)) {
                 _cache[quad] &= ~MASK_START_N;  // E high if is_upper else low.
 
                 if (!_filled && quad < start_location.quad)
@@ -944,8 +927,7 @@ py::tuple ThreadedContourGenerator::get_chunk_count() const
     return py::make_tuple(_ny_chunks, _nx_chunks);
 }
 
-void ThreadedContourGenerator::get_chunk_limits(
-    index_t chunk, ChunkLocal& local) const
+void ThreadedContourGenerator::get_chunk_limits(index_t chunk, ChunkLocal& local) const
 {
     assert(chunk >= 0 && chunk < _n_chunks && "chunk index out of bounds");
 
@@ -986,8 +968,7 @@ index_t ThreadedContourGenerator::get_thread_count() const
     return _n_threads;
 }
 
-void ThreadedContourGenerator::get_point_xy(
-    index_t point, double*& points) const
+void ThreadedContourGenerator::get_point_xy(index_t point, double*& points) const
 {
     assert(point >= 0 && point < _n && "point index out of bounds");
     *points++ = _x.data()[point];
@@ -1094,12 +1075,10 @@ void ThreadedContourGenerator::init_cache_grid(const MaskArray& mask)
                     bool N_exists_quad = (j < _ny-1 && EXISTS_QUAD(quad+_nx));
                     bool exists = EXISTS_QUAD(quad);
 
-                    if (exists != E_exists_quad ||
-                        (i_chunk_boundary && exists && E_exists_quad))
+                    if (exists != E_exists_quad || (i_chunk_boundary && exists && E_exists_quad))
                         _cache[quad] |= MASK_BOUNDARY_E;
 
-                    if (exists != N_exists_quad ||
-                        (j_chunk_boundary && exists && N_exists_quad))
+                    if (exists != N_exists_quad || (j_chunk_boundary && exists && N_exists_quad))
                         _cache[quad] |= MASK_BOUNDARY_N;
                 }
             }
@@ -1163,35 +1142,31 @@ void ThreadedContourGenerator::init_cache_levels_and_starts(ChunkLocal& local)
                 if (_filled) {
                     if (EXISTS_N_AND_E_EDGES(quad)) {
                         if (z_nw == 0 && z_se == 0 && z_ne > 0 &&
-                            (EXISTS_NE_CORNER(quad) ||
-                             z_sw == 0 || SADDLE_Z_LEVEL(quad) == 0)) {
+                            (EXISTS_NE_CORNER(quad) || z_sw == 0 || SADDLE_Z_LEVEL(quad) == 0)) {
                             _cache[quad] |= MASK_START_N;  // N to E low.
                             start_in_row = true;
                         }
                         else if (z_nw == 2 && z_se == 2 && z_ne < 2 &&
-                                 (EXISTS_NE_CORNER(quad) ||
-                                  z_sw == 2 || SADDLE_Z_LEVEL(quad) == 2)) {
+                                 (EXISTS_NE_CORNER(quad) || z_sw == 2 ||
+                                  SADDLE_Z_LEVEL(quad) == 2)) {
                             _cache[quad] |= MASK_START_N;  // N to E high.
                             start_in_row = true;
                         }
 
                         if (z_ne == 0 && z_nw > 0 && z_se > 0 &&
-                            (EXISTS_NE_CORNER(quad) ||
-                             z_sw > 0 || SADDLE_Z_LEVEL(quad) > 0)) {
+                            (EXISTS_NE_CORNER(quad) || z_sw > 0 || SADDLE_Z_LEVEL(quad) > 0)) {
                             _cache[quad] |= MASK_START_E;  // E to N low.
                             start_in_row = true;
                         }
                         else if (z_ne == 2 && z_nw < 2 && z_se < 2 &&
-                                 (EXISTS_NE_CORNER(quad) ||
-                                  z_sw < 2 || SADDLE_Z_LEVEL(quad) < 2)) {
+                                 (EXISTS_NE_CORNER(quad) || z_sw < 2 || SADDLE_Z_LEVEL(quad) < 2)) {
                             _cache[quad] |= MASK_START_E;  // E to N high.
                             start_in_row = true;
                         }
                     }
 
                     if (BOUNDARY_S(quad) &&
-                        ((z_sw == 2 && z_se < 2) || (z_sw == 0 && z_se > 0) ||
-                         z_sw == 1)) {
+                        ((z_sw == 2 && z_se < 2) || (z_sw == 0 && z_se > 0) || z_sw == 1)) {
                         _cache[quad] |= MASK_START_BOUNDARY_S;
                         start_in_row = true;
                     }
@@ -1205,25 +1180,21 @@ void ThreadedContourGenerator::init_cache_levels_and_starts(ChunkLocal& local)
 
                     if (EXISTS_ANY_CORNER(quad)) {
                         if (EXISTS_NE_CORNER(quad) &&
-                            ((z_nw == 2 && z_se < 2) ||
-                             (z_nw == 0 && z_se > 0) || z_nw == 1)) {
+                            ((z_nw == 2 && z_se < 2) || (z_nw == 0 && z_se > 0) || z_nw == 1)) {
                             _cache[quad] |= MASK_START_CORNER;
                             start_in_row = true;
                         }
                         else if (EXISTS_NW_CORNER(quad) &&
-                                 ((z_sw == 2 && z_ne < 2) ||
-                                  (z_sw == 0 && z_ne > 0))) {
+                                 ((z_sw == 2 && z_ne < 2) || (z_sw == 0 && z_ne > 0))) {
                             _cache[quad] |= MASK_START_CORNER;
                             start_in_row = true;
                         }
-                        else if (EXISTS_SE_CORNER(quad) &&
-                                 ((z_sw == 0 && z_se == 0 && z_ne > 0) ||
-                                  (z_sw == 2 && z_se == 2 && z_ne < 2))) {
+                        else if (EXISTS_SE_CORNER(quad) && ((z_sw == 0 && z_se == 0 && z_ne > 0) ||
+                                                            (z_sw == 2 && z_se == 2 && z_ne < 2))) {
                             _cache[quad] |= MASK_START_CORNER;
                             start_in_row = true;
                         }
-                        else if (EXISTS_SW_CORNER(quad) &&
-                                 z_nw == 1 && z_se == 1) {
+                        else if (EXISTS_SW_CORNER(quad) && z_nw == 1 && z_se == 1) {
                             _cache[quad] |= MASK_START_CORNER;
                             start_in_row = true;
                         }
@@ -1232,9 +1203,8 @@ void ThreadedContourGenerator::init_cache_levels_and_starts(ChunkLocal& local)
                     // Start following N boundary from E to W which is a hole.
                     // Required for an internal masked region which is a hole in
                     // a filled polygon.
-                    if (BOUNDARY_N(quad) && EXISTS_N_EDGE(quad) &&
-                        z_nw == 1 && z_ne == 1 && !START_HOLE_N(quad-1) &&
-                        j % _y_chunk_size != 0 && j != _ny-1) {
+                    if (BOUNDARY_N(quad) && EXISTS_N_EDGE(quad) && z_nw == 1 && z_ne == 1 &&
+                        !START_HOLE_N(quad-1) && j % _y_chunk_size != 0 && j != _ny-1) {
                         _cache[quad] |= MASK_START_HOLE_N;
                         start_in_row = true;
                     }
@@ -1260,11 +1230,9 @@ void ThreadedContourGenerator::init_cache_levels_and_starts(ChunkLocal& local)
                         start_in_row = true;
                     }
 
-                    if (EXISTS_N_AND_E_EDGES(quad) &&
-                        !BOUNDARY_N(quad) && !BOUNDARY_E(quad)) {
+                    if (EXISTS_N_AND_E_EDGES(quad) && !BOUNDARY_N(quad) && !BOUNDARY_E(quad)) {
                         if (z_ne == 0 && z_nw > 0 && z_se > 0 &&
-                            (EXISTS_NE_CORNER(quad) || z_sw > 0 ||
-                             SADDLE_Z_LEVEL(quad) > 0)) {
+                            (EXISTS_NE_CORNER(quad) || z_sw > 0 || SADDLE_Z_LEVEL(quad) > 0)) {
                             _cache[quad] |= MASK_START_E;  // E to N low.
                             start_in_row = true;
                         }
@@ -1336,36 +1304,29 @@ void ThreadedContourGenerator::interp(
 
     assert(frac >= 0.0 && frac <= 1.0 && "Interp fraction out of bounds");
 
-    *local.points++ =
-        get_point_x(point0)*frac + get_point_x(point1)*(1.0 - frac);
-    *local.points++ =
-        get_point_y(point0)*frac + get_point_y(point1)*(1.0 - frac);
+    *local.points++ = get_point_x(point0)*frac + get_point_x(point1)*(1.0 - frac);
+    *local.points++ = get_point_y(point0)*frac + get_point_y(point1)*(1.0 - frac);
 }
 
-bool ThreadedContourGenerator::is_point_in_chunk(
-    index_t point, const ChunkLocal& local) const
+bool ThreadedContourGenerator::is_point_in_chunk(index_t point, const ChunkLocal& local) const
 {
     return is_quad_in_bounds(
         point, local.istart-1, local.iend, local.jstart-1, local.jend);
 }
 
 bool ThreadedContourGenerator::is_quad_in_bounds(
-    index_t quad, index_t istart, index_t iend, index_t jstart,
-    index_t jend) const
+    index_t quad, index_t istart, index_t iend, index_t jstart, index_t jend) const
 {
     return (quad % _nx >= istart && quad % _nx <= iend &&
             quad / _nx >= jstart && quad / _nx <= jend);
 }
 
-bool ThreadedContourGenerator::is_quad_in_chunk(
-    index_t quad, const ChunkLocal& local) const
+bool ThreadedContourGenerator::is_quad_in_chunk(index_t quad, const ChunkLocal& local) const
 {
-    return is_quad_in_bounds(
-        quad, local.istart, local.iend, local.jstart, local.jend);
+    return is_quad_in_bounds(quad, local.istart, local.iend, local.jstart, local.jend);
 }
 
-index_t ThreadedContourGenerator::limit_n_threads(
-    index_t n_threads, index_t n_chunks)
+index_t ThreadedContourGenerator::limit_n_threads(index_t n_threads, index_t n_chunks)
 {
     index_t max_threads = std::max<index_t>(Util::get_max_threads(), 1);
     if (n_threads == 0)
@@ -1374,8 +1335,7 @@ index_t ThreadedContourGenerator::limit_n_threads(
         return std::min({max_threads, n_chunks, n_threads});
 }
 
-void ThreadedContourGenerator::line(
-    const Location& start_location, ChunkLocal& local)
+void ThreadedContourGenerator::line(const Location& start_location, ChunkLocal& local)
 {
     // start_location.on_boundary indicates starts (and therefore also finishes)
 
@@ -1385,8 +1345,7 @@ void ThreadedContourGenerator::line(
     size_t point_count = 0;
 
     // finished == true indicates closed line loop.
-    bool finished = follow_interior(
-        location, start_location, local, point_count);
+    bool finished = follow_interior(location, start_location, local, point_count);
 
     if (local.pass > 0)
         local.line_offsets[local.line_count] = local.total_point_count;
@@ -1416,10 +1375,8 @@ py::sequence ThreadedContourGenerator::lines(const double& level)
 py::sequence ThreadedContourGenerator::march()
 {
     index_t list_len = _n_chunks;
-    if ((_filled && (_fill_type == FillType::OuterCodes ||
-                     _fill_type == FillType::OuterOffsets)) ||
-        (!_filled && (_line_type == LineType::Separate ||
-                      _line_type == LineType::SeparateCodes)))
+    if ((_filled && (_fill_type == FillType::OuterCodes || _fill_type == FillType::OuterOffsets)) ||
+        (!_filled && (_line_type == LineType::Separate || _line_type == LineType::SeparateCodes)))
         list_len = 0;
 
     // Prepare lists to return to python.
@@ -1444,8 +1401,7 @@ py::sequence ThreadedContourGenerator::march()
     threads.reserve(_n_threads);
     for (unsigned int i = 0; i < _n_threads-1; ++i)
         threads.emplace_back(
-            &ThreadedContourGenerator::thread_function, this,
-            std::ref(return_lists));
+            &ThreadedContourGenerator::thread_function, this, std::ref(return_lists));
 
     thread_function(std::ref(return_lists));  // Main thread work.
 
@@ -1491,8 +1447,7 @@ void ThreadedContourGenerator::march_chunk_filled(
             // Want to count number of starts in this row, so store how many
             // starts at start of row.
             size_t prev_start_count =
-                (_identify_holes ? local.line_count - local.hole_count
-                                 : local.line_count);
+                (_identify_holes ? local.line_count - local.hole_count : local.line_count);
 
             for (index_t i = local.istart; i <= local.iend; ++i, ++quad) {
                 if (!ANY_START_FILLED(quad))
@@ -1558,8 +1513,7 @@ void ThreadedContourGenerator::march_chunk_filled(
 
             // Number of starts at end of row.
             size_t start_count =
-                (_identify_holes ? local.line_count - local.hole_count
-                                 : local.line_count);
+                (_identify_holes ? local.line_count - local.hole_count : local.line_count);
             if (start_count - prev_start_count)
                 j_final_start = j;
             else
@@ -1570,8 +1524,7 @@ void ThreadedContourGenerator::march_chunk_filled(
             _cache[local.istart + (j_final_start+1)*_nx] |= MASK_NO_MORE_STARTS;
 
         if (local.pass == 0) {
-            if (_fill_type == FillType::OuterCodes ||
-                _fill_type == FillType::OuterOffsets) {
+            if (_fill_type == FillType::OuterCodes || _fill_type == FillType::OuterOffsets) {
                 all_points.resize(2*local.total_point_count);
 
                 // Where to store contour points.
@@ -1614,8 +1567,7 @@ void ThreadedContourGenerator::march_chunk_filled(
     assert(local.line_offsets.back() == local.total_point_count);
 
     if (_identify_holes) {
-        assert(local.outer_offsets.size() ==
-               local.line_count - local.hole_count + 1);
+        assert(local.outer_offsets.size() == local.line_count - local.hole_count + 1);
         assert(local.outer_offsets.back() == local.line_count);
     }
     else {
@@ -1717,8 +1669,7 @@ void ThreadedContourGenerator::march_chunk_lines(
             _cache[local.istart + (j_final_start+1)*_nx] |= MASK_NO_MORE_STARTS;
 
         if (local.pass == 0) {
-            if (_line_type == LineType::Separate ||
-                _line_type == LineType::SeparateCodes) {
+            if (_line_type == LineType::Separate || _line_type == LineType::SeparateCodes) {
                 all_points.resize(2*local.total_point_count);
 
                 // Where to store contour points.
@@ -1927,11 +1878,9 @@ void ThreadedContourGenerator::set_look_flags(index_t hole_start_quad)
 
     while (true) {
         assert(quad >= 0 && quad < _n);
-        assert(EXISTS_N_EDGE(quad) ||
-               (quad == hole_start_quad && EXISTS_SW_CORNER(quad)));
+        assert(EXISTS_N_EDGE(quad) || (quad == hole_start_quad && EXISTS_SW_CORNER(quad)));
 
-        if (BOUNDARY_S(quad) || EXISTS_NE_CORNER(quad) ||
-            EXISTS_NW_CORNER(quad) || Z_SE != 1) {
+        if (BOUNDARY_S(quad) || EXISTS_NE_CORNER(quad) || EXISTS_NW_CORNER(quad) || Z_SE != 1) {
             assert(!LOOK_N(quad) && "Look N already set");
             _cache[quad] |= MASK_LOOK_N;
             break;
@@ -1969,8 +1918,7 @@ bool ThreadedContourGenerator::supports_line_type(LineType line_type)
     }
 }
 
-void ThreadedContourGenerator::thread_function(
-    std::vector<py::list>& return_lists)
+void ThreadedContourGenerator::thread_function(std::vector<py::list>& return_lists)
 {
     // Function that is executed by each of the threads.
     // _next_chunk starts at zero and increases up to 2*_n_chunks.  A thread in

--- a/src/threaded.cpp
+++ b/src/threaded.cpp
@@ -691,9 +691,8 @@ bool ThreadedContourGenerator::follow_interior(
     auto right_point = left_point - left;
     bool want_look_N = _identify_holes && pass > 0;
 
-    bool abort = false;     // Whether to about the loop.
     bool finished = false;  // Whether finished line, i.e. returned to start.
-    while (!abort) {
+    while (true) {
         assert(is_quad_in_chunk(quad, local));
         assert(is_point_in_chunk(left_point, local));
         assert(is_point_in_chunk(right_point, local));
@@ -1086,7 +1085,7 @@ void ThreadedContourGenerator::init_cache_grid(const MaskArray& mask)
     }
 }
 
-void ThreadedContourGenerator::init_cache_levels_and_starts(ChunkLocal& local)
+void ThreadedContourGenerator::init_cache_levels_and_starts(const ChunkLocal& local)
 {
     CacheItem keep_mask =
         (_corner_mask ? MASK_EXISTS_ANY | MASK_BOUNDARY_N | MASK_BOUNDARY_E

--- a/src/threaded.cpp
+++ b/src/threaded.cpp
@@ -950,7 +950,7 @@ py::tuple ThreadedContourGenerator::get_chunk_size() const
 
 bool ThreadedContourGenerator::get_corner_mask() const
 {
-    return false;
+    return _corner_mask;
 }
 
 FillType ThreadedContourGenerator::get_fill_type() const

--- a/src/threaded.h
+++ b/src/threaded.h
@@ -21,6 +21,10 @@ public:
         const MaskArray& mask, bool corner_mask, LineType line_type, FillType fill_type,
         Interp interp, index_t x_chunk_size, index_t y_chunk_size, index_t n_threads);
 
+    // Non-copyable.
+    ThreadedContourGenerator(const ThreadedContourGenerator& other) = delete;
+    const ThreadedContourGenerator& operator=(const ThreadedContourGenerator& other) = delete;
+
     ~ThreadedContourGenerator();
 
     static FillType default_fill_type();
@@ -107,7 +111,7 @@ private:
 
     void init_cache_grid(const MaskArray& mask);
 
-    void init_cache_levels_and_starts(ChunkLocal& local);
+    void init_cache_levels_and_starts(const ChunkLocal& local);
 
     // Increments local.points twice.
     void interp(index_t point0, index_t point1, bool is_upper, ChunkLocal& local) const;

--- a/src/threaded.h
+++ b/src/threaded.h
@@ -17,10 +17,9 @@ class ThreadedContourGenerator
 {
 public:
     ThreadedContourGenerator(
-        const CoordinateArray& x, const CoordinateArray& y,
-        const CoordinateArray& z, const MaskArray& mask, bool corner_mask,
-        LineType line_type, FillType fill_type, Interp interp,
-        index_t x_chunk_size, index_t y_chunk_size, index_t n_threads);
+        const CoordinateArray& x, const CoordinateArray& y, const CoordinateArray& z,
+        const MaskArray& mask, bool corner_mask, LineType line_type, FillType fill_type,
+        Interp interp, index_t x_chunk_size, index_t y_chunk_size, index_t n_threads);
 
     ~ThreadedContourGenerator();
 
@@ -51,8 +50,7 @@ private:
 
     struct Location
     {
-        Location(index_t quad_, index_t forward_, index_t left_, bool is_upper_,
-                 bool on_boundary_)
+        Location(index_t quad_, index_t forward_, index_t left_, bool is_upper_, bool on_boundary_)
             : quad(quad_), forward(forward_), left(left_), is_upper(is_upper_),
               on_boundary(on_boundary_)
         {}
@@ -60,9 +58,9 @@ private:
         friend std::ostream &operator<<(
             std::ostream &os, const Location& location)
         {
-            os << "quad=" << location.quad << " forward=" << location.forward
-                << " left=" << location.left << " is_upper="
-                << location.is_upper << " on_boundary=" << location.on_boundary;
+            os << "quad=" << location.quad << " forward=" << location.forward << " left="
+                << location.left << " is_upper=" << location.is_upper << " on_boundary="
+                << location.on_boundary;
             return os;
         }
 
@@ -74,13 +72,10 @@ private:
 
     ZLevel calc_z_level_mid(index_t quad);
 
-    void closed_line(
-        const Location& start_location, OuterOrHole outer_or_hole,
-        ChunkLocal& local);
+    void closed_line(const Location& start_location, OuterOrHole outer_or_hole, ChunkLocal& local);
 
     void closed_line_wrapper(
-        const Location& start_location, OuterOrHole outer_or_hole,
-        ChunkLocal& local);
+        const Location& start_location, OuterOrHole outer_or_hole, ChunkLocal& local);
 
     // Write points and offsets/codes to output numpy arrays.
     void export_filled(
@@ -88,20 +83,17 @@ private:
         std::vector<py::list>& return_lists);
 
     void export_lines(
-        ChunkLocal& local, const double* all_points_ptr,
-        std::vector<py::list>& return_lists);
+        ChunkLocal& local, const double* all_points_ptr, std::vector<py::list>& return_lists);
 
     index_t find_look_S(index_t look_N_quad) const;
 
     // Return true if finished (i.e. back to start quad, direction and upper).
     bool follow_boundary(
-        Location& location, const Location& start_location, ChunkLocal& local,
-        size_t& point_count);
+        Location& location, const Location& start_location, ChunkLocal& local, size_t& point_count);
 
     // Return true if finished (i.e. back to start quad, direction and upper).
     bool follow_interior(
-        Location& location, const Location& start_location, ChunkLocal& local,
-        size_t& point_count);
+        Location& location, const Location& start_location, ChunkLocal& local, size_t& point_count);
 
     // These are quad chunk limits, not point chunk limits.
     // chunk is index in range 0.._n_chunks-1.
@@ -118,14 +110,12 @@ private:
     void init_cache_levels_and_starts(ChunkLocal& local);
 
     // Increments local.points twice.
-    void interp(
-        index_t point0, index_t point1, bool is_upper, ChunkLocal& local) const;
+    void interp(index_t point0, index_t point1, bool is_upper, ChunkLocal& local) const;
 
     bool is_point_in_chunk(index_t point, const ChunkLocal& local) const;
 
     bool is_quad_in_bounds(
-        index_t quad, index_t istart, index_t iend, index_t jstart,
-        index_t jend) const;
+        index_t quad, index_t istart, index_t iend, index_t jstart, index_t jend) const;
 
     bool is_quad_in_chunk(index_t quad, const ChunkLocal& local) const;
 
@@ -135,14 +125,11 @@ private:
 
     py::sequence march();
 
-    void march_chunk_filled(
-        ChunkLocal& local, std::vector<py::list>& return_lists);
+    void march_chunk_filled(ChunkLocal& local, std::vector<py::list>& return_lists);
 
-    void march_chunk_lines(
-        ChunkLocal& local, std::vector<py::list>& return_lists);
+    void march_chunk_lines(ChunkLocal& local, std::vector<py::list>& return_lists);
 
-    void move_to_next_boundary_edge(
-        index_t& quad, index_t& forward, index_t& left) const;
+    void move_to_next_boundary_edge(index_t& quad, index_t& forward, index_t& left) const;
 
     void set_look_flags(index_t hole_start_quad);
 

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -57,6 +57,7 @@ PYBIND11_MODULE(_contourpy, m) {
         .def("lines", &mpl2014::Mpl2014ContourGenerator::lines)
         .def_property_readonly("chunk_count", &mpl2014::Mpl2014ContourGenerator::get_chunk_count)
         .def_property_readonly("chunk_size", &mpl2014::Mpl2014ContourGenerator::get_chunk_size)
+        .def_property_readonly("corner_mask", &mpl2014::Mpl2014ContourGenerator::get_corner_mask)
         .def_property_readonly_static(
             "default_fill_type",
             [](py::object /* self */) {
@@ -102,6 +103,7 @@ PYBIND11_MODULE(_contourpy, m) {
         .def("write_cache", &SerialContourGenerator::write_cache)
         .def_property_readonly("chunk_count", &SerialContourGenerator::get_chunk_count)
         .def_property_readonly("chunk_size", &SerialContourGenerator::get_chunk_size)
+        .def_property_readonly("corner_mask", &SerialContourGenerator::get_corner_mask)
         .def_property_readonly_static(
             "default_fill_type",
             [](py::object /* self */) {
@@ -149,6 +151,7 @@ PYBIND11_MODULE(_contourpy, m) {
         .def("write_cache", &ThreadedContourGenerator::write_cache)
         .def_property_readonly("chunk_count", &ThreadedContourGenerator::get_chunk_count)
         .def_property_readonly("chunk_size", &ThreadedContourGenerator::get_chunk_size)
+        .def_property_readonly("corner_mask", &ThreadedContourGenerator::get_corner_mask)
         .def_property_readonly_static(
             "default_fill_type",
             [](py::object /* self */) {

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -55,10 +55,8 @@ PYBIND11_MODULE(_contourpy, m) {
              py::arg("y_chunk_size") = 0)
         .def("filled", &mpl2014::Mpl2014ContourGenerator::filled)
         .def("lines", &mpl2014::Mpl2014ContourGenerator::lines)
-        .def_property_readonly(
-            "chunk_count", &mpl2014::Mpl2014ContourGenerator::get_chunk_count)
-        .def_property_readonly(
-            "chunk_size", &mpl2014::Mpl2014ContourGenerator::get_chunk_size)
+        .def_property_readonly("chunk_count", &mpl2014::Mpl2014ContourGenerator::get_chunk_count)
+        .def_property_readonly("chunk_size", &mpl2014::Mpl2014ContourGenerator::get_chunk_size)
         .def_property_readonly_static(
             "default_fill_type",
             [](py::object /* self */) {
@@ -69,18 +67,12 @@ PYBIND11_MODULE(_contourpy, m) {
             [](py::object /* self */) {
                 return mpl2014::Mpl2014ContourGenerator::default_line_type();
             })
-        .def_property_readonly(
-            "fill_type", &mpl2014::Mpl2014ContourGenerator::get_fill_type)
-        .def_property_readonly(
-            "line_type", &mpl2014::Mpl2014ContourGenerator::get_line_type)
+        .def_property_readonly("fill_type", &mpl2014::Mpl2014ContourGenerator::get_fill_type)
+        .def_property_readonly("line_type", &mpl2014::Mpl2014ContourGenerator::get_line_type)
         .def_static("supports_corner_mask", []() {return true;})
-        .def_static(
-            "supports_fill_type",
-            &mpl2014::Mpl2014ContourGenerator::supports_fill_type)
+        .def_static("supports_fill_type", &mpl2014::Mpl2014ContourGenerator::supports_fill_type)
         .def_static("supports_interp", []() {return false;})
-        .def_static(
-            "supports_line_type",
-            &mpl2014::Mpl2014ContourGenerator::supports_line_type)
+        .def_static("supports_line_type", &mpl2014::Mpl2014ContourGenerator::supports_line_type)
         .def_static("supports_threads", []() {return false;});
 
     py::class_<SerialContourGenerator>(m, "SerialContourGenerator")
@@ -108,10 +100,8 @@ PYBIND11_MODULE(_contourpy, m) {
         .def("filled", &SerialContourGenerator::filled)
         .def("lines", &SerialContourGenerator::lines)
         .def("write_cache", &SerialContourGenerator::write_cache)
-        .def_property_readonly(
-            "chunk_count", &SerialContourGenerator::get_chunk_count)
-        .def_property_readonly(
-            "chunk_size", &SerialContourGenerator::get_chunk_size)
+        .def_property_readonly("chunk_count", &SerialContourGenerator::get_chunk_count)
+        .def_property_readonly("chunk_size", &SerialContourGenerator::get_chunk_size)
         .def_property_readonly_static(
             "default_fill_type",
             [](py::object /* self */) {
@@ -122,18 +112,12 @@ PYBIND11_MODULE(_contourpy, m) {
             [](py::object /* self */) {
                 return SerialContourGenerator::default_line_type();
             })
-        .def_property_readonly(
-            "fill_type", &SerialContourGenerator::get_fill_type)
-        .def_property_readonly(
-            "line_type", &SerialContourGenerator::get_line_type)
+        .def_property_readonly("fill_type", &SerialContourGenerator::get_fill_type)
+        .def_property_readonly("line_type", &SerialContourGenerator::get_line_type)
         .def_static("supports_corner_mask", []() {return true;})
-        .def_static(
-            "supports_fill_type",
-            &SerialContourGenerator::supports_fill_type)
+        .def_static("supports_fill_type", &SerialContourGenerator::supports_fill_type)
         .def_static("supports_interp", []() {return true;})
-        .def_static(
-            "supports_line_type",
-            &SerialContourGenerator::supports_line_type)
+        .def_static("supports_line_type", &SerialContourGenerator::supports_line_type)
         .def_static("supports_threads", []() {return false;});
 
     py::class_<ThreadedContourGenerator>(m, "ThreadedContourGenerator")
@@ -163,10 +147,8 @@ PYBIND11_MODULE(_contourpy, m) {
         .def("filled", &ThreadedContourGenerator::filled)
         .def("lines", &ThreadedContourGenerator::lines)
         .def("write_cache", &ThreadedContourGenerator::write_cache)
-        .def_property_readonly(
-            "chunk_count", &ThreadedContourGenerator::get_chunk_count)
-        .def_property_readonly(
-            "chunk_size", &ThreadedContourGenerator::get_chunk_size)
+        .def_property_readonly("chunk_count", &ThreadedContourGenerator::get_chunk_count)
+        .def_property_readonly("chunk_size", &ThreadedContourGenerator::get_chunk_size)
         .def_property_readonly_static(
             "default_fill_type",
             [](py::object /* self */) {
@@ -177,19 +159,12 @@ PYBIND11_MODULE(_contourpy, m) {
             [](py::object /* self */) {
                 return ThreadedContourGenerator::default_line_type();
             })
-        .def_property_readonly(
-            "fill_type", &ThreadedContourGenerator::get_fill_type)
-        .def_property_readonly(
-            "line_type", &ThreadedContourGenerator::get_line_type)
-        .def_property_readonly(
-            "thread_count", &ThreadedContourGenerator::get_thread_count)
+        .def_property_readonly("fill_type", &ThreadedContourGenerator::get_fill_type)
+        .def_property_readonly("line_type", &ThreadedContourGenerator::get_line_type)
+        .def_property_readonly("thread_count", &ThreadedContourGenerator::get_thread_count)
         .def_static("supports_corner_mask", []() {return true;})
-        .def_static(
-            "supports_fill_type",
-            &ThreadedContourGenerator::supports_fill_type)
+        .def_static("supports_fill_type", &ThreadedContourGenerator::supports_fill_type)
         .def_static("supports_interp", []() {return true;})
-        .def_static(
-            "supports_line_type",
-            &ThreadedContourGenerator::supports_line_type)
+        .def_static("supports_line_type", &ThreadedContourGenerator::supports_line_type)
         .def_static("supports_threads", []() {return true;});
 }

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -1,6 +1,23 @@
+import pytest
 from subprocess import run
 
 
+def test_cppcheck():
+    # Skip test if cppcheck is not installed.
+    cmd = ["cppcheck", "--version"]
+    try:
+        proc = run(cmd)
+    except FileNotFoundError:
+        pytest.skip()
+
+    # Note excluding mpl2005 code.
+    cmd = ["cppcheck", "--quiet", "--enable=all", "--error-exitcode=1", "src", "-isrc/mpl2005.c",
+           "--suppress=missingIncludeSystem", "--inline-suppr"]
+    proc = run(cmd, capture_output=True)
+    assert proc.returncode == 0, f"cppcheck issues:\n{proc.stderr.decode('utf-8')}"
+
+
 def test_flake8():
-    proc = run(["flake8"], capture_output=True)
+    cmd = ["flake8"]
+    proc = run(cmd, capture_output=True)
     assert proc.returncode == 0, f"Flake8 issues:\n{proc.stdout.decode('utf-8')}"

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -84,7 +84,16 @@ def test_xyz_diff_shapes(xyz_3x3_as_lists, name, diff_shape):
         contourpy.contour_generator(x, y, diff_shape, name=name)
 
 
-@pytest.mark.parametrize("name", util_test.all_names())
+@pytest.mark.parametrize("name", util_test.corner_mask_names())
+def test_corner_mask(xyz_3x3_as_lists, name):
+    x, y, z = xyz_3x3_as_lists
+    for corner_mask in [False, True]:
+        cont_gen = contourpy.contour_generator(x, y, z, name=name, corner_mask=corner_mask)
+        assert cont_gen.corner_mask == corner_mask
+
+
+@pytest.mark.parametrize('name', util_test.all_names())
+>>>>>>> e981673... Add corner_mask property to algorithms
 def test_chunk_size_negative(xyz_3x3_as_lists, name):
     x, y, z = xyz_3x3_as_lists
     msg = "chunk_size cannot be negative"

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -93,7 +93,6 @@ def test_corner_mask(xyz_3x3_as_lists, name):
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
->>>>>>> e981673... Add corner_mask property to algorithms
 def test_chunk_size_negative(xyz_3x3_as_lists, name):
     x, y, z = xyz_3x3_as_lists
     msg = "chunk_size cannot be negative"

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -55,7 +55,7 @@ def test_filled_random_uniform_no_corner_mask_chunk(name, fill_type):
             max_threshold = 99
             mean_threshold = 0.18
         else:
-            max_threshold = 134
+            max_threshold = 135
             mean_threshold = 0.23
 
     compare_images(


### PR DESCRIPTION
Added use of `cppcheck` to lint C++ code.  Ignoring `mpl2005.c` as do not want to modify legacy code if at all possible.

Codebase test using `cppcheck` is only performed on Linux, after installing `cppcheck` package.

Various fixes added as a result on linting, and have also increased C++ linewidth to 120 characters, in line with Python code.