### PR TITLE
Add count_t and offset_t types

### DIFF
--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -206,14 +206,16 @@ class MplDebugRenderer(MplRenderer):
         elif line_type == LineType.ChunkCombinedCodes:
             all_lines = []
             for points, codes in zip(*lines):
-                offsets = mpl_codes_to_offsets(codes)
-                for i in range(len(offsets)-1):
-                    all_lines.append(points[offsets[i]:offsets[i+1]])
+                if points is not None:
+                    offsets = mpl_codes_to_offsets(codes)
+                    for i in range(len(offsets)-1):
+                        all_lines.append(points[offsets[i]:offsets[i+1]])
         elif line_type == LineType.ChunkCombinedOffsets:
             all_lines = []
             for points, offsets in zip(*lines):
-                for i in range(len(offsets)-1):
-                    all_lines.append(points[offsets[i]:offsets[i+1]])
+                if points is not None:
+                    for i in range(len(offsets)-1):
+                        all_lines.append(points[offsets[i]:offsets[i+1]])
         else:
             raise RuntimeError(f"Rendering LineType {line_type} not implemented")
 

--- a/src/base.h
+++ b/src/base.h
@@ -96,11 +96,13 @@ protected:
 
     // Return true if finished (i.e. back to start quad, direction and upper).
     bool follow_boundary(
-        Location& location, const Location& start_location, ChunkLocal& local, size_t& point_count);
+        Location& location, const Location& start_location, ChunkLocal& local,
+        count_t& point_count);
 
     // Return true if finished (i.e. back to start quad, direction and upper).
     bool follow_interior(
-        Location& location, const Location& start_location, ChunkLocal& local, size_t& point_count);
+        Location& location, const Location& start_location, ChunkLocal& local,
+        count_t& point_count);
 
     index_t get_boundary_start_point(const Location& location) const;
 

--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -183,7 +183,7 @@ void BaseContourGenerator<Derived>::closed_line(
 
     Location location = start_location;
     bool finished = false;
-    size_t point_count = 0;
+    count_t point_count = 0;
 
     if (outer_or_hole == Hole && local.pass == 0 && _identify_holes)
         set_look_flags(start_location.quad);
@@ -199,7 +199,7 @@ void BaseContourGenerator<Derived>::closed_line(
     if (local.pass > 0) {
         local.line_offsets[local.line_count] = local.total_point_count;
         if (outer_or_hole == Outer && _identify_holes) {
-            size_t outer_count = local.line_count - local.hole_count;
+            auto outer_count = local.line_count - local.hole_count;
             local.outer_offsets[outer_count] = local.line_count;
         }
     }
@@ -225,15 +225,15 @@ void BaseContourGenerator<Derived>::closed_line_wrapper(
 
         closed_line(start_location, outer_or_hole, local);
 
-        for (size_t i = 0; i < local.look_up_quads.size(); ++i) {
+        for (py::size_t i = 0; i < local.look_up_quads.size(); ++i) {
             // Note that the collection can increase in size during this loop.
             index_t quad = local.look_up_quads[i];
 
             // Walk N to corresponding look S flag is reached.
             quad = find_look_S(quad);
 
-            // Only 3 possible types of hole start: START_E, START_HOLE_N or
-            // START_CORNER for SW corner.
+            // Only 3 possible types of hole start: START_E, START_HOLE_N or START_CORNER for SW
+            // corner.
             if (START_E(quad)) {
                 closed_line(Location(quad, -1, -_nx, Z_NE > 0, false), Hole, local);
             }
@@ -351,7 +351,7 @@ void BaseContourGenerator<Derived>::export_lines(
         case LineType::SeparateCodes:
             if (local.total_point_count > 0) {
                 assert(all_points_ptr != nullptr);
-                for (size_t i = 0; i < local.line_count; ++i) {
+                for (decltype(local.line_count) i = 0; i < local.line_count; ++i) {
                     auto point_start = local.line_offsets[i];
                     auto point_end = local.line_offsets[i+1];
                     auto point_count = point_end - point_start;
@@ -447,7 +447,7 @@ index_t BaseContourGenerator<Derived>::find_look_S(index_t look_N_quad) const
 
 template <typename Derived>
 bool BaseContourGenerator<Derived>::follow_boundary(
-    Location& location, const Location& start_location, ChunkLocal& local, size_t& point_count)
+    Location& location, const Location& start_location, ChunkLocal& local, count_t& point_count)
 {
     // forward values for boundaries:
     //     -1 = N boundary, E to W.
@@ -592,7 +592,7 @@ bool BaseContourGenerator<Derived>::follow_boundary(
 
 template <typename Derived>
 bool BaseContourGenerator<Derived>::follow_interior(
-    Location& location, const Location& start_location, ChunkLocal& local, size_t& point_count)
+    Location& location, const Location& start_location, ChunkLocal& local, count_t& point_count)
 {
     // Adds the start point in each quad visited, but not the end point unless closing the polygon.
     // Only need to consider a single level of course.
@@ -848,7 +848,7 @@ index_t BaseContourGenerator<Derived>::get_boundary_start_point(const Location& 
     auto quad = location.quad;
     auto forward = location.forward;
     auto left = location.left;
-    index_t start_point;
+    index_t start_point = -1;
 
     if (forward > 0) {
         if (forward == _nx) {
@@ -937,7 +937,7 @@ index_t BaseContourGenerator<Derived>::get_interior_start_left_point(
     auto quad = location.quad;
     auto forward = location.forward;
     auto left = location.left;
-    index_t left_point;
+    index_t left_point = -1;
 
     if (forward > 0) {
         if (forward == _nx) {
@@ -1391,7 +1391,7 @@ void BaseContourGenerator<Derived>::line(const Location& start_location, ChunkLo
     assert(is_quad_in_chunk(start_location.quad, local));
 
     Location location = start_location;
-    size_t point_count = 0;
+    count_t point_count = 0;
 
     // finished == true indicates closed line loop.
     bool finished = follow_interior(location, start_location, local, point_count);
@@ -1445,7 +1445,7 @@ void BaseContourGenerator<Derived>::march_chunk(
                 continue;
 
             // Want to count number of starts in this row, so store how many starts at start of row.
-            size_t prev_start_count =
+            auto prev_start_count =
                 (_identify_holes ? local.line_count - local.hole_count : local.line_count);
 
             for (index_t i = local.istart; i <= local.iend; ++i, ++quad) {
@@ -1539,7 +1539,7 @@ void BaseContourGenerator<Derived>::march_chunk(
             } // i
 
             // Number of starts at end of row.
-            size_t start_count =
+            auto start_count =
                 (_identify_holes ? local.line_count - local.hole_count : local.line_count);
             if (start_count - prev_start_count)
                 j_final_start = j;
@@ -1563,7 +1563,7 @@ void BaseContourGenerator<Derived>::march_chunk(
                 }
             }
             else if (local.total_point_count > 0) {  // Combined points.
-                py::size_t points_shape[2] = {local.total_point_count, 2};
+                index_t points_shape[2] = {static_cast<index_t>(local.total_point_count), 2};
 
                 typename Derived::Lock lock(static_cast<Derived&>(*this));
                 PointArray py_all_points(points_shape);

--- a/src/chunk_local.cpp
+++ b/src/chunk_local.cpp
@@ -3,8 +3,6 @@
 
 ChunkLocal::ChunkLocal()
 {
-    line_offsets.reserve(100);
-    outer_offsets.reserve(100);
     look_up_quads.reserve(100);
     clear();
 }
@@ -21,6 +19,8 @@ void ChunkLocal::clear()
     hole_count = 0;
     line_offsets.clear();
     outer_offsets.clear();
+
+    look_up_quads.clear();
 }
 
 std::ostream &operator<<(std::ostream &os, const ChunkLocal& local)

--- a/src/chunk_local.h
+++ b/src/chunk_local.h
@@ -15,21 +15,20 @@ struct ChunkLocal
 
 
 
-    index_t chunk;                      // Index in range 0 to _n_chunks-1.
-
-    index_t istart, iend, jstart, jend; // Chunk limits, inclusive.
+    index_t chunk;                       // Index in range 0 to _n_chunks-1.
+    index_t istart, iend, jstart, jend;  // Chunk limits, inclusive.
     int pass;
-    double* points;                     // Where to store next point.
+    double* points;                      // Where to store next point.
 
     // Data for whole pass.
-    size_t total_point_count;
-    size_t line_count;                  // Total of all lines
-    size_t hole_count;                  // Holes only.
-    std::vector<size_t> line_offsets;   // Into array of all points.
-    std::vector<size_t> outer_offsets;  // Into array of line offsets.
+    count_t total_point_count;
+    count_t line_count;                  // Count of all lines
+    count_t hole_count;                  // Count of holes only.
+    std::vector<offset_t> line_offsets;  // Into array of all points.
+    std::vector<offset_t> outer_offsets; // Into array of line offsets.
 
     // Data for current outer.
-    std::vector<index_t> look_up_quads; // To find holes of current outer.
+    std::vector<index_t> look_up_quads;  // To find holes of current outer.
 };
 
 #endif // CONTOURPY_CHUNK_LOCAL_H

--- a/src/common.h
+++ b/src/common.h
@@ -6,19 +6,23 @@
 
 namespace py = pybind11;
 
-// quad/point index type, the same as for numpy array shape/indices (== npy_intp).
+// quad/point index type, the same as for numpy array shape/indices (== npy_intp).  Also used for
+// chunks.
 typedef py::ssize_t index_t;
 
-// Typedef for lengths and indices of STL collections (== npy_uintp).
-typedef py::size_t size_t;
+// Count of points, lines and holes.
+typedef py::size_t count_t;
+
+// Offsets into point arrays.
+typedef uint32_t offset_t;
 
 // Input numpy array classes.
 typedef py::array_t<double, py::array::c_style | py::array::forcecast> CoordinateArray;
 typedef py::array_t<bool,   py::array::c_style | py::array::forcecast> MaskArray;
 
 // Output numpy array classes.
-typedef py::array_t<double>  PointArray;
-typedef py::array_t<uint8_t> CodeArray;
-typedef py::array_t<index_t> OffsetArray;
+typedef py::array_t<double>   PointArray;
+typedef py::array_t<uint8_t>  CodeArray;
+typedef py::array_t<offset_t> OffsetArray;
 
 #endif // CONTOURPY_COMMON_H

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -2,7 +2,7 @@
 #include "mpl_kind_code.h"
 #include <limits>
 
-void Converter::check_max_offset(size_t max_offset)
+void Converter::check_max_offset(count_t max_offset)
 {
     if (max_offset > std::numeric_limits<OffsetArray::value_type>::max())
         throw std::range_error(
@@ -10,12 +10,9 @@ void Converter::check_max_offset(size_t max_offset)
 }
 
 CodeArray Converter::convert_codes(
-    size_t point_count, size_t cut_count, const size_t* cut_start, size_t subtract)
+    count_t point_count, count_t cut_count, const offset_t* cut_start, offset_t subtract)
 {
-    assert(point_count > 0);
-    assert(cut_count > 0);
-
-    py::ssize_t codes_shape[1] = {static_cast<py::ssize_t>(point_count)};
+    index_t codes_shape[1] = {static_cast<index_t>(point_count)};
     CodeArray py_codes(codes_shape);
     auto py_ptr = py_codes.mutable_data();
 
@@ -29,12 +26,9 @@ CodeArray Converter::convert_codes(
 }
 
 CodeArray Converter::convert_codes_check_closed(
-    size_t point_count, size_t cut_count, const size_t* cut_start, const double* check_closed)
+    count_t point_count, count_t cut_count, const offset_t* cut_start, const double* check_closed)
 {
-    assert(point_count > 0);
-    assert(cut_count > 0);
-
-    py::ssize_t codes_shape[1] = {static_cast<py::ssize_t>(point_count)};
+    index_t codes_shape[1] = {static_cast<index_t>(point_count)};
     CodeArray py_codes(codes_shape);
     auto py_ptr = py_codes.mutable_data();
 
@@ -52,11 +46,9 @@ CodeArray Converter::convert_codes_check_closed(
     return py_codes;
 }
 
-CodeArray Converter::convert_codes_check_closed_single(size_t point_count, const double* points)
+CodeArray Converter::convert_codes_check_closed_single(count_t point_count, const double* points)
 {
-    assert(point_count > 0);
-
-    py::ssize_t codes_shape[1] = {static_cast<py::ssize_t>(point_count)};
+    index_t codes_shape[1] = {static_cast<index_t>(point_count)};
     CodeArray py_codes(codes_shape);
     auto py_ptr = py_codes.mutable_data();
 
@@ -75,46 +67,41 @@ CodeArray Converter::convert_codes_check_closed_single(size_t point_count, const
     return py_codes;
 }
 
-OffsetArray Converter::convert_offsets(size_t offset_count, const size_t* start, size_t subtract)
+OffsetArray Converter::convert_offsets(
+    count_t offset_count, const offset_t* start, offset_t subtract)
 {
-    assert(offset_count > 0);
-
     check_max_offset(*(start + offset_count - 1) - subtract);
 
-    py::ssize_t offsets_shape[1] = {static_cast<py::ssize_t>(offset_count)};
+    index_t offsets_shape[1] = {static_cast<index_t>(offset_count)};
     OffsetArray py_offsets(offsets_shape);
     if (subtract == 0)
         std::copy(start, start + offset_count, py_offsets.mutable_data());
     else {
         auto py_ptr = py_offsets.mutable_data();
         for (decltype(offset_count) i = 0; i < offset_count; ++i)
-            *py_ptr++ = static_cast<OffsetArray::value_type>(*(start + i) - subtract);
+            *py_ptr++ = *(start + i) - subtract;
     }
 
     return py_offsets;
 }
 
 OffsetArray Converter::convert_offsets_nested(
-    size_t offset_count, const size_t* start, const size_t* nested_start)
+    count_t offset_count, const offset_t* start, const offset_t* nested_start)
 {
-    assert(offset_count > 0);
-
     check_max_offset(*(nested_start + *(start + offset_count - 1)));
 
-    py::ssize_t offsets_shape[1] = {static_cast<py::ssize_t>(offset_count)};
+    index_t offsets_shape[1] = {static_cast<index_t>(offset_count)};
     OffsetArray py_offsets(offsets_shape);
     auto py_ptr = py_offsets.mutable_data();
     for (decltype(offset_count) i = 0; i < offset_count; ++i)
-        *py_ptr++ = static_cast<OffsetArray::value_type>(*(nested_start + *(start + i)));
+        *py_ptr++ = *(nested_start + *(start + i));
 
     return py_offsets;
 }
 
-PointArray Converter::convert_points(size_t point_count, const double* start)
+PointArray Converter::convert_points(count_t point_count, const double* start)
 {
-    assert(point_count > 0);
-
-    py::ssize_t points_shape[2] = {static_cast<py::ssize_t>(point_count), 2};
+    index_t points_shape[2] = {static_cast<index_t>(point_count), 2};
     PointArray py_points(points_shape);
     std::copy(start, start + 2*point_count, py_points.mutable_data());
 

--- a/src/converter.h
+++ b/src/converter.h
@@ -8,23 +8,23 @@ class Converter
 {
 public:
     static CodeArray convert_codes(
-        size_t point_count, size_t cut_count, const size_t* cut_start, size_t subtract = 0);
+        count_t point_count, count_t cut_count, const offset_t* cut_start, offset_t subtract = 0);
 
     static CodeArray convert_codes_check_closed(
-        size_t point_count, size_t cut_count, const size_t* cut_start, const double* points);
+        count_t point_count, count_t cut_count, const offset_t* cut_start, const double* points);
 
-    static CodeArray convert_codes_check_closed_single(size_t point_count, const double* points);
+    static CodeArray convert_codes_check_closed_single(count_t point_count, const double* points);
 
     static OffsetArray convert_offsets(
-        size_t offset_count, const size_t* start, size_t subtract = 0);
+        count_t offset_count, const offset_t* start, offset_t subtract = 0);
 
     static OffsetArray convert_offsets_nested(
-        size_t offset_count, const size_t* start, const size_t* nested_start);
+        count_t offset_count, const offset_t* start, const offset_t* nested_start);
 
-    static PointArray convert_points(size_t point_count, const double* start);
+    static PointArray convert_points(count_t point_count, const double* start);
 
 private:
-    static void check_max_offset(size_t max_offset);
+    static void check_max_offset(count_t max_offset);
 };
 
 #endif // CONTOURPY_CONVERTER_H

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -123,7 +123,7 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
         assert isinstance(points, list) and len(points) == 2
         for p in points:
             assert isinstance(p, np.ndarray)
-            assert p.dtype == np.float64
+            assert p.dtype == util_test.point_dtype
         assert points[0].shape == (13, 2)
         assert points[1].shape == (4, 2)
         assert_array_equal(points[0][0], points[0][7])
@@ -134,7 +134,7 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
             assert isinstance(codes, list) and len(codes) == 2
             for c in codes:
                 assert isinstance(c, np.ndarray)
-                assert c.dtype == np.uint8
+                assert c.dtype == util_test.code_dtype
             assert_array_equal(codes[0], [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79])
             assert_array_equal(codes[1], [1, 2, 2, 79])
         else:  # FillType.OuterOffsets.
@@ -142,7 +142,7 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
             assert isinstance(offsets, list) and len(offsets) == 2
             for o in offsets:
                 assert isinstance(o, np.ndarray)
-                assert o.dtype == np.intp
+                assert o.dtype == util_test.offset_dtype
             assert_array_equal(offsets[0], [0, 8, 13])
             assert_array_equal(offsets[1], [0, 4])
     elif fill_type in (FillType.ChunkCombinedCodes, FillType.ChunkCombinedOffsets,
@@ -155,7 +155,7 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
         assert isinstance(points, list) and len(points) == 1
         points = points[0]
         assert isinstance(points, np.ndarray)
-        assert points.dtype == np.float64
+        assert points.dtype == util_test.point_dtype
         assert points.shape == (17, 2)
         assert_array_equal(points[0], points[7])
         assert_array_equal(points[8], points[12])
@@ -165,14 +165,14 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
             assert isinstance(codes, list) and len(codes) == 1
             codes = codes[0]
             assert isinstance(codes, np.ndarray)
-            assert codes.dtype == np.uint8
+            assert codes.dtype == util_test.code_dtype
             assert_array_equal(codes, [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79, 1, 2, 2, 79])
         else:
             offsets = filled[1]
             assert isinstance(offsets, list) and len(offsets) == 1
             offsets = offsets[0]
             assert isinstance(offsets, np.ndarray)
-            assert offsets.dtype == np.intp
+            assert offsets.dtype == util_test.offset_dtype
             assert_array_equal(offsets, [0, 8, 13, 17])
 
         if fill_type in (FillType.ChunkCombinedCodesOffsets, FillType.ChunkCombinedOffsets2):
@@ -180,7 +180,7 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
             assert isinstance(outer_offsets, list) and len(outer_offsets) == 1
             outer_offsets = outer_offsets[0]
             assert isinstance(outer_offsets, np.ndarray)
-            assert outer_offsets.dtype == np.intp
+            assert outer_offsets.dtype == util_test.offset_dtype
             if fill_type == FillType.ChunkCombinedCodesOffsets:
                 assert_array_equal(outer_offsets, [0, 13, 17])
             else:

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -184,7 +184,7 @@ def test_return_by_line_type(one_loop_one_strip, name, line_type):
         assert isinstance(points, list) and len(points) == 2
         for p in points:
             assert isinstance(p, np.ndarray)
-            assert p.dtype == np.float64
+            assert p.dtype == util_test.point_dtype
         assert points[0].shape == (5, 2)
         assert points[1].shape == (2, 2)
         assert_array_equal(points[0][0], points[0][4])
@@ -193,29 +193,28 @@ def test_return_by_line_type(one_loop_one_strip, name, line_type):
             assert isinstance(codes, list) and len(codes) == 2
             for c in codes:
                 assert isinstance(c, np.ndarray)
-                assert c.dtype == np.uint8
+                assert c.dtype == util_test.code_dtype
             assert_array_equal(codes[0], [1, 2, 2, 2, 79])
             assert_array_equal(codes[1], [1, 2])
-    elif line_type in (LineType.ChunkCombinedCodes,
-                       LineType.ChunkCombinedOffsets):
+    elif line_type in (LineType.ChunkCombinedCodes, LineType.ChunkCombinedOffsets):
         assert isinstance(lines, tuple) and len(lines) == 2
         points = lines[0]
         assert isinstance(points, list) and len(points) == 1
         assert isinstance(points[0], np.ndarray)
-        assert points[0].dtype == np.float64
+        assert points[0].dtype == util_test.point_dtype
         assert points[0].shape == (7, 2)
         assert_array_equal(points[0][0], points[0][4])
         if line_type == LineType.ChunkCombinedCodes:
             codes = lines[1]
             assert isinstance(codes, list) and len(codes) == 1
             assert isinstance(codes[0], np.ndarray)
-            assert codes[0].dtype == np.uint8
+            assert codes[0].dtype == util_test.code_dtype
             assert_array_equal(codes[0], [1, 2, 2, 2, 79, 1, 2])
         else:
             offsets = lines[1]
             assert isinstance(offsets, list) and len(offsets) == 1
             assert isinstance(offsets[0], np.ndarray)
-            assert offsets[0].dtype == np.intp
+            assert offsets[0].dtype == util_test.offset_dtype
             assert_array_equal(offsets[0], [0, 5, 7])
     else:
         raise RuntimeError(f"Unexpected line_type {line_type}")

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,4 +1,10 @@
 from contourpy import FillType, LineType
+import numpy as np
+
+
+point_dtype = np.float64
+code_dtype = np.uint8
+offset_dtype = np.uint32
 
 
 def all_class_names():


### PR DESCRIPTION
Added separate `count_t` and `offset_t` typedefs to `serial` and `threaded` algorithms.  `count_t` is used for count of points, lines and holes in `ChunkLocal`, and `offset_t` is used for offsets into point and line arrays.

`count_t` is the same as `py::size_t`  and `npy_uintp`, i.e. unsigned 64-bit on 64-bit machines.

`offset_t` is `uint32_t` on all platforms.  Maximum value is 2<sup>32</sup>-1 = 4,294,967,295.  Minimum chunk size to hit this limit for filled contours (assuming 2 contour points per quad) is 46340.  Corresponding points array would be ~64 GB in size.  It is reasonable to assume users will be using smaller chunks than this!

Note that this is partial reversion of issue #39.