### PR TITLE
Use OutputArray<T> for line and outer offsets

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -170,7 +170,10 @@ private:
 
     // Current contouring operation, based on return type and filled or lines.
     bool _identify_holes;
-    bool _combined_points;
+    bool _output_chunked;             // Implies empty chunks will have py::none().
+    bool _direct_points;              // Whether points array is written direct to Python.
+    bool _direct_line_offsets;        // Whether line offsets array is written direct to Python.
+    bool _direct_outer_offsets;       // Whether outer offsets array is written direct to Python.
     unsigned int _return_list_count;
 };
 

--- a/src/chunk_local.cpp
+++ b/src/chunk_local.cpp
@@ -1,5 +1,6 @@
 #include "chunk_local.h"
 #include <iostream>
+#include <limits>
 
 ChunkLocal::ChunkLocal()
 {
@@ -36,18 +37,18 @@ std::ostream &operator<<(std::ostream &os, const ChunkLocal& local)
         << " line_count=" << local.line_count
         << " hole_count=" << local.hole_count;
 
-    os << " line_offsets(" << local.line_offsets.size() << ")";
-    if (!local.line_offsets.empty()) {
-        os << "=";
-        for (auto count : local.line_offsets)
-            os << count << " ";
+    if (local.line_offsets.start != nullptr) {
+        os << " line_offsets=";
+        for (count_t i = 0; i < local.line_count + 1; ++i) {
+            os << local.line_offsets.start[i] << " ";
+        }
     }
 
-    os << " outer_offsets(" << local.outer_offsets.size() << ")";
-    if (!local.outer_offsets.empty()) {
-        os << "=";
-        for (auto count : local.outer_offsets)
-            os << count << " ";
+    if (local.outer_offsets.start != nullptr) {
+        os << " outer_offsets=";
+        for (count_t i = 0; i < local.line_count - local.hole_count + 1; ++i) {
+            os << local.outer_offsets.start[i] << " ";
+        }
     }
 
     return os;

--- a/src/chunk_local.h
+++ b/src/chunk_local.h
@@ -25,8 +25,8 @@ struct ChunkLocal
 
     // Output arrays that are initialised at the end of pass 0 and written to during pass 1.
     OutputArray<double> points;
-    std::vector<offset_t> line_offsets;  // Into array of all points.
-    std::vector<offset_t> outer_offsets; // Into array of line offsets.
+    OutputArray<offset_t> line_offsets;  // Into array of all points.
+    OutputArray<offset_t> outer_offsets; // Into array of line offsets.
 
     // Data for current outer.
     std::vector<index_t> look_up_quads;  // To find holes of current outer.

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -17,8 +17,8 @@ CodeArray Converter::convert_codes(
 
     std::fill(py_ptr + 1, py_ptr + point_count - 1, LINETO);
     for (decltype(cut_count) i = 0; i < cut_count-1; ++i) {
-        py_ptr[*(cut_start + i) - subtract] = MOVETO;
-        py_ptr[*(cut_start + i+1) - 1 - subtract] = CLOSEPOLY;
+        py_ptr[cut_start[i] - subtract] = MOVETO;
+        py_ptr[cut_start[i+1] - 1 - subtract] = CLOSEPOLY;
     }
 
     return py_codes;
@@ -33,8 +33,8 @@ CodeArray Converter::convert_codes_check_closed(
 
     std::fill(py_ptr + 1, py_ptr + point_count, LINETO);
     for (decltype(cut_count) i = 0; i < cut_count-1; ++i) {
-        auto start = *(cut_start + i);
-        auto end = *(cut_start + i+1);
+        auto start = cut_start[i];
+        auto end = cut_start[i+1];
         py_ptr[start] = MOVETO;
         bool closed = check_closed[2*start] == check_closed[2*end-2] &&
                       check_closed[2*start+1] == check_closed[2*end-1];
@@ -78,7 +78,7 @@ OffsetArray Converter::convert_offsets(
     else {
         auto py_ptr = py_offsets.mutable_data();
         for (decltype(offset_count) i = 0; i < offset_count; ++i)
-            *py_ptr++ = *(start + i) - subtract;
+            *py_ptr++ = start[i] - subtract;
     }
 
     return py_offsets;
@@ -93,7 +93,7 @@ OffsetArray Converter::convert_offsets_nested(
     OffsetArray py_offsets(offsets_shape);
     auto py_ptr = py_offsets.mutable_data();
     for (decltype(offset_count) i = 0; i < offset_count; ++i)
-        *py_ptr++ = *(nested_start + *(start + i));
+        *py_ptr++ = nested_start[start[i]];
 
     return py_offsets;
 }

--- a/src/output_array.h
+++ b/src/output_array.h
@@ -30,8 +30,17 @@ public:
         start = current = vector.data();
     }
 
+    py::array_t<T> create_python(count_t size)
+    {
+        assert(size > 0);
+        py::array_t<T> py_array(size);
+        start = current = py_array.mutable_data();
+        return py_array;
+    }
+
     py::array_t<T> create_python(count_t shape0, count_t shape1)
     {
+        assert(shape0 > 0 && shape1 > 0);
         py::array_t<T> py_array({shape0, shape1});
         start = current = py_array.mutable_data();
         return py_array;


### PR DESCRIPTION
Output offset arrays direct to python where possible, using new `OutputArray<T>` class.

Whether to output directly to python or not is controlled by `BaseContourGenerator` member variables `_direct_points`, `_direct_line_offsets` and `_direct_outer_offsets`, which are set at the start of each call to `filled()` or `lines()`.

Also some minor replacement of C++ pointer dereferencing with array notation.