### PR TITLE
Improved build system

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,9 +22,9 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.2.2
+        uses: pypa/cibuildwheel@v2.3.1
         env:
-          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
+          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* pp37-*
           CIBW_BUILD_VERBOSITY: 2
 
       - uses: actions/upload-artifact@v2
@@ -47,11 +47,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pybind11>=2.6 setuptools>=42 wheel
+          pip install build
 
       - name: Build sdist
         run: |
-          python setup.py sdist
+          python -m build --sdist
 
       - uses: actions/upload-artifact@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
+    "build",
     "pybind11>=2.6",
     "setuptools>=42",
-    "wheel",
 ]


### PR DESCRIPTION
It is recommended to build `sdist`s using
```
pip install build
python -m build --sdist
```
for full PEP517/518 compliance rather than the older `python setup.py sdist`.

Also support building of PyPy 3.7 packages.