### PR TITLE
Support string to enum conversion in contour_generator

### DIFF
--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -37,6 +37,7 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None, lin
     # Check arguments: z.
     if z.ndim != 2:
         raise TypeError(f"Input z must be 2D, not {z.ndim}D")
+
     if z.shape[0] < 2 or z.shape[1] < 2:
         raise TypeError(f"Input z must be at least a (2, 2) shaped array, but has shape {z.shape}")
 
@@ -45,6 +46,7 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None, lin
     # Check arguments: x and y.
     if x.ndim != y.ndim:
         raise TypeError(f"Number of dimensions of x ({x.ndim}) and y ({y.ndim}) do not match")
+
     if x.ndim == 0:
         x = np.arange(nx)
         y = np.arange(ny)
@@ -98,12 +100,18 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None, lin
     # Check arguments: line_type.
     if line_type is None:
         line_type = cls.default_line_type
+    elif isinstance(line_type, str):
+        line_type = LineType._from_string(line_type)
+
     if not cls.supports_line_type(line_type):
         raise ValueError(f"{name} contour generator does not support line_type {line_type}")
 
     # Check arguments: fill_type.
     if fill_type is None:
         fill_type = cls.default_fill_type
+    elif isinstance(fill_type, str):
+        fill_type = FillType._from_string(fill_type)
+
     if not cls.supports_fill_type(fill_type):
         raise ValueError(f"{name} contour generator does not support fill_type {fill_type}")
 
@@ -114,6 +122,11 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None, lin
         raise ValueError(f"{name} contour generator does not support quad_as_tri=True")
 
     # Check arguments: z_interp.
+    if z_interp is None:
+        z_interp = ZInterp.Linear
+    elif isinstance(z_interp, str):
+        z_interp = ZInterp._from_string(z_interp)
+
     if z_interp != ZInterp.Linear and not cls.supports_z_interp():
         raise ValueError(f"{name} contour generator does not support z_interp {z_interp}")
 
@@ -131,12 +144,16 @@ def contour_generator(x, y, z, name=None, corner_mask=None, chunk_size=None, lin
     if name not in ("mpl2005", "mpl2014"):
         kwargs["line_type"] = line_type
         kwargs["fill_type"] = fill_type
+
     if cls.supports_corner_mask():
         kwargs["corner_mask"] = corner_mask
+
     if cls.supports_quad_as_tri():
         kwargs["quad_as_tri"] = quad_as_tri
+
     if cls.supports_z_interp():
         kwargs["z_interp"] = z_interp
+
     if cls.supports_threads():
         kwargs["thread_count"] = thread_count
 

--- a/src/fill_type.cpp
+++ b/src/fill_type.cpp
@@ -1,6 +1,24 @@
 #include "fill_type.h"
 #include <iostream>
 
+FillType FillType_from_string(const std::string& string)
+{
+    if       (string == "OuterCodes")
+        return FillType::OuterCodes;
+    else if  (string == "OuterOffsets")
+        return FillType::OuterOffsets;
+    else if  (string == "ChunkCombinedCodes")
+        return FillType::ChunkCombinedCodes;
+    else if  (string == "ChunkCombinedOffsets")
+        return FillType::ChunkCombinedOffsets;
+    else if  (string == "ChunkCombinedCodesOffsets")
+        return FillType::ChunkCombinedCodesOffsets;
+    else if  (string == "ChunkCombinedOffsets2")
+        return FillType::ChunkCombinedOffsets2;
+    else
+        throw std::invalid_argument("'" + string + "' is not a valid FillType");
+}
+
 std::ostream &operator<<(std::ostream &os, const FillType& fill_type)
 {
     switch (fill_type) {

--- a/src/fill_type.h
+++ b/src/fill_type.h
@@ -2,6 +2,7 @@
 #define CONTOURPY_FILL_TYPE_H
 
 #include <iosfwd>
+#include <string>
 
 // C++11 scoped enum, must be fully qualified to use.
 enum class FillType
@@ -13,6 +14,8 @@ enum class FillType
     ChunkCombinedCodesOffsets = 205,
     ChunkCombinedOffsets2 = 206,
 };
+
+FillType FillType_from_string(const std::string& string);
 
 std::ostream &operator<<(std::ostream &os, const FillType& fill_type);
 

--- a/src/line_type.cpp
+++ b/src/line_type.cpp
@@ -1,6 +1,20 @@
 #include "line_type.h"
 #include <iostream>
 
+LineType LineType_from_string(const std::string& string)
+{
+    if       (string == "Separate")
+        return LineType::Separate;
+    else if  (string == "SeparateCodes")
+        return LineType::SeparateCodes;
+    else if  (string == "ChunkCombinedCodes")
+        return LineType::ChunkCombinedCodes;
+    else if  (string == "ChunkCombinedOffsets")
+        return LineType::ChunkCombinedOffsets;
+    else
+        throw std::invalid_argument("'" + string + "' is not a valid LineType");
+}
+
 std::ostream &operator<<(std::ostream &os, const LineType& line_type)
 {
     switch (line_type) {

--- a/src/line_type.h
+++ b/src/line_type.h
@@ -2,6 +2,7 @@
 #define CONTOURPY_LINE_TYPE_H
 
 #include <iosfwd>
+#include <string>
 
 // C++11 scoped enum, must be fully qualified to use.
 enum class LineType
@@ -11,6 +12,8 @@ enum class LineType
     ChunkCombinedCodes = 103,
     ChunkCombinedOffsets = 104,
 };
+
+LineType LineType_from_string(const std::string& string);
 
 std::ostream &operator<<(std::ostream &os, const LineType& line_type);
 

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -28,19 +28,22 @@ PYBIND11_MODULE(_contourpy, m) {
         .value("ChunkCombinedOffsets", FillType::ChunkCombinedOffsets)
         .value("ChunkCombinedCodesOffsets", FillType::ChunkCombinedCodesOffsets)
         .value("ChunkCombinedOffsets2", FillType::ChunkCombinedOffsets2)
-        .export_values();
+        .export_values()
+        .def_static("_from_string", &FillType_from_string);
 
     py::enum_<LineType>(m, "LineType")
         .value("Separate", LineType::Separate)
         .value("SeparateCodes", LineType::SeparateCodes)
         .value("ChunkCombinedCodes", LineType::ChunkCombinedCodes)
         .value("ChunkCombinedOffsets", LineType::ChunkCombinedOffsets)
-        .export_values();
+        .export_values()
+        .def_static("_from_string", &LineType_from_string);
 
     py::enum_<ZInterp>(m, "ZInterp")
         .value("Linear", ZInterp::Linear)
         .value("Log", ZInterp::Log)
-        .export_values();
+        .export_values()
+        .def_static("_from_string", &ZInterp_from_string);
 
     m.def("max_threads", &Util::get_max_threads, "docs");
 

--- a/src/z_interp.cpp
+++ b/src/z_interp.cpp
@@ -1,6 +1,16 @@
 #include "z_interp.h"
 #include <iostream>
 
+ZInterp ZInterp_from_string(const std::string& string)
+{
+    if      (string == "Linear")
+        return ZInterp::Linear;
+    else if (string == "Log")
+        return ZInterp::Log;
+    else
+        throw std::invalid_argument("'" + string + "' is not a valid ZInterp");
+}
+
 std::ostream &operator<<(std::ostream &os, const ZInterp& z_interp)
 {
     switch (z_interp) {

--- a/src/z_interp.h
+++ b/src/z_interp.h
@@ -2,6 +2,7 @@
 #define CONTOURPY_Z_INTERP_H
 
 #include <iosfwd>
+#include <string>
 
 // Enum for type of interpolation used to find intersection of contour lines
 // with grid cell edges.
@@ -12,6 +13,8 @@ enum class ZInterp
     Linear = 1,
     Log = 2
 };
+
+ZInterp ZInterp_from_string(const std::string& string);
 
 std::ostream &operator<<(std::ostream &os, const ZInterp& z_interp);
 

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -256,3 +256,12 @@ def test_thread_count(xyz_7x5_as_arrays, chunk_size, thread_count):
         assert ret_thread_count == min(max_threads, ret_chunk_count)
     else:
         assert ret_thread_count == min(max_threads, ret_chunk_count, ret_thread_count)
+
+
+def test_enums_as_strings(xyz_3x3_as_lists):
+    x, y, z = xyz_3x3_as_lists
+    cg = contourpy.contour_generator(
+        x, y, z, line_type="SeparateCodes", fill_type="ChunkCombinedCodesOffsets", z_interp="Log")
+    assert cg.line_type == contourpy.LineType.SeparateCodes
+    assert cg.fill_type == contourpy.FillType.ChunkCombinedCodesOffsets
+    assert cg.z_interp == contourpy.ZInterp.Log

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -39,3 +39,14 @@ def test_all_z_interps():
     for name, enum in dict(ZInterp.__members__).items():
         assert name in z_interps
         assert z_interps[name] == enum.value
+
+
+@pytest.mark.parametrize("enum_type", [FillType, LineType, ZInterp])
+def test_string_to_enum(enum_type):
+    for name, enum in enum_type.__members__.items():
+        line_type = enum_type._from_string(name)
+        assert line_type == enum
+
+    msg = f"'unknown' is not a valid {enum_type.__name__}"
+    with pytest.raises(ValueError, match=msg):
+        enum_type._from_string("unknown")


### PR DESCRIPTION
Allows use of e.g. `contour_generator(..., line_type="SeparateCodes")` and similar for `fill_type` and `z_interp`.