### PR TITLE
Minor improvments to BaseContourGenerator

### DIFF
--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -7,10 +7,10 @@
 
 
 // Point indices from current quad index.
-#define POINT_SW (quad-_nx-1)
-#define POINT_SE (quad-_nx)
-#define POINT_NW (quad-1)
 #define POINT_NE (quad)
+#define POINT_NW (quad-1)
+#define POINT_SE (quad-_nx)
+#define POINT_SW (quad-_nx-1)
 
 
 // CacheItem masks, only accessed directly to set.  To read, use accessors detailed below.
@@ -21,8 +21,8 @@
 #define MASK_MIDDLE_Z_LEVEL_1  (0x1 <<  2)  // middle z > lower_level
 #define MASK_MIDDLE_Z_LEVEL_2  (0x1 <<  3)  // middle z > upper_level
 #define MASK_MIDDLE            (MASK_MIDDLE_Z_LEVEL_1 | MASK_MIDDLE_Z_LEVEL_2)
-#define MASK_BOUNDARY_N        (0x1 <<  4)  // N edge of quad is a boundary.
-#define MASK_BOUNDARY_E        (0x1 <<  5)  // E edge of quad is a boundary.
+#define MASK_BOUNDARY_E        (0x1 <<  4)  // E edge of quad is a boundary.
+#define MASK_BOUNDARY_N        (0x1 <<  5)  // N edge of quad is a boundary.
 // EXISTS_QUAD bit is always used, but the 4 EXISTS_CORNER are only used if _corner_mask is true.
 // Only one of EXISTS_QUAD or EXISTS_??_CORNER is ever set per quad.
 #define MASK_EXISTS_QUAD       (0x1 <<  6)  // All of quad exists (is not masked).
@@ -30,16 +30,16 @@
 #define MASK_EXISTS_NW_CORNER  (0x1 <<  8)
 #define MASK_EXISTS_SE_CORNER  (0x1 <<  9)
 #define MASK_EXISTS_SW_CORNER  (0x1 << 10)
-#define MASK_EXISTS_ANY_CORNER (MASK_EXISTS_NW_CORNER | MASK_EXISTS_NE_CORNER | MASK_EXISTS_SW_CORNER | MASK_EXISTS_SE_CORNER)
+#define MASK_EXISTS_ANY_CORNER (MASK_EXISTS_NE_CORNER | MASK_EXISTS_NW_CORNER | MASK_EXISTS_SE_CORNER | MASK_EXISTS_SW_CORNER)
 #define MASK_EXISTS_ANY        (MASK_EXISTS_QUAD | MASK_EXISTS_ANY_CORNER)
-#define MASK_START_N           (0x1 << 11)  // N to E, filled and lines.
-#define MASK_START_E           (0x1 << 12)  // E to N, filled and lines.
-#define MASK_START_BOUNDARY_N  (0x1 << 13)  // Lines only.
-#define MASK_START_BOUNDARY_E  (0x1 << 14)  // Lines only.
+#define MASK_START_E           (0x1 << 11)  // E to N, filled and lines.
+#define MASK_START_N           (0x1 << 12)  // N to E, filled and lines.
+#define MASK_START_BOUNDARY_E  (0x1 << 13)  // Lines only.
+#define MASK_START_BOUNDARY_N  (0x1 << 14)  // Lines only.
 #define MASK_START_BOUNDARY_S  (0x1 << 15)  // Filled and lines.
 #define MASK_START_BOUNDARY_W  (0x1 << 16)  // Filled and lines.
-#define MASK_START_HOLE_N      (0x1 << 17)  // N boundary of EXISTS, E to W, filled only.
 #define MASK_START_CORNER      (0x1 << 18)  // Filled and lines.
+#define MASK_START_HOLE_N      (0x1 << 17)  // N boundary of EXISTS, E to W, filled only.
 #define MASK_ANY_START         (MASK_START_N | MASK_START_E | MASK_START_BOUNDARY_N | MASK_START_BOUNDARY_E | MASK_START_BOUNDARY_S | MASK_START_BOUNDARY_W | MASK_START_HOLE_N | MASK_START_CORNER)
 #define MASK_LOOK_N            (0x1 << 19)
 #define MASK_LOOK_S            (0x1 << 20)
@@ -53,8 +53,8 @@
 #define Z_SE                       Z_LEVEL(POINT_SE)
 #define Z_SW                       Z_LEVEL(POINT_SW)
 #define MIDDLE_Z_LEVEL(quad)       ((_cache[quad] & MASK_MIDDLE) >> 2)
-#define BOUNDARY_N(quad)           (_cache[quad] & MASK_BOUNDARY_N)
 #define BOUNDARY_E(quad)           (_cache[quad] & MASK_BOUNDARY_E)
+#define BOUNDARY_N(quad)           (_cache[quad] & MASK_BOUNDARY_N)
 #define BOUNDARY_S(quad)           (_cache[quad-_nx] & MASK_BOUNDARY_N)
 #define BOUNDARY_W(quad)           (_cache[quad-1] & MASK_BOUNDARY_E)
 #define EXISTS_QUAD(quad)          (_cache[quad] & MASK_EXISTS_QUAD)
@@ -64,19 +64,19 @@
 #define EXISTS_SW_CORNER(quad)     (_cache[quad] & MASK_EXISTS_SW_CORNER)
 #define EXISTS_ANY(quad)           (_cache[quad] & MASK_EXISTS_ANY)
 #define EXISTS_ANY_CORNER(quad)    (_cache[quad] & MASK_EXISTS_ANY_CORNER)
-#define EXISTS_N_EDGE(quad)        (_cache[quad] & (MASK_EXISTS_QUAD | MASK_EXISTS_NW_CORNER | MASK_EXISTS_NE_CORNER))
 #define EXISTS_E_EDGE(quad)        (_cache[quad] & (MASK_EXISTS_QUAD | MASK_EXISTS_NE_CORNER | MASK_EXISTS_SE_CORNER))
+#define EXISTS_N_EDGE(quad)        (_cache[quad] & (MASK_EXISTS_QUAD | MASK_EXISTS_NW_CORNER | MASK_EXISTS_NE_CORNER))
 #define EXISTS_S_EDGE(quad)        (_cache[quad] & (MASK_EXISTS_QUAD | MASK_EXISTS_SW_CORNER | MASK_EXISTS_SE_CORNER))
 #define EXISTS_W_EDGE(quad)        (_cache[quad] & (MASK_EXISTS_QUAD | MASK_EXISTS_NW_CORNER | MASK_EXISTS_SW_CORNER))
 // Note that EXISTS_NE_CORNER(quad) is equivalent to BOUNDARY_SW(quad), etc.
-#define START_N(quad)              (_cache[quad] & MASK_START_N)
 #define START_E(quad)              (_cache[quad] & MASK_START_E)
-#define START_BOUNDARY_N(quad)     (_cache[quad] & MASK_START_BOUNDARY_N)
+#define START_N(quad)              (_cache[quad] & MASK_START_N)
 #define START_BOUNDARY_E(quad)     (_cache[quad] & MASK_START_BOUNDARY_E)
+#define START_BOUNDARY_N(quad)     (_cache[quad] & MASK_START_BOUNDARY_N)
 #define START_BOUNDARY_S(quad)     (_cache[quad] & MASK_START_BOUNDARY_S)
 #define START_BOUNDARY_W(quad)     (_cache[quad] & MASK_START_BOUNDARY_W)
-#define START_HOLE_N(quad)         (_cache[quad] & MASK_START_HOLE_N)
 #define START_CORNER(quad)         (_cache[quad] & MASK_START_CORNER)
+#define START_HOLE_N(quad)         (_cache[quad] & MASK_START_HOLE_N)
 #define ANY_START(quad)            (_cache[quad] & MASK_ANY_START)
 #define LOOK_N(quad)               (_cache[quad] & MASK_LOOK_N)
 #define LOOK_S(quad)               (_cache[quad] & MASK_LOOK_S)


### PR DESCRIPTION
A few minor improvements to `BaseContourGenerator`:
* Reorder `#defines` more alphabetically.
* Improvments to `if` and `switch` statements.
* Reuse of `z_to_zlevel()` rather than duplicating code.
