### PR TITLE
All ContourGenerator classes implement the same readonly properties

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -36,6 +36,8 @@ public:
 
     bool get_quad_as_tri() const;
 
+    ZInterp get_z_interp() const;
+
     py::sequence filled(double lower_level, double upper_level);
     py::sequence lines(double level);
 

--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -1120,6 +1120,12 @@ bool BaseContourGenerator<Derived>::get_quad_as_tri() const
 }
 
 template <typename Derived>
+ZInterp BaseContourGenerator<Derived>::get_z_interp() const
+{
+    return _z_interp;
+}
+
+template <typename Derived>
 void BaseContourGenerator<Derived>::init_cache_grid(const MaskArray& mask)
 {
     index_t i, j, quad;

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -62,21 +62,24 @@ PYBIND11_MODULE(_contourpy, m) {
         .def("lines", &Mpl2005ContourGenerator::lines)
         .def_property_readonly("chunk_count", &Mpl2005ContourGenerator::get_chunk_count)
         .def_property_readonly("chunk_size", &Mpl2005ContourGenerator::get_chunk_size)
-        .def_property_readonly("corner_mask", []() {return false;})
-        .def_property_readonly_static(
-            "default_fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
-        .def_property_readonly_static(
-            "default_line_type", [](py::object /* self */) {return mpl20xx_line_type;})
-        .def_property_readonly(
-            "fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
-        .def_property_readonly(
-            "line_type", [](py::object /* self */) {return mpl20xx_line_type;})
-        .def_property_readonly("quad_as_tri", []() {return false;})
+        .def_property_readonly("corner_mask", [](py::object /* self */) {return false;})
+        .def_property_readonly("fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
+        .def_property_readonly("line_type", [](py::object /* self */) {return mpl20xx_line_type;})
+        .def_property_readonly("quad_as_tri", [](py::object /* self */) {return false;})
+        .def_property_readonly("thread_count", [](py::object /* self */) {return 1;})
+        .def_property_readonly("z_interp", [](py::object /* self */) {return ZInterp::Linear;})
+        .def_property_readonly_static("default_fill_type", [](py::object /* self */) {
+            return mpl20xx_fill_type;})
+        .def_property_readonly_static("default_line_type", [](py::object /* self */) {
+            return mpl20xx_line_type;})
+        .def_property_readonly("fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
+        .def_property_readonly("line_type", [](py::object /* self */) {return mpl20xx_line_type;})
+        .def_property_readonly("quad_as_tri", [](py::object /* self */) {return false;})
         .def_static("supports_corner_mask", []() {return false;})
-        .def_static(
-            "supports_fill_type", [](FillType fill_type) {return fill_type == mpl20xx_fill_type;})
-        .def_static(
-            "supports_line_type", [](LineType line_type) {return line_type == mpl20xx_line_type;})
+        .def_static("supports_fill_type", [](FillType fill_type) {
+            return fill_type == mpl20xx_fill_type;})
+        .def_static("supports_line_type", [](LineType line_type) {
+            return line_type == mpl20xx_line_type;})
         .def_static("supports_quad_as_tri", []() {return false;})
         .def_static("supports_threads", []() {return false;})
         .def_static("supports_z_interp", []() {return false;});
@@ -102,20 +105,20 @@ PYBIND11_MODULE(_contourpy, m) {
         .def_property_readonly("chunk_count", &mpl2014::Mpl2014ContourGenerator::get_chunk_count)
         .def_property_readonly("chunk_size", &mpl2014::Mpl2014ContourGenerator::get_chunk_size)
         .def_property_readonly("corner_mask", &mpl2014::Mpl2014ContourGenerator::get_corner_mask)
-        .def_property_readonly_static(
-            "default_fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
-        .def_property_readonly_static(
-            "default_line_type", [](py::object /* self */) {return mpl20xx_line_type;})
-        .def_property_readonly(
-            "fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
-        .def_property_readonly(
-            "line_type", [](py::object /* self */) {return mpl20xx_line_type;})
-        .def_property_readonly("quad_as_tri", []() {return false;})
+        .def_property_readonly("fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
+        .def_property_readonly("line_type", [](py::object /* self */) {return mpl20xx_line_type;})
+        .def_property_readonly("quad_as_tri", [](py::object /* self */) {return false;})
+        .def_property_readonly("thread_count", [](py::object /* self */) {return 1;})
+        .def_property_readonly("z_interp", [](py::object /* self */) {return ZInterp::Linear;})
+        .def_property_readonly_static("default_fill_type", [](py::object /* self */) {
+            return mpl20xx_fill_type;})
+        .def_property_readonly_static("default_line_type", [](py::object /* self */) {
+            return mpl20xx_line_type;})
         .def_static("supports_corner_mask", []() {return true;})
-        .def_static(
-            "supports_fill_type", [](FillType fill_type) {return fill_type == mpl20xx_fill_type;})
-        .def_static(
-            "supports_line_type", [](LineType line_type) {return line_type == mpl20xx_line_type;})
+        .def_static("supports_fill_type", [](FillType fill_type) {
+            return fill_type == mpl20xx_fill_type;})
+        .def_static("supports_line_type", [](LineType line_type) {
+            return line_type == mpl20xx_line_type;})
         .def_static("supports_quad_as_tri", []() {return false;})
         .def_static("supports_threads", []() {return false;})
         .def_static("supports_z_interp", []() {return false;});
@@ -150,19 +153,15 @@ PYBIND11_MODULE(_contourpy, m) {
         .def_property_readonly("chunk_count", &SerialContourGenerator::get_chunk_count)
         .def_property_readonly("chunk_size", &SerialContourGenerator::get_chunk_size)
         .def_property_readonly("corner_mask", &SerialContourGenerator::get_corner_mask)
-        .def_property_readonly_static(
-            "default_fill_type",
-            [](py::object /* self */) {
-                return SerialContourGenerator::default_fill_type();
-            })
-        .def_property_readonly_static(
-            "default_line_type",
-            [](py::object /* self */) {
-                return SerialContourGenerator::default_line_type();
-            })
         .def_property_readonly("fill_type", &SerialContourGenerator::get_fill_type)
         .def_property_readonly("line_type", &SerialContourGenerator::get_line_type)
         .def_property_readonly("quad_as_tri", &SerialContourGenerator::get_quad_as_tri)
+        .def_property_readonly("thread_count", [](py::object /* self */) {return 1;})
+        .def_property_readonly("z_interp", &SerialContourGenerator::get_z_interp)
+        .def_property_readonly_static("default_fill_type", [](py::object /* self */) {
+                return SerialContourGenerator::default_fill_type();})
+        .def_property_readonly_static("default_line_type", [](py::object /* self */) {
+                return SerialContourGenerator::default_line_type();})
         .def_static("supports_corner_mask", []() {return true;})
         .def_static("supports_fill_type", &SerialContourGenerator::supports_fill_type)
         .def_static("supports_line_type", &SerialContourGenerator::supports_line_type)
@@ -202,20 +201,15 @@ PYBIND11_MODULE(_contourpy, m) {
         .def_property_readonly("chunk_count", &ThreadedContourGenerator::get_chunk_count)
         .def_property_readonly("chunk_size", &ThreadedContourGenerator::get_chunk_size)
         .def_property_readonly("corner_mask", &ThreadedContourGenerator::get_corner_mask)
-        .def_property_readonly_static(
-            "default_fill_type",
-            [](py::object /* self */) {
-                return ThreadedContourGenerator::default_fill_type();
-            })
-        .def_property_readonly_static(
-            "default_line_type",
-            [](py::object /* self */) {
-                return ThreadedContourGenerator::default_line_type();
-            })
         .def_property_readonly("fill_type", &ThreadedContourGenerator::get_fill_type)
         .def_property_readonly("line_type", &ThreadedContourGenerator::get_line_type)
         .def_property_readonly("quad_as_tri", &ThreadedContourGenerator::get_quad_as_tri)
         .def_property_readonly("thread_count", &ThreadedContourGenerator::get_thread_count)
+        .def_property_readonly("z_interp", &ThreadedContourGenerator::get_z_interp)
+        .def_property_readonly_static("default_fill_type", [](py::object /* self */) {
+            return ThreadedContourGenerator::default_fill_type();})
+        .def_property_readonly_static("default_line_type", [](py::object /* self */) {
+            return ThreadedContourGenerator::default_line_type();})
         .def_static("supports_corner_mask", []() {return true;})
         .def_static("supports_fill_type", &ThreadedContourGenerator::supports_fill_type)
         .def_static("supports_line_type", &ThreadedContourGenerator::supports_line_type)

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -216,6 +216,21 @@ def test_total_chunk_count(xyz_7x5_as_arrays, name, total_chunk_count, ret_chunk
     assert (ret_x_chunk_count-1)*ret_x_chunk_size < nx-1
 
 
+@pytest.mark.parametrize("name", util_test.all_names())
+def test_properties(xyz_3x3_as_lists, name):
+    # Test that each ContourGenerator class implements all the required properties.
+    x, y, z = xyz_3x3_as_lists
+    cont_gen = contourpy.contour_generator(x, y, z, name=name)
+    _, _ = cont_gen.chunk_count
+    _, _ = cont_gen.chunk_size
+    _ = cont_gen.corner_mask
+    _ = cont_gen.fill_type
+    _ = cont_gen.line_type
+    _ = cont_gen.quad_as_tri
+    _ = cont_gen.thread_count
+    _ = cont_gen.z_interp
+
+
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_quad_as_tri(xyz_3x3_as_lists, name):
     x, y, z = xyz_3x3_as_lists

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -51,15 +51,6 @@ def test_supports_fill_type(class_name):
 
 
 @pytest.mark.parametrize("class_name", util_test.all_class_names())
-def test_supports_z_interp(class_name):
-    cls = get_class_from_name(class_name)
-    supports = cls.supports_z_interp()
-    assert isinstance(supports, bool)
-    expect = class_name not in ("Mpl2005ContourGenerator", "Mpl2014ContourGenerator")
-    assert supports == expect
-
-
-@pytest.mark.parametrize("class_name", util_test.all_class_names())
 def test_supports_line_type(class_name):
     cls = get_class_from_name(class_name)
     supports = cls.supports_line_type(LineType.SeparateCodes)
@@ -87,4 +78,13 @@ def test_supports_threads(class_name):
     supports = cls.supports_threads()
     assert isinstance(supports, bool)
     expect = class_name == "ThreadedContourGenerator"
+    assert supports == expect
+
+
+@pytest.mark.parametrize("class_name", util_test.all_class_names())
+def test_supports_z_interp(class_name):
+    cls = get_class_from_name(class_name)
+    supports = cls.supports_z_interp()
+    assert isinstance(supports, bool)
+    expect = class_name not in ("Mpl2005ContourGenerator", "Mpl2014ContourGenerator")
     assert supports == expect


### PR DESCRIPTION
Add readonly properties to all contour generator classes so that they implement the same interface. Add tests for this too.