### PR TITLE
Don't store mask in mpl2005

### DIFF
--- a/src/mpl2005.cpp
+++ b/src/mpl2005.cpp
@@ -6,7 +6,6 @@ Mpl2005ContourGenerator::Mpl2005ContourGenerator(
     : _x(x),
       _y(y),
       _z(z),
-      _mask(mask),
       _site(cntr_new())
 {
     if (_x.ndim() != 2 || _y.ndim() != 2 || _z.ndim() != 2)
@@ -34,7 +33,7 @@ Mpl2005ContourGenerator::Mpl2005ContourGenerator(
     if (x_chunk_size < 0 || y_chunk_size < 0)
         throw std::invalid_argument("chunk_sizes cannot be negative");
 
-    const bool* mask_data = (_mask.ndim() > 0 ? _mask.data() : nullptr);
+    const bool* mask_data = (mask.ndim() > 0 ? mask.data() : nullptr);
 
     cntr_init(
         _site, nx, ny, _x.data(), _y.data(), _z.data(), mask_data, x_chunk_size, y_chunk_size);

--- a/src/mpl2005.h
+++ b/src/mpl2005.h
@@ -28,7 +28,6 @@ public:
 
 private:
     CoordinateArray _x, _y, _z;
-    MaskArray _mask;
     Csite *_site;
 };
 


### PR DESCRIPTION
Do not need to store the `mask` in `Mpl2005ContourGenerator` as it is only used in the constructor.