### PR TITLE
Build more wheels via cibuildwheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -21,11 +21,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
-        env:
-          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* pp37-*
-          CIBW_BUILD_VERBOSITY: 2
 
       - uses: actions/upload-artifact@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,13 @@ requires = [
     "pybind11>=2.6",
     "setuptools>=42",
 ]
+
+[tool.cibuildwheel]
+build-verbosity = "2"
+build = "cp37-* cp38-* cp39-* cp310-* pp37-* pp38-*"
+
+[tool.cibuildwheel.linux]
+archs = "auto aarch64"
+
+[tool.cibuildwheel.macos]
+archs = "x86_64 arm64 universal2"


### PR DESCRIPTION
This adds building the full set of wheels to the `cibuildwheel` github action. Takes about 2 hours to run, artifact is 20 MB.

Linux: x86_64, i686 and aarch64 on manylinux and musllinux.
macOS: x86_64, arm64 and universal2.
Windows: win_amd64 and win32.

Not all for all versions of Python.