### PR TITLE
New OutputArray<T> class for combined chunk points

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -85,12 +85,9 @@ protected:
         const Location& start_location, OuterOrHole outer_or_hole, ChunkLocal& local);
 
     // Write points and offsets/codes to output numpy arrays.
-    void export_filled(
-        ChunkLocal& local, const std::vector<double>& all_points,
-        std::vector<py::list>& return_lists);
+    void export_filled(ChunkLocal& local, std::vector<py::list>& return_lists);
 
-    void export_lines(
-        ChunkLocal& local, const double* all_points_ptr, std::vector<py::list>& return_lists);
+    void export_lines(ChunkLocal& local, std::vector<py::list>& return_lists);
 
     index_t find_look_S(index_t look_N_quad) const;
 

--- a/src/base.h
+++ b/src/base.h
@@ -124,7 +124,7 @@ protected:
     void init_cache_levels_and_starts(const ChunkLocal* local = nullptr);
 
     // Increments local.points twice.
-    void interp(index_t point0, index_t point1, bool is_upper, ChunkLocal& local) const;
+    void interp(index_t point0, index_t point1, bool is_upper, double*& points) const;
 
     bool is_filled() const;
 

--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -112,6 +112,7 @@ BaseContourGenerator<Derived>::BaseContourGenerator(
       _lower_level(0.0),
       _upper_level(0.0),
       _identify_holes(false),
+      _combined_points(false),
       _return_list_count(0)
 {
     if (_x.ndim() != 2 || _y.ndim() != 2 || _z.ndim() != 2)
@@ -266,10 +267,8 @@ LineType BaseContourGenerator<Derived>::default_line_type()
 
 template <typename Derived>
 void BaseContourGenerator<Derived>::export_filled(
-    ChunkLocal& local, const std::vector<double>& all_points, std::vector<py::list>& return_lists)
+    ChunkLocal& local, std::vector<py::list>& return_lists)
 {
-    // all_points is only used for fill_types OuterCodes and OuterOffsets.
-
     typename Derived::Lock lock(static_cast<Derived&>(*this));
 
     switch (_fill_type)
@@ -287,7 +286,7 @@ void BaseContourGenerator<Derived>::export_filled(
                     assert(point_count > 2);
 
                     return_lists[0].append(Converter::convert_points(
-                        point_count, all_points.data() + 2*point_start));
+                        point_count, local.points.start + 2*point_start));
 
                     if (_fill_type == FillType::OuterCodes)
                         return_lists[1].append(Converter::convert_codes(
@@ -341,7 +340,7 @@ void BaseContourGenerator<Derived>::export_filled(
 
 template <typename Derived>
 void BaseContourGenerator<Derived>::export_lines(
-    ChunkLocal& local, const double* all_points_ptr, std::vector<py::list>& return_lists)
+    ChunkLocal& local, std::vector<py::list>& return_lists)
 {
     typename Derived::Lock lock(static_cast<Derived&>(*this));
 
@@ -350,7 +349,6 @@ void BaseContourGenerator<Derived>::export_lines(
         case LineType::Separate:
         case LineType::SeparateCodes:
             if (local.total_point_count > 0) {
-                assert(all_points_ptr != nullptr);
                 for (decltype(local.line_count) i = 0; i < local.line_count; ++i) {
                     auto point_start = local.line_offsets[i];
                     auto point_end = local.line_offsets[i+1];
@@ -358,12 +356,12 @@ void BaseContourGenerator<Derived>::export_lines(
                     assert(point_count > 1);
 
                     return_lists[0].append(Converter::convert_points(
-                        point_count, all_points_ptr + 2*point_start));
+                        point_count, local.points.start + 2*point_start));
 
                     if (_line_type == LineType::SeparateCodes) {
                         return_lists[1].append(
                             Converter::convert_codes_check_closed_single(
-                                point_count, all_points_ptr + 2*point_start));
+                                point_count, local.points.start + 2*point_start));
                     }
                 }
             }
@@ -371,12 +369,11 @@ void BaseContourGenerator<Derived>::export_lines(
         case LineType::ChunkCombinedCodes: {
             if (local.total_point_count > 0) {
                 // return_lists[0] already set.
-                assert(all_points_ptr != nullptr);
                 assert(!local.line_offsets.empty());
                 return_lists[1][local.chunk] =
                     Converter::convert_codes_check_closed(
                         local.total_point_count, local.line_offsets.size(),
-                        local.line_offsets.data(), all_points_ptr);
+                        local.line_offsets.data(), local.points.start);
             }
             else {
                 for (auto& list : return_lists)
@@ -485,7 +482,7 @@ bool BaseContourGenerator<Derived>::follow_boundary(
     point_count++;
     if (pass > 0) {
         if (start_z == 1)
-            get_point_xy(start_point, local.points);
+            get_point_xy(start_point, local.points.current);
         else  // start_z != 1
             interp(start_point, end_point, location.is_upper, local);
     }
@@ -566,7 +563,7 @@ bool BaseContourGenerator<Derived>::follow_boundary(
         // Add end point.
         point_count++;
         if (pass > 0) {
-            get_point_xy(end_point, local.points);
+            get_point_xy(end_point, local.points.current);
 
             if (LOOK_N(quad) && _identify_holes &&
                 (left == _nx || left == _nx+1 || forward == _nx+1)) {
@@ -1352,8 +1349,8 @@ void BaseContourGenerator<Derived>::interp(
 
     assert(frac >= 0.0 && frac <= 1.0 && "Interp fraction out of bounds");
 
-    *local.points++ = get_point_x(point0)*frac + get_point_x(point1)*(1.0 - frac);
-    *local.points++ = get_point_y(point0)*frac + get_point_y(point1)*(1.0 - frac);
+    *local.points.current++ = get_point_x(point0)*frac + get_point_x(point1)*(1.0 - frac);
+    *local.points.current++ = get_point_y(point0)*frac + get_point_y(point1)*(1.0 - frac);
 }
 
 template <typename Derived>
@@ -1427,10 +1424,6 @@ template <typename Derived>
 void BaseContourGenerator<Derived>::march_chunk(
     ChunkLocal& local, std::vector<py::list>& return_lists)
 {
-    // May be allocated at end of pass 0, depending on _filled and _fill_type or _line_type.
-    std::vector<double> all_points;
-    const double* all_points_ptr = nullptr;  // Only used for lines.
-
     for (local.pass = 0; local.pass < 2; ++local.pass) {
         bool ignore_holes = (_identify_holes && local.pass == 1);
 
@@ -1551,33 +1544,18 @@ void BaseContourGenerator<Derived>::march_chunk(
             _cache[local.istart + (j_final_start+1)*_nx] |= MASK_NO_MORE_STARTS;
 
         if (local.pass == 0) {
-            if (!_combined_points) {
-                all_points.resize(2*local.total_point_count);
-
-                // Where to store contour points.
-                local.points = all_points.data();
-
-                if (!_filled) {
-                    // Needed to check if lines are closed loops or not.
-                    all_points_ptr = all_points.data();
-                }
+            if (local.total_point_count == 0) {
+                local.points.clear();
             }
-            else if (local.total_point_count > 0) {  // Combined points.
-                index_t points_shape[2] = {static_cast<index_t>(local.total_point_count), 2};
-
+            else if (!_combined_points) {
+                local.points.create_cpp(2*local.total_point_count);
+            }
+            else {  // Combined points.
                 typename Derived::Lock lock(static_cast<Derived&>(*this));
-                PointArray py_all_points(points_shape);
+                auto py_points = local.points.create_python(local.total_point_count, 2);
                 lock.unlock();
 
-                return_lists[0][local.chunk] = py_all_points;
-
-                // Where to store contour points.
-                local.points = py_all_points.mutable_data();
-
-                if (!_filled) {
-                    // Needed to check if lines are closed loops or not.
-                    all_points_ptr = py_all_points.data();
-                }
+                return_lists[0][local.chunk] = py_points;
             }
 
             // Allocate space for line_offsets, and set final offsets.
@@ -1601,6 +1579,13 @@ void BaseContourGenerator<Derived>::march_chunk(
     } // pass
 
     // Check both passes returned same number of points, lines, etc.
+    if (local.total_point_count == 0) {
+        assert(local.points.start == nullptr && local.points.current == nullptr);
+    }
+    else {
+        assert(local.points.current = local.points.start + 2*local.total_point_count);
+    }
+
     assert(local.line_offsets.size() == local.line_count + 1);
     assert(local.line_offsets.back() == local.total_point_count);
 
@@ -1613,9 +1598,9 @@ void BaseContourGenerator<Derived>::march_chunk(
     }
 
     if (_filled)
-        export_filled(local, all_points, return_lists);
+        export_filled(local, return_lists);
     else
-        export_lines(local, all_points_ptr, return_lists);
+        export_lines(local, return_lists);
 }
 
 template <typename Derived>

--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -467,6 +467,7 @@ bool BaseContourGenerator<Derived>::follow_boundary(
     auto start_forward = start_location.forward;
     auto start_left = start_location.left;
     auto pass = local.pass;
+    double*& points = local.points.current;
 
     auto start_point = get_boundary_start_point(location);
     auto end_point = start_point + forward;
@@ -482,9 +483,9 @@ bool BaseContourGenerator<Derived>::follow_boundary(
     point_count++;
     if (pass > 0) {
         if (start_z == 1)
-            get_point_xy(start_point, local.points.current);
+            get_point_xy(start_point, points);
         else  // start_z != 1
-            interp(start_point, end_point, location.is_upper, local);
+            interp(start_point, end_point, location.is_upper, points);
     }
 
     bool finished = false;
@@ -563,7 +564,7 @@ bool BaseContourGenerator<Derived>::follow_boundary(
         // Add end point.
         point_count++;
         if (pass > 0) {
-            get_point_xy(end_point, local.points.current);
+            get_point_xy(end_point, points);
 
             if (LOOK_N(quad) && _identify_holes &&
                 (left == _nx || left == _nx+1 || forward == _nx+1)) {
@@ -605,6 +606,7 @@ bool BaseContourGenerator<Derived>::follow_interior(
     auto start_forward = start_location.forward;
     auto start_left = start_location.left;
     auto pass = local.pass;
+    double*& points = local.points.current;
 
     // left direction, and indices of points on entry edge.
     bool start_corner_diagonal = false;
@@ -619,7 +621,7 @@ bool BaseContourGenerator<Derived>::follow_interior(
         assert(is_point_in_chunk(right_point, local));
 
         if (pass > 0)
-            interp(left_point, right_point, is_upper, local);
+            interp(left_point, right_point, is_upper, points);
         point_count++;
 
         if (quad == start_quad && forward == start_forward &&
@@ -822,7 +824,7 @@ bool BaseContourGenerator<Derived>::follow_interior(
             if (!_filled) {
                 point_count++;
                 if (pass > 0)
-                    interp(left_point, right_point, false, local);
+                    interp(left_point, right_point, false, points);
             }
             break;
         }
@@ -1326,11 +1328,8 @@ void BaseContourGenerator<Derived>::init_cache_levels_and_starts(const ChunkLoca
 
 template <typename Derived>
 void BaseContourGenerator<Derived>::interp(
-    index_t point0, index_t point1, bool is_upper, ChunkLocal& local) const
+    index_t point0, index_t point1, bool is_upper, double*& points) const
 {
-    assert(is_point_in_chunk(point0, local));
-    assert(is_point_in_chunk(point1, local));
-
     const double& z1 = get_point_z(point1);
     const double& level = is_upper ? _upper_level : _lower_level;
 
@@ -1349,8 +1348,8 @@ void BaseContourGenerator<Derived>::interp(
 
     assert(frac >= 0.0 && frac <= 1.0 && "Interp fraction out of bounds");
 
-    *local.points.current++ = get_point_x(point0)*frac + get_point_x(point1)*(1.0 - frac);
-    *local.points.current++ = get_point_y(point0)*frac + get_point_y(point1)*(1.0 - frac);
+    *points++ = get_point_x(point0)*frac + get_point_x(point1)*(1.0 - frac);
+    *points++ = get_point_y(point0)*frac + get_point_y(point1)*(1.0 - frac);
 }
 
 template <typename Derived>

--- a/src/chunk_local.cpp
+++ b/src/chunk_local.cpp
@@ -12,11 +12,12 @@ void ChunkLocal::clear()
     chunk = -1;
     istart = iend = jstart = jend = -1;
     pass = -1;
-    points = nullptr;
 
     total_point_count = 0;
     line_count = 0;
     hole_count = 0;
+
+    points.clear();
     line_offsets.clear();
     outer_offsets.clear();
 

--- a/src/chunk_local.h
+++ b/src/chunk_local.h
@@ -1,9 +1,8 @@
 #ifndef CONTOURPY_CHUNK_LOCAL_H
 #define CONTOURPY_CHUNK_LOCAL_H
 
-#include "common.h"
+#include "output_array.h"
 #include <iosfwd>
-#include <vector>
 
 struct ChunkLocal
 {
@@ -18,12 +17,14 @@ struct ChunkLocal
     index_t chunk;                       // Index in range 0 to _n_chunks-1.
     index_t istart, iend, jstart, jend;  // Chunk limits, inclusive.
     int pass;
-    double* points;                      // Where to store next point.
 
     // Data for whole pass.
     count_t total_point_count;
     count_t line_count;                  // Count of all lines
     count_t hole_count;                  // Count of holes only.
+
+    // Output arrays that are initialised at the end of pass 0 and written to during pass 1.
+    OutputArray<double> points;
     std::vector<offset_t> line_offsets;  // Into array of all points.
     std::vector<offset_t> outer_offsets; // Into array of line offsets.
 

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -5,14 +5,13 @@
 void Converter::check_max_offset(count_t max_offset)
 {
     if (max_offset > std::numeric_limits<OffsetArray::value_type>::max())
-        throw std::range_error(
-            "Max offset too large to fit in NumPy array of dtype npy_intp. Use smaller chunks.");
+        throw std::range_error("Max offset too large to fit in np.uint32. Use smaller chunks.");
 }
 
 CodeArray Converter::convert_codes(
     count_t point_count, count_t cut_count, const offset_t* cut_start, offset_t subtract)
 {
-    index_t codes_shape[1] = {static_cast<index_t>(point_count)};
+    index_t codes_shape = static_cast<index_t>(point_count);
     CodeArray py_codes(codes_shape);
     auto py_ptr = py_codes.mutable_data();
 
@@ -28,7 +27,7 @@ CodeArray Converter::convert_codes(
 CodeArray Converter::convert_codes_check_closed(
     count_t point_count, count_t cut_count, const offset_t* cut_start, const double* check_closed)
 {
-    index_t codes_shape[1] = {static_cast<index_t>(point_count)};
+    index_t codes_shape = static_cast<index_t>(point_count);
     CodeArray py_codes(codes_shape);
     auto py_ptr = py_codes.mutable_data();
 
@@ -48,7 +47,7 @@ CodeArray Converter::convert_codes_check_closed(
 
 CodeArray Converter::convert_codes_check_closed_single(count_t point_count, const double* points)
 {
-    index_t codes_shape[1] = {static_cast<index_t>(point_count)};
+    index_t codes_shape = static_cast<index_t>(point_count);
     CodeArray py_codes(codes_shape);
     auto py_ptr = py_codes.mutable_data();
 
@@ -72,7 +71,7 @@ OffsetArray Converter::convert_offsets(
 {
     check_max_offset(*(start + offset_count - 1) - subtract);
 
-    index_t offsets_shape[1] = {static_cast<index_t>(offset_count)};
+    index_t offsets_shape = static_cast<index_t>(offset_count);
     OffsetArray py_offsets(offsets_shape);
     if (subtract == 0)
         std::copy(start, start + offset_count, py_offsets.mutable_data());
@@ -90,7 +89,7 @@ OffsetArray Converter::convert_offsets_nested(
 {
     check_max_offset(*(nested_start + *(start + offset_count - 1)));
 
-    index_t offsets_shape[1] = {static_cast<index_t>(offset_count)};
+    index_t offsets_shape = static_cast<index_t>(offset_count);
     OffsetArray py_offsets(offsets_shape);
     auto py_ptr = py_offsets.mutable_data();
     for (decltype(offset_count) i = 0; i < offset_count; ++i)

--- a/src/output_array.h
+++ b/src/output_array.h
@@ -1,0 +1,52 @@
+#ifndef CONTOURPY_OUTPUT_ARRAY_H
+#define CONTOURPY_OUTPUT_ARRAY_H
+
+#include "common.h"
+#include <vector>
+
+// A reusable array that is output from C++ to Python.  Depending on the chosen line or fill type,
+// it can either be created as a NumPy array that will be directly returned to the Python caller,
+// or as a C++ vector that will be further manipulated (such as split up) before being converted to
+// NumPy array(s) for returning.  BaseContourGenerator's marching does not care which form it is as
+// it just writes values to either array using an incrementing pointer.
+template <typename T>
+class OutputArray
+{
+public:
+    OutputArray()
+        : start(nullptr), current(nullptr)
+    {}
+
+    void clear()
+    {
+        vector.clear();
+        start = current = nullptr;
+    }
+
+    void create_cpp(count_t size)
+    {
+        assert(size > 0);
+        vector.resize(size);
+        start = current = vector.data();
+    }
+
+    py::array_t<T> create_python(count_t shape0, count_t shape1)
+    {
+        py::array_t<T> py_array({shape0, shape1});
+        start = current = py_array.mutable_data();
+        return py_array;
+    }
+
+    // Non-copyable and non-moveable.
+    OutputArray(const OutputArray& other) = delete;
+    OutputArray(const OutputArray&& other) = delete;
+    OutputArray& operator=(const OutputArray& other) = delete;
+    OutputArray& operator=(const OutputArray&& other) = delete;
+
+
+    std::vector<T> vector;
+    T* start;               // Start of array, whether C++ or Python.
+    T* current;             // Where to write next value to before incrementing.
+};
+
+#endif // CONTOURPY_OUTPUT_ARRAY_H


### PR DESCRIPTION
Added new C++ class `OutputArray<T>` to combine the possibilities of outputting arrays directly to Python (NumPy) arrays or to C++ vectors first.  Marching functions don't care which it is, they just append to an incrementing pointer.  This is a cleaner solution to that previously.

Also change `interp()` to accept a `double*&` rather than `ChunkLocal&` so that the `OutputArray<T>`'s current pointer is passed straight in.