### PR TITLE
Use enum for Direction in follow_interior

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -57,6 +57,14 @@ protected:
     typedef uint32_t CacheItem;
     typedef CacheItem ZLevel;
 
+    // C++11 scoped enum for direction of movement from one quad to the next.
+    enum class Direction
+    {
+        Left = 1,
+        Straight = 0,
+        Right = -1
+    };
+
     struct Location
     {
         Location(index_t quad_, index_t forward_, index_t left_, bool is_upper_, bool on_boundary_)


### PR DESCRIPTION
Replace use of `int turn_left` with `Direction` enum in `BaseContourGenerator<>::follow_interior` as easier to understand and can use `switch` statements instead of multiple `if` statements.