### PR TITLE
CI build wheels less often

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -2,10 +2,9 @@ name: Build binary wheels
 
 on:
   push:
-    branches:
-      - main
     tags:
       - v*
+  workflow_dispatch:
 
 jobs:
   build_wheels:


### PR DESCRIPTION
`build_wheels` CI action should only run when pushing a tag, or on demand.