### PR TITLE
32bit support

### DIFF
--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -161,7 +161,7 @@ def test_filled_random_chunk(name, fill_type):
     elif name in ("serial", "threaded"):
         if fill_type in (FillType.ChunkCombinedCodes, FillType.ChunkCombinedOffsets):
             max_threshold = 99
-            mean_threshold = 0.14
+            mean_threshold = 0.142
         else:
             max_threshold = 135
             mean_threshold = 0.19


### PR DESCRIPTION
On 32-bit, Matplotlib agg backend produces RGB components that are sometimes 1 out compared to 64-bit, so ignore test image differences of 1 on 32-bit.