### PR TITLE
Implement log interpolation for saddle quads

### DIFF
--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -82,6 +82,14 @@ class MplRenderer:
     def title(self, title, ax=0):
         self._get_ax(ax).set_title(title)
 
+    def z_values(self, x, y, z, ax=0, color="green", fmt=".1f"):
+        ax = self._get_ax(ax)
+        ny, nx = z.shape
+        for j in range(ny):
+            for i in range(nx):
+                ax.text(x[j, i], y[j, i], f"{z[j,i]:{fmt}}", ha="center", va="center",
+                        color=color, clip_on=True)
+
 
 # Test renderer without whitespace around plots and no spines/ticks displayed.
 # Uses Agg backend, so can only save to file/buffer, cannot call show().

--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -162,8 +162,21 @@ typename BaseContourGenerator<Derived>::ZLevel BaseContourGenerator<Derived>::ca
 {
     assert(quad >= 0 && quad < _n);
 
-    double zmid = 0.25*(get_point_z(quad-_nx-1) + get_point_z(quad-_nx) +
-                        get_point_z(quad-1) + get_point_z(quad));
+    double zmid;
+    switch (_interp) {
+        case Interp::Log:
+            zmid = exp(0.25*(log(get_point_z(POINT_SW)) +
+                             log(get_point_z(POINT_SE)) +
+                             log(get_point_z(POINT_NW)) +
+                             log(get_point_z(POINT_NE))));
+            break;
+        default:  // Interp::Linear
+            zmid = 0.25*(get_point_z(POINT_SW) +
+                         get_point_z(POINT_SE) +
+                         get_point_z(POINT_NW) +
+                         get_point_z(POINT_NE));
+            break;
+    }
 
     _cache[quad] &= ~MASK_SADDLE;  // Clear saddle bits.
 


### PR DESCRIPTION
Log interpolation has been implemented for interpolation of contour levels on grid cell edges, but not for calculation of the z-level in the centre of saddle quads.  This PR corrects that.

Test added.

Also add new `util` function `MplRenderer.z_values()` to display the z-values at grid points which will help with examples to explain what is occurring here.  Have not done this for `BokehRenderer` yet.