### PR TITLE
Move mpl2014 line and fill_type handling up to wrap.cpp

### DIFF
--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -119,12 +119,13 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None, lin
     # Prepare args and kwargs for contour generator constructor.
     args = [x, y, z, mask]
     kwargs = {
-        "line_type": line_type,
-        "fill_type": fill_type,
         "x_chunk_size": x_chunk_size,
         "y_chunk_size": y_chunk_size,
     }
 
+    if name != "mpl2014":
+        kwargs["line_type"] = line_type
+        kwargs["fill_type"] = fill_type
     if cls.supports_corner_mask():
         kwargs["corner_mask"] = corner_mask
     if cls.supports_interp():

--- a/src/mpl2014.cpp
+++ b/src/mpl2014.cpp
@@ -327,8 +327,7 @@ void ParentCache::set_parent(index_t quad, ContourLine& contour_line)
 
 Mpl2014ContourGenerator::Mpl2014ContourGenerator(
     const CoordinateArray& x, const CoordinateArray& y, const CoordinateArray& z,
-    const MaskArray& mask, bool corner_mask, LineType line_type, FillType fill_type,
-    index_t x_chunk_size, index_t y_chunk_size)
+    const MaskArray& mask, bool corner_mask, index_t x_chunk_size, index_t y_chunk_size)
     : _x(x),
       _y(y),
       _z(z),
@@ -364,12 +363,6 @@ Mpl2014ContourGenerator::Mpl2014ContourGenerator(
             throw std::invalid_argument(
                 "If mask is set it must be a 2D array with the same shape as z");
     }
-
-    if (!supports_line_type(line_type))
-        throw std::invalid_argument("Unsupported LineType");
-
-    if (!supports_fill_type(fill_type))
-        throw std::invalid_argument("Unsupported FillType");
 
     if (x_chunk_size < 0 || y_chunk_size < 0)
         throw std::invalid_argument("chunk_size cannot be negative");
@@ -523,16 +516,6 @@ index_t Mpl2014ContourGenerator::calc_chunk_count(
     }
     else
         return 1;
-}
-
-FillType Mpl2014ContourGenerator::default_fill_type()
-{
-    return FillType::OuterCodes;
-}
-
-LineType Mpl2014ContourGenerator::default_line_type()
-{
-    return LineType::SeparateCodes;
 }
 
 void Mpl2014ContourGenerator::edge_interp(
@@ -1037,16 +1020,6 @@ Edge Mpl2014ContourGenerator::get_exit_edge(const QuadEdge& quad_edge, Dir dir) 
             default: assert(0 && "Invalid edge"); return Edge_None;
         }
     }
-}
-
-FillType Mpl2014ContourGenerator::get_fill_type() const
-{
-    return FillType::OuterCodes;
-}
-
-LineType Mpl2014ContourGenerator::get_line_type() const
-{
-    return LineType::SeparateCodes;
 }
 
 const double& Mpl2014ContourGenerator::get_point_x(index_t point) const
@@ -1750,16 +1723,6 @@ bool Mpl2014ContourGenerator::start_line(
     append_contour_line_to_vertices_and_codes(contour_line, vertices_list, codes_list);
 
     return VISITED(quad,1);
-}
-
-bool Mpl2014ContourGenerator::supports_fill_type(FillType fill_type)
-{
-    return fill_type == FillType::OuterCodes;
-}
-
-bool Mpl2014ContourGenerator::supports_line_type(LineType line_type)
-{
-    return line_type == LineType::SeparateCodes;
 }
 
 void Mpl2014ContourGenerator::write_cache(bool grid_only) const

--- a/src/mpl2014.h
+++ b/src/mpl2014.h
@@ -143,8 +143,6 @@
 #define CONTOURPY_MPL_2014_H
 
 #include "common.h"
-#include "fill_type.h"
-#include "line_type.h"
 #include <list>
 #include <iostream>
 #include <vector>
@@ -277,18 +275,16 @@ public:
     //     the y-direction is subdivided into.
     Mpl2014ContourGenerator(
         const CoordinateArray& x, const CoordinateArray& y, const CoordinateArray& z,
-        const MaskArray& mask, bool corner_mask, LineType line_type, FillType fill_type,
-        index_t x_chunk_size, index_t y_chunk_size);
+        const MaskArray& mask, bool corner_mask, index_t x_chunk_size, index_t y_chunk_size);
 
-    // Non-copyable.
+    // Non-copyable and non-moveable.
     Mpl2014ContourGenerator(const Mpl2014ContourGenerator& other) = delete;
-    const Mpl2014ContourGenerator& operator=(const Mpl2014ContourGenerator& other) = delete;
+    Mpl2014ContourGenerator(const Mpl2014ContourGenerator&& other) = delete;
+    Mpl2014ContourGenerator& operator=(const Mpl2014ContourGenerator& other) = delete;
+    Mpl2014ContourGenerator& operator=(const Mpl2014ContourGenerator&& other) = delete;
 
     // Destructor.
     ~Mpl2014ContourGenerator();
-
-    static FillType default_fill_type();
-    static LineType default_line_type();
 
     // Create and return polygons for a filled contour between the two
     // specified levels.
@@ -299,15 +295,9 @@ public:
 
     bool get_corner_mask() const;
 
-    FillType get_fill_type() const;
-    LineType get_line_type() const;
-
     // Create and return polygons for a line (i.e. non-filled) contour at the
     // specified level.
     py::tuple lines(const double& level);
-
-    static bool supports_fill_type(FillType fill_type);
-    static bool supports_line_type(LineType line_type);
 
 private:
     // Typedef for following either a boundary of the domain or the interior;

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -10,6 +10,9 @@
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)
 
+static LineType mpl20xx_line_type = LineType::SeparateCodes;
+static FillType mpl20xx_fill_type = FillType::OuterCodes;
+
 PYBIND11_MODULE(_contourpy, m) {
     m.doc() = "doc notes";
 
@@ -46,8 +49,6 @@ PYBIND11_MODULE(_contourpy, m) {
                       const CoordinateArray&,
                       const MaskArray&,
                       bool,
-                      LineType,
-                      FillType,
                       index_t,
                       index_t>(),
              py::arg("x"),
@@ -56,8 +57,6 @@ PYBIND11_MODULE(_contourpy, m) {
              py::arg("mask"),
              py::kw_only(),
              py::arg("corner_mask"),
-             py::arg("line_type"),
-             py::arg("fill_type"),
              py::arg("x_chunk_size") = 0,
              py::arg("y_chunk_size") = 0)
         .def("filled", &mpl2014::Mpl2014ContourGenerator::filled)
@@ -66,21 +65,19 @@ PYBIND11_MODULE(_contourpy, m) {
         .def_property_readonly("chunk_size", &mpl2014::Mpl2014ContourGenerator::get_chunk_size)
         .def_property_readonly("corner_mask", &mpl2014::Mpl2014ContourGenerator::get_corner_mask)
         .def_property_readonly_static(
-            "default_fill_type",
-            [](py::object /* self */) {
-                return mpl2014::Mpl2014ContourGenerator::default_fill_type();
-            })
+            "default_fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
         .def_property_readonly_static(
-            "default_line_type",
-            [](py::object /* self */) {
-                return mpl2014::Mpl2014ContourGenerator::default_line_type();
-            })
-        .def_property_readonly("fill_type", &mpl2014::Mpl2014ContourGenerator::get_fill_type)
-        .def_property_readonly("line_type", &mpl2014::Mpl2014ContourGenerator::get_line_type)
+            "default_line_type", [](py::object /* self */) {return mpl20xx_line_type;})
+        .def_property_readonly(
+            "fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
+        .def_property_readonly(
+            "line_type", [](py::object /* self */) {return mpl20xx_line_type;})
         .def_static("supports_corner_mask", []() {return true;})
-        .def_static("supports_fill_type", &mpl2014::Mpl2014ContourGenerator::supports_fill_type)
+        .def_static(
+            "supports_fill_type", [](FillType fill_type) {return fill_type == mpl20xx_fill_type;})
         .def_static("supports_interp", []() {return false;})
-        .def_static("supports_line_type", &mpl2014::Mpl2014ContourGenerator::supports_line_type)
+        .def_static(
+            "supports_line_type", [](LineType line_type) {return line_type == mpl20xx_line_type;})
         .def_static("supports_threads", []() {return false;});
 
     py::class_<SerialContourGenerator>(m, "SerialContourGenerator")


### PR DESCRIPTION
As `mpl2014` only supports a single `LineType` and `FillType`, here moving all `Line/FillType` handling up to `wrap.cpp` so that there is no dependency on `line_type.h` or `fill_type.h` in `Mpl2014ContourGenerator` class.