### PR TITLE
String to enum moved from C++ to python

### DIFF
--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -1,10 +1,12 @@
+import numpy as np
+
 from .chunk import calc_chunk_sizes
 from ._contourpy import (
     max_threads, FillType, LineType, Mpl2005ContourGenerator, Mpl2014ContourGenerator,
     SerialContourGenerator, ThreadedContourGenerator, ZInterp
 )
+from .enum_util import as_fill_type, as_line_type, as_z_interp
 from ._version import __version__
-import numpy as np
 
 
 __all__ = [
@@ -25,6 +27,9 @@ def _name_to_class(name):
     class_name = f"{name.capitalize()}ContourGenerator"
     cls = globals()[class_name]
     return cls
+
+
+_valid_names = ["mpl2005", "mpl2014", "serial", "threaded"]
 
 
 def contour_generator(x=None, y=None, z=None, *, name=None, corner_mask=None, line_type=None,
@@ -81,7 +86,7 @@ def contour_generator(x=None, y=None, z=None, *, name=None, corner_mask=None, li
     if name is None:
         name = "serial"  # Default algorithm.
 
-    if name not in ("mpl2005", "mpl2014", "serial", "threaded"):
+    if name not in _valid_names:
         raise ValueError(f"Unrecognised contour generator name: {name}")
 
     # Check arguments: chunk_size, chunk_count and total_chunk_count.
@@ -100,8 +105,8 @@ def contour_generator(x=None, y=None, z=None, *, name=None, corner_mask=None, li
     # Check arguments: line_type.
     if line_type is None:
         line_type = cls.default_line_type
-    elif isinstance(line_type, str):
-        line_type = LineType._from_string(line_type)
+    else:
+        line_type = as_line_type(line_type)
 
     if not cls.supports_line_type(line_type):
         raise ValueError(f"{name} contour generator does not support line_type {line_type}")
@@ -109,8 +114,8 @@ def contour_generator(x=None, y=None, z=None, *, name=None, corner_mask=None, li
     # Check arguments: fill_type.
     if fill_type is None:
         fill_type = cls.default_fill_type
-    elif isinstance(fill_type, str):
-        fill_type = FillType._from_string(fill_type)
+    else:
+        fill_type = as_fill_type(fill_type)
 
     if not cls.supports_fill_type(fill_type):
         raise ValueError(f"{name} contour generator does not support fill_type {fill_type}")
@@ -124,8 +129,8 @@ def contour_generator(x=None, y=None, z=None, *, name=None, corner_mask=None, li
     # Check arguments: z_interp.
     if z_interp is None:
         z_interp = ZInterp.Linear
-    elif isinstance(z_interp, str):
-        z_interp = ZInterp._from_string(z_interp)
+    else:
+        z_interp = as_z_interp(z_interp)
 
     if z_interp != ZInterp.Linear and not cls.supports_z_interp():
         raise ValueError(f"{name} contour generator does not support z_interp {z_interp}")

--- a/lib/contourpy/enum_util.py
+++ b/lib/contourpy/enum_util.py
@@ -1,0 +1,19 @@
+from ._contourpy import FillType, LineType, ZInterp
+
+
+def as_fill_type(fill_type):
+    if isinstance(fill_type, str):
+        fill_type = FillType.__members__[fill_type]
+    return fill_type
+
+
+def as_line_type(line_type):
+    if isinstance(line_type, str):
+        line_type = LineType.__members__[line_type]
+    return line_type
+
+
+def as_z_interp(z_interp):
+    if isinstance(z_interp, str):
+        z_interp = ZInterp.__members__[z_interp]
+    return z_interp

--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -1,5 +1,3 @@
-from .bokeh_util import filled_to_bokeh, lines_to_bokeh
-
 from bokeh.io import export_png, export_svg, show
 from bokeh.io.export import get_screenshot_as_png
 from bokeh.layouts import gridplot
@@ -8,6 +6,8 @@ from bokeh.palettes import Category10
 from bokeh.plotting import figure
 import io
 import numpy as np
+
+from .bokeh_util import filled_to_bokeh, lines_to_bokeh
 
 
 class BokehRenderer:

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -6,13 +6,13 @@ import matplotlib
 _default_backend = matplotlib.get_backend()
 matplotlib.use("Agg")
 
-from contourpy import FillType, LineType
-from .mpl_util import filled_to_mpl_paths, lines_to_mpl_paths, mpl_codes_to_offsets
-
 import io
 import matplotlib.pyplot as plt
 import matplotlib.collections as mcollections
 import numpy as np
+
+from contourpy import FillType, LineType
+from .mpl_util import filled_to_mpl_paths, lines_to_mpl_paths, mpl_codes_to_offsets
 
 
 class MplRenderer:

--- a/lib/contourpy/util/mpl_util.py
+++ b/lib/contourpy/util/mpl_util.py
@@ -1,6 +1,7 @@
-from contourpy import FillType, LineType
 import matplotlib.path as mpath
 import numpy as np
+
+from contourpy import FillType, LineType
 
 
 def filled_to_mpl_paths(filled, fill_type):

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ url = https://github.com/contourpy/contourpy
 
 [options]
 install_requires =
-    numpy>=1.16
+    numpy>=1.20
 package_dir =
     = lib
 packages = find:

--- a/src/fill_type.cpp
+++ b/src/fill_type.cpp
@@ -1,24 +1,6 @@
 #include "fill_type.h"
 #include <iostream>
 
-FillType FillType_from_string(const std::string& string)
-{
-    if       (string == "OuterCodes")
-        return FillType::OuterCodes;
-    else if  (string == "OuterOffsets")
-        return FillType::OuterOffsets;
-    else if  (string == "ChunkCombinedCodes")
-        return FillType::ChunkCombinedCodes;
-    else if  (string == "ChunkCombinedOffsets")
-        return FillType::ChunkCombinedOffsets;
-    else if  (string == "ChunkCombinedCodesOffsets")
-        return FillType::ChunkCombinedCodesOffsets;
-    else if  (string == "ChunkCombinedOffsets2")
-        return FillType::ChunkCombinedOffsets2;
-    else
-        throw std::invalid_argument("'" + string + "' is not a valid FillType");
-}
-
 std::ostream &operator<<(std::ostream &os, const FillType& fill_type)
 {
     switch (fill_type) {

--- a/src/fill_type.h
+++ b/src/fill_type.h
@@ -15,8 +15,6 @@ enum class FillType
     ChunkCombinedOffsets2 = 206,
 };
 
-FillType FillType_from_string(const std::string& string);
-
 std::ostream &operator<<(std::ostream &os, const FillType& fill_type);
 
 #endif // CONTOURPY_FILL_TYPE_H

--- a/src/line_type.cpp
+++ b/src/line_type.cpp
@@ -1,20 +1,6 @@
 #include "line_type.h"
 #include <iostream>
 
-LineType LineType_from_string(const std::string& string)
-{
-    if       (string == "Separate")
-        return LineType::Separate;
-    else if  (string == "SeparateCodes")
-        return LineType::SeparateCodes;
-    else if  (string == "ChunkCombinedCodes")
-        return LineType::ChunkCombinedCodes;
-    else if  (string == "ChunkCombinedOffsets")
-        return LineType::ChunkCombinedOffsets;
-    else
-        throw std::invalid_argument("'" + string + "' is not a valid LineType");
-}
-
 std::ostream &operator<<(std::ostream &os, const LineType& line_type)
 {
     switch (line_type) {

--- a/src/line_type.h
+++ b/src/line_type.h
@@ -13,8 +13,6 @@ enum class LineType
     ChunkCombinedOffsets = 104,
 };
 
-LineType LineType_from_string(const std::string& string);
-
 std::ostream &operator<<(std::ostream &os, const LineType& line_type);
 
 #endif // CONTOURPY_LINE_TYPE_H

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -28,22 +28,19 @@ PYBIND11_MODULE(_contourpy, m) {
         .value("ChunkCombinedOffsets", FillType::ChunkCombinedOffsets)
         .value("ChunkCombinedCodesOffsets", FillType::ChunkCombinedCodesOffsets)
         .value("ChunkCombinedOffsets2", FillType::ChunkCombinedOffsets2)
-        .export_values()
-        .def_static("_from_string", &FillType_from_string);
+        .export_values();
 
     py::enum_<LineType>(m, "LineType")
         .value("Separate", LineType::Separate)
         .value("SeparateCodes", LineType::SeparateCodes)
         .value("ChunkCombinedCodes", LineType::ChunkCombinedCodes)
         .value("ChunkCombinedOffsets", LineType::ChunkCombinedOffsets)
-        .export_values()
-        .def_static("_from_string", &LineType_from_string);
+        .export_values();
 
     py::enum_<ZInterp>(m, "ZInterp")
         .value("Linear", ZInterp::Linear)
         .value("Log", ZInterp::Log)
-        .export_values()
-        .def_static("_from_string", &ZInterp_from_string);
+        .export_values();
 
     m.def("max_threads", &Util::get_max_threads, "docs");
 
@@ -152,7 +149,7 @@ PYBIND11_MODULE(_contourpy, m) {
              py::arg("y_chunk_size") = 0)
         .def("filled", &SerialContourGenerator::filled)
         .def("lines", &SerialContourGenerator::lines)
-        .def("write_cache", &SerialContourGenerator::write_cache)
+        .def("_write_cache", &SerialContourGenerator::write_cache)
         .def_property_readonly("chunk_count", &SerialContourGenerator::get_chunk_count)
         .def_property_readonly("chunk_size", &SerialContourGenerator::get_chunk_size)
         .def_property_readonly("corner_mask", &SerialContourGenerator::get_corner_mask)

--- a/src/z_interp.cpp
+++ b/src/z_interp.cpp
@@ -1,16 +1,6 @@
 #include "z_interp.h"
 #include <iostream>
 
-ZInterp ZInterp_from_string(const std::string& string)
-{
-    if      (string == "Linear")
-        return ZInterp::Linear;
-    else if (string == "Log")
-        return ZInterp::Log;
-    else
-        throw std::invalid_argument("'" + string + "' is not a valid ZInterp");
-}
-
 std::ostream &operator<<(std::ostream &os, const ZInterp& z_interp)
 {
     switch (z_interp) {

--- a/src/z_interp.h
+++ b/src/z_interp.h
@@ -14,8 +14,6 @@ enum class ZInterp
     Log = 2
 };
 
-ZInterp ZInterp_from_string(const std::string& string);
-
 std::ostream &operator<<(std::ostream &os, const ZInterp& z_interp);
 
 #endif // CONTOURPY_ZINTERP_H

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -1,7 +1,8 @@
-import contourpy
 import pytest
 import re
 from subprocess import run
+
+import contourpy
 
 
 # From PEP440 appendix.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
-from image_comparison import compare_images
 import pytest
+
+from image_comparison import compare_images
 import util_config
 import util_test
 

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -1,6 +1,7 @@
-import contourpy
 import numpy as np
 import pytest
+
+import contourpy
 import util_test
 
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,5 +1,7 @@
-from contourpy import FillType, LineType, ZInterp
 import pytest
+
+from contourpy import FillType, LineType, ZInterp
+from contourpy.enum_util import as_fill_type, as_line_type, as_z_interp
 import util_test
 
 
@@ -41,12 +43,14 @@ def test_all_z_interps():
         assert z_interps[name] == enum.value
 
 
-@pytest.mark.parametrize("enum_type", [FillType, LineType, ZInterp])
-def test_string_to_enum(enum_type):
+@pytest.mark.parametrize(
+    ["enum_type", "from_string_function"],
+    [(FillType, as_fill_type), (LineType, as_line_type), (ZInterp, as_z_interp)])
+def test_string_to_enum(enum_type, from_string_function):
     for name, enum in enum_type.__members__.items():
-        line_type = enum_type._from_string(name)
+        line_type = from_string_function(name)
         assert line_type == enum
 
-    msg = f"'unknown' is not a valid {enum_type.__name__}"
-    with pytest.raises(ValueError, match=msg):
-        enum_type._from_string("unknown")
+    msg = "'unknown'"
+    with pytest.raises(KeyError, match=msg):
+        _ = from_string_function("unknown")

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -1,10 +1,11 @@
+import numpy as np
+from numpy.testing import assert_array_equal
+import pytest
+
 from contourpy import contour_generator, FillType
 from contourpy.util.data import random, simple
 from contourpy.util.mpl_renderer import MplTestRenderer
 from image_comparison import compare_images
-import numpy as np
-from numpy.testing import assert_array_equal
-import pytest
 import util_test
 
 

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -1,10 +1,11 @@
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
+import pytest
+
 from contourpy import contour_generator, LineType
 from contourpy.util.data import random, simple
 from contourpy.util.mpl_renderer import MplTestRenderer
 from image_comparison import compare_images
-import numpy as np
-from numpy.testing import assert_allclose, assert_array_equal
-import pytest
 import util_test
 
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,9 +1,10 @@
+import numpy as np
+import pytest
+
 from contourpy import contour_generator, FillType, LineType
 from contourpy.util.data import random
 from contourpy.util.mpl_renderer import MplRenderer
 from image_comparison import compare_images
-import numpy as np
-import pytest
 
 
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,9 +1,10 @@
+import pytest
+import util_test
+
 from contourpy import (
     FillType, LineType, Mpl2005ContourGenerator, Mpl2014ContourGenerator, SerialContourGenerator,
     ThreadedContourGenerator,
 )
-import pytest
-import util_test
 
 
 def get_class_from_name(name):

--- a/tests/test_z_interp.py
+++ b/tests/test_z_interp.py
@@ -1,7 +1,8 @@
-from contourpy import contour_generator, LineType, ZInterp
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
+
+from contourpy import contour_generator, LineType, ZInterp
 
 
 @pytest.fixture

--- a/tests/util_config.py
+++ b/tests/util_config.py
@@ -1,10 +1,12 @@
-from contourpy import contour_generator, LineType
-from enum import Enum
-import io
 import matplotlib
 matplotlib.use("Agg")
+
+from enum import Enum
+import io
 import matplotlib.pyplot as plt
 import numpy as np
+
+from contourpy import contour_generator, LineType
 
 
 class PointType(Enum):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,5 +1,6 @@
-from contourpy import FillType, LineType
 import numpy as np
+
+from contourpy import FillType, LineType
 
 
 point_dtype = np.float64


### PR DESCRIPTION
Moved conversion of strings to enums from C++ to Python. Also improved order of some import statements.