### PR TITLE
Build environment variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,20 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Test ${{ matrix.python-version }} ${{ matrix.os }} ${{ matrix.debug == 1 && 'debug' || '' }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9]
+        debug: [0]
+        include:
+          # Add debug build and test to matrix.
+          - os: ubuntu-latest
+            python-version: 3.9
+            debug: 1
 
     steps:
       - name: Checkout source
@@ -31,11 +37,17 @@ jobs:
           python -m pip list
 
       - name: Install
+        if: matrix.debug == 0
         run: |
           python -m pip install --no-deps -ve .
 
+      - name: Install debug
+        if: matrix.debug == 1
+        run: |
+          BUILD_DEBUG=1 BUILD_CXX11=1 python -m pip install --no-deps -ve .
+
       - name: Install cppcheck
-        if: startsWith(runner.os, 'Linux')
+        if: runner.os == 'Linux'
         run: |
           sudo apt install -y cppcheck
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ To build and install in developer's mode
 
     pip install -ve .
 
+To build in debug mode, which enables `assert`s in C++ code
+
+    BUILD_DEBUG=1 pip install -ve .
+
 To run tests
 
     pip install -r requirements/test.txt

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -10,6 +10,9 @@
 PYBIND11_MODULE(_contourpy, m) {
     m.doc() = "doc notes";
 
+    m.attr("BUILD_DEBUG") = BUILD_DEBUG;
+    m.attr("BUILD_CXX11") = BUILD_CXX11;
+
     py::enum_<FillType>(m, "FillType")
         .value("OuterCodes", FillType::OuterCodes)
         .value("OuterOffsets", FillType::OuterOffsets)


### PR DESCRIPTION
Added environment variables to control some aspects of build process.  These are BUILD_DEBUG that builds in debug mode and in particular enables the `assert`s in the C++ code, and BUILD_CXX11 which forces use of c++11 standard rather than using the latest C++ standard available.  To build using both of these use
```
BUILD_DEBUG=1 BUILD_CXX11 pip install -ve .
```

Added attributes to the `_contourpy` extension so that the values used at build time are stored and can be checked later.

Also added a new CI test run with uses both of these flags.