### PR TITLE
Default line/fill type for serial/threaded

### DIFF
--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -268,7 +268,7 @@ void BaseContourGenerator<Derived>::closed_line_wrapper(
 template <typename Derived>
 FillType BaseContourGenerator<Derived>::default_fill_type()
 {
-    FillType fill_type = FillType::OuterCodes;
+    FillType fill_type = FillType::OuterOffsets;
     assert(supports_fill_type(fill_type));
     return fill_type;
 }
@@ -276,7 +276,7 @@ FillType BaseContourGenerator<Derived>::default_fill_type()
 template <typename Derived>
 LineType BaseContourGenerator<Derived>::default_line_type()
 {
-    LineType line_type = LineType::SeparateCodes;
+    LineType line_type = LineType::Separate;
     assert(supports_line_type(line_type));
     return line_type;
 }

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -15,7 +15,10 @@ def test_default_fill_type(class_name):
     cls = get_class_from_name(class_name)
     default = cls.default_fill_type
     assert isinstance(default, FillType)
-    expect = FillType.OuterCodes
+    if class_name in ("Mpl2005ContourGenerator", "Mpl2014ContourGenerator"):
+        expect = FillType.OuterCodes
+    else:
+        expect = FillType.OuterOffsets
     assert default == expect
 
 
@@ -24,7 +27,10 @@ def test_default_line_type(class_name):
     cls = get_class_from_name(class_name)
     default = cls.default_line_type
     assert isinstance(default, LineType)
-    expect = LineType.SeparateCodes
+    if class_name in ("Mpl2005ContourGenerator", "Mpl2014ContourGenerator"):
+        expect = LineType.SeparateCodes
+    else:
+        expect = LineType.Separate
     assert default == expect
 
 

--- a/tests/util_config.py
+++ b/tests/util_config.py
@@ -1,4 +1,4 @@
-from contourpy import contour_generator
+from contourpy import contour_generator, LineType
 from enum import Enum
 import io
 import matplotlib
@@ -143,7 +143,9 @@ class Config:
             filled = cont_gen.filled(zlower, zupper)
             lines = filled[0]
         else:
-            lines = cont_gen.lines(zlower)[0]
+            lines = cont_gen.lines(zlower)
+            if cont_gen.line_type == LineType.SeparateCodes:
+                lines = lines[0]
 
         # May be 0..2 polygons, and there cannot be any holes.
         for points in lines:


### PR DESCRIPTION
For `serial` and `threaded` algorithms, set default line type to be `LineType.Separate` and default fill type to `FillType.OuterOffsets`.