### PR TITLE
Use switch statement on config to determine possible starts

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -155,7 +155,7 @@ protected:
 
     void write_cache_quad(index_t quad) const;
 
-    ZLevel z_to_zlevel(const double& z_value);
+    ZLevel z_to_zlevel(const double& z_value) const;
 
 
 private:


### PR DESCRIPTION
This PR changes the logic used in `init_cache_levels_and_starts()` from `if` to `switch` statements using the numerical `config` of each quad in turn.  Saddle z-levels are also calculated here, rather than when first needed, using the `config` values.  Also reordered the 2 loops from (1) filled or not and (2) quad or corner to the other way around which speeds up the processing of masked quads.

This is a major change in the number of lines of code as it introduces repeated duplication of code to create the possible start flags.  It is justifiable on performance grounds as we only need to check for starts that are possible for each specific config.  Hence there is a reduction in the number of if-statements and also better grouping of the remaining checks, e.g. `start_in_row` doesn't need to be set multiple times.

Although the code is more verbose, it is arguably easier to understand when viewed in conjunction with the config plots such as `tests/baseline_images/config_filled.png`.

Performance benchmarks show significant improvement for the `simple` test dataset of ~20% for lines and ~5% for filled contours.  Changes to `random` dataset are not significant.