### PR TITLE
Improvements for conda build

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -25,6 +25,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.1.2
         env:
           CIBW_BUILD: cp37-* cp38-* cp39-*
+          CIBW_BUILD_VERBOSITY: 2
 
       - uses: actions/upload-artifact@v2
         with:

--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -77,7 +77,7 @@
 #define START_BOUNDARY_W(quad)     (_cache[quad] & MASK_START_BOUNDARY_W)
 #define START_CORNER(quad)         (_cache[quad] & MASK_START_CORNER)
 #define START_HOLE_N(quad)         (_cache[quad] & MASK_START_HOLE_N)
-#define ANY_START(quad)            (_cache[quad] & MASK_ANY_START)
+#define ANY_START(quad)            ((_cache[quad] & MASK_ANY_START) != 0)
 #define LOOK_N(quad)               (_cache[quad] & MASK_LOOK_N)
 #define LOOK_S(quad)               (_cache[quad] & MASK_LOOK_S)
 #define NO_STARTS_IN_ROW(quad)     (_cache[quad] & MASK_NO_STARTS_IN_ROW)

--- a/src/serial.h
+++ b/src/serial.h
@@ -12,7 +12,7 @@ public:
         bool quad_as_tri, ZInterp z_interp, index_t x_chunk_size, index_t y_chunk_size);
 
 private:
-    friend class BaseContourGenerator;
+    friend class BaseContourGenerator<SerialContourGenerator>;
 
     // Dummy Lock class which is the single-threaded version of ThreadedContourGenerator::Lock and
     // does not do anything, allowing base class code to use Lock objects for both serial and

--- a/src/threaded.h
+++ b/src/threaded.h
@@ -17,7 +17,7 @@ public:
     index_t get_thread_count() const;
 
 private:
-    friend class BaseContourGenerator;
+    friend class BaseContourGenerator<ThreadedContourGenerator>;
 
     // Lock class is used to lock access to a single thread when creating/modifying Python objects.
     // Automatically unlocks in destructor or when unlock() member function is called.


### PR DESCRIPTION
Improvement to assist with conda builds:

  1. Verbose `cibuildwheel` action to identify errors and warnings.
  2. More specific templated `friend` declarations.
  3. Explicit conversion of `ANY_START(quad)` to `bool`.

Item 2 is the important one here, it was identified when trying to build packages on conda-forge that use an older MSVC compiler.