### PR TITLE
Rename BUILD_* to CONTOURPY_*

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install contourpy (debug)
         if: matrix.debug == 1
         run: |
-          BUILD_DEBUG=1 BUILD_CXX11=1 python -m pip install -ve .[test]
+          CONTOURPY_DEBUG=1 CONTOURPY_CXX11=1 python -m pip install -ve .[test]
           python -m pip list
 
       - name: Install cppcheck

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To build and install in developer's mode
 
 To build in debug mode, which enables `assert`s in C++ code
 
-    BUILD_DEBUG=1 pip install -ve .
+    CONTOURPY_DEBUG=1 pip install -ve .
 
 To run tests
 

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,12 @@ def get_version():
 
 __version__ = get_version()
 
-# Set environment variable BUILD_DEBUG=1 if you want to enable asserts in C++ code.
-build_debug = int(os.environ.get("BUILD_DEBUG", 0))
+# Set environment variable CONTOURPY_DEBUG=1 if you want to enable asserts in C++ code.
+CONTOURPY_DEBUG = int(os.environ.get("CONTOURPY_DEBUG", 0))
 
-# Set environment variable BUILD_CXX11=1 if you want to use C++11 standard rather than the highest
-# supported standard.
-build_cxx11 = int(os.environ.get("BUILD_CXX11", 0))
+# Set environment variable CONTOURPY_CXX11=1 if you want to use C++11 standard rather than the
+# highest supported standard.
+CONTOURPY_CXX11 = int(os.environ.get("CONTOURPY_CXX11", 0))
 
 
 define_macros = [
@@ -33,11 +33,11 @@ define_macros = [
 ]
 undef_macros = []
 
-if build_debug:
+if CONTOURPY_DEBUG:
     define_macros.append(("DEBUG", 1))
     undef_macros.append("NDEBUG")
 
-if build_cxx11:
+if CONTOURPY_CXX11:
     cxx_std = 11
     cmdclass = {}
 else:
@@ -65,8 +65,8 @@ _contourpy = Pybind11Extension(
     ],
     cxx_std=cxx_std,
     define_macros=define_macros + [
-        ("BUILD_DEBUG", build_debug),
-        ("BUILD_CXX11", build_cxx11),
+        ("CONTOURPY_DEBUG", CONTOURPY_DEBUG),
+        ("CONTOURPY_CXX11", CONTOURPY_CXX11),
     ],
     undef_macros=undef_macros,
 )

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -17,8 +17,8 @@ static FillType mpl20xx_fill_type = FillType::OuterCodes;
 PYBIND11_MODULE(_contourpy, m) {
     m.doc() = "doc notes";
 
-    m.attr("BUILD_DEBUG") = BUILD_DEBUG;
-    m.attr("BUILD_CXX11") = BUILD_CXX11;
+    m.attr("CONTOURPY_DEBUG") = CONTOURPY_DEBUG;
+    m.attr("CONTOURPY_CXX11") = CONTOURPY_CXX11;
     m.attr("__version__") = MACRO_STRINGIFY(CONTOURPY_VERSION);
 
     py::enum_<FillType>(m, "FillType")


### PR DESCRIPTION
Rename environment variables BUILD_DEBUG and BUILD_CXX11 to CONTOURPY_BUILD and CONTOURPY_CXX11 instead, for increased clarity.