### PR TITLE
Fixed missing SW corner mask starts

### DIFF
--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -142,6 +142,15 @@ class MplRenderer:
         ax.add_collection(collection)
         ax._need_autoscale = True
 
+    def mask(self, x, y, z, ax=0, color="black"):
+        mask = np.ma.getmask(z)
+        if mask is np.ma.nomask:
+            return
+
+        ax = self._get_ax(ax)
+        x, y = self._grid_as_2d(x, y)
+        ax.plot(x[mask], y[mask], 'o', c=color)
+
     def save(self, filename):
         """Save plots to SVG or PNG file.
 

--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -1746,10 +1746,8 @@ void BaseContourGenerator<Derived>::init_cache_levels_and_starts(const ChunkLoca
                             case  6:  // 012
                             case  8:  // 020
                             case  9:  // 021
-                            case 17:  // 101
                             case 18:  // 102
                             case 24:  // 120
-                            case 25:  // 121
                             case 33:  // 201
                             case 34:  // 202
                             case 36:  // 210
@@ -1768,11 +1766,20 @@ void BaseContourGenerator<Derived>::init_cache_levels_and_starts(const ChunkLoca
                                     start_in_row = true;
                                 }
                                 break;
+                            case 17:  // 101
+                            case 25:  // 121
+                                if (BOUNDARY_S(quad)) _cache[quad] |= MASK_START_BOUNDARY_S;
+                                if (BOUNDARY_W(quad)) _cache[quad] |= MASK_START_BOUNDARY_W;
+                                _cache[quad] |= MASK_START_CORNER;
+                                start_in_row = true;
+                                break;
                             case 20:  // 110
                             case 21:  // 111
                             case 22:  // 112
-                                if (BOUNDARY_S(quad)) _cache[quad] |= MASK_START_BOUNDARY_S;
-                                _cache[quad] |= MASK_START_CORNER;
+                                if (BOUNDARY_S(quad))
+                                    _cache[quad] |= MASK_START_BOUNDARY_S;
+                                else
+                                    _cache[quad] |= MASK_START_CORNER;
                                 start_in_row = true;
                                 break;
                         }
@@ -2156,13 +2163,16 @@ void BaseContourGenerator<Derived>::march_chunk(
 
     // Check both passes returned same number of points, lines, etc.
     if (local.total_point_count == 0) {
+        assert(local.points.size == 0);
         assert(local.points.start == nullptr && local.points.current == nullptr);
     }
     else {
+        assert(local.points.size == 2*local.total_point_count);
         assert(local.points.current = local.points.start + 2*local.total_point_count);
     }
 
     if (local.line_count > 0) {
+        assert(local.line_offsets.size == local.line_count+1);
         assert(local.line_offsets.current != nullptr);
         assert(local.line_offsets.current == local.line_offsets.start + local.line_count);
 
@@ -2170,10 +2180,12 @@ void BaseContourGenerator<Derived>::march_chunk(
         *local.line_offsets.current++ = local.total_point_count;
     }
     else {
+        assert(local.line_offsets.size == 0);
         assert(local.line_offsets.start == nullptr && local.line_offsets.current == nullptr);
     }
 
     if (_identify_holes && local.line_count > 0) {
+        assert(local.outer_offsets.size == local.line_count - local.hole_count + 1);
         assert(local.outer_offsets.current != nullptr);
         assert(local.outer_offsets.current ==
             local.outer_offsets.start + local.line_count - local.hole_count);
@@ -2185,6 +2197,7 @@ void BaseContourGenerator<Derived>::march_chunk(
             *local.outer_offsets.current++ = local.line_count;
     }
     else {
+        assert(local.outer_offsets.size == 0);
         assert(local.outer_offsets.start == nullptr && local.outer_offsets.current == nullptr);
     }
 

--- a/src/output_array.h
+++ b/src/output_array.h
@@ -14,25 +14,28 @@ class OutputArray
 {
 public:
     OutputArray()
-        : start(nullptr), current(nullptr)
+        : size(0), start(nullptr), current(nullptr)
     {}
 
     void clear()
     {
         vector.clear();
+        size = 0;
         start = current = nullptr;
     }
 
-    void create_cpp(count_t size)
+    void create_cpp(count_t new_size)
     {
-        assert(size > 0);
+        assert(new_size > 0);
+        size = new_size;
         vector.resize(size);
         start = current = vector.data();
     }
 
-    py::array_t<T> create_python(count_t size)
+    py::array_t<T> create_python(count_t new_size)
     {
-        assert(size > 0);
+        assert(new_size > 0);
+        size = new_size;
         py::array_t<T> py_array(size);
         start = current = py_array.mutable_data();
         return py_array;
@@ -41,6 +44,7 @@ public:
     py::array_t<T> create_python(count_t shape0, count_t shape1)
     {
         assert(shape0 > 0 && shape1 > 0);
+        size = shape0*shape1;
         py::array_t<T> py_array({shape0, shape1});
         start = current = py_array.mutable_data();
         return py_array;
@@ -54,6 +58,7 @@ public:
 
 
     std::vector<T> vector;
+    count_t size;
     T* start;               // Start of array, whether C++ or Python.
     T* current;             // Where to write next value to before incrementing.
 };

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -91,3 +91,149 @@ def all_z_interps_str_value():
         ("Linear", 1),
         ("Log", 2),
     ]
+
+
+def assert_point_array(points):
+    assert isinstance(points, np.ndarray)
+    assert points.dtype == point_dtype
+    assert points.ndim == 2
+    assert points.shape[1] == 2
+    npoints = points.shape[0]
+    assert npoints >= 1
+    return npoints
+
+
+def assert_code_array(codes, npoints):
+    assert isinstance(codes, np.ndarray)
+    assert codes.dtype == code_dtype
+    assert codes.ndim == 1
+    assert len(codes) == npoints
+    assert codes[0] == 1
+
+
+def assert_offset_array(offsets, max_offset):
+    assert isinstance(offsets, np.ndarray)
+    assert offsets.dtype == offset_dtype
+    assert offsets.ndim == 1
+    assert len(offsets) > 1
+    assert offsets[0] == 0
+    assert offsets[-1] == max_offset
+    assert np.all(np.diff(offsets) > 0)
+    return len(offsets)
+
+
+def assert_filled(filled, fill_type):
+    if fill_type == FillType.OuterCodes:
+        assert isinstance(filled, tuple) and len(filled) == 2
+        polygons, codes = filled
+        assert isinstance(polygons, list)
+        assert isinstance(codes, list)
+        assert len(polygons) == len(codes)
+        for polygon, code in zip(polygons, codes):
+            npoints = assert_point_array(polygon)
+            assert_code_array(code, npoints)
+    elif fill_type == FillType.OuterOffsets:
+        assert isinstance(filled, tuple) and len(filled) == 2
+        polygons, offsets = filled
+        assert isinstance(polygons, list)
+        assert isinstance(offsets, list)
+        assert len(polygons) == len(offsets)
+        for polygon, offset in zip(polygons, offsets):
+            npoints = assert_point_array(polygon)
+            assert_offset_array(offset, npoints)
+    elif fill_type == FillType.ChunkCombinedCodes:
+        assert isinstance(filled, tuple) and len(filled) == 2
+        polygons, codes = filled
+        assert isinstance(polygons, list)
+        assert isinstance(codes, list)
+        assert len(polygons) == len(codes)
+        for polygon, code in zip(polygons, codes):
+            if polygon is None:
+                assert code is None
+            else:
+                npoints = assert_point_array(polygon)
+                assert_code_array(code, npoints)
+    elif fill_type == FillType.ChunkCombinedOffsets:
+        assert isinstance(filled, tuple) and len(filled) == 2
+        polygons, offsets = filled
+        assert isinstance(polygons, list)
+        assert isinstance(offsets, list)
+        assert len(polygons) == len(offsets)
+        for polygon, offset in zip(polygons, offsets):
+            if polygon is None:
+                assert offset is None
+            else:
+                npoints = assert_point_array(polygon)
+                assert_offset_array(offset, npoints)
+    elif fill_type == FillType.ChunkCombinedCodesOffsets:
+        assert isinstance(filled, tuple) and len(filled) == 3
+        polygons, codes, outer_offsets = filled
+        assert isinstance(polygons, list)
+        assert isinstance(codes, list)
+        assert isinstance(outer_offsets, list)
+        assert len(polygons) == len(codes) == len(outer_offsets)
+        for polygon, code, outer_offset in zip(polygons, codes, outer_offsets):
+            if polygon is None:
+                assert code is None and outer_offset is None
+            else:
+                npoints = assert_point_array(polygon)
+                assert_code_array(code, npoints)
+                assert_offset_array(outer_offset, npoints)
+    elif fill_type == FillType.ChunkCombinedOffsets2:
+        assert isinstance(filled, tuple) and len(filled) == 3
+        polygons, offsets, outer_offsets = filled
+        assert isinstance(polygons, list)
+        assert isinstance(offsets, list)
+        assert isinstance(outer_offsets, list)
+        assert len(polygons) == len(offsets) == len(outer_offsets)
+        for polygon, offset, outer_offset in zip(polygons, offsets, outer_offsets):
+            if polygon is None:
+                assert offset is None and outer_offset is None
+            else:
+                npoints = assert_point_array(polygon)
+                noffsets = assert_offset_array(offset, npoints)
+                assert_offset_array(outer_offset, noffsets-1)
+    else:
+        raise RuntimeError(f"Unexpected fill_type {fill_type}")
+
+
+def assert_lines(lines, line_type):
+    if line_type == LineType.Separate:
+        assert isinstance(lines, list)
+        for line in lines:
+            assert_point_array(line)
+    elif line_type == LineType.SeparateCodes:
+        assert isinstance(lines, tuple) and len(lines) == 2
+        lines, codes = lines
+        assert isinstance(lines, list)
+        assert isinstance(codes, list)
+        assert len(lines) == len(codes)
+        for line, code in zip(lines, codes):
+            npoints = assert_point_array(line)
+            assert_code_array(code, npoints)
+    elif line_type == LineType.ChunkCombinedCodes:
+        assert isinstance(lines, tuple) and len(lines) == 2
+        points, codes = lines
+        assert isinstance(points, list)
+        assert isinstance(codes, list)
+        assert len(points) == len(codes)
+        for line, code in zip(points, codes):
+            if line is None:
+                assert code is None
+            else:
+                npoints = assert_point_array(line)
+                assert_code_array(code, npoints)
+    elif line_type == LineType.ChunkCombinedOffsets:
+        assert isinstance(lines, tuple) and len(lines) == 2
+        points, offsets = lines
+        assert isinstance(points, list)
+        assert isinstance(offsets, list)
+        assert len(points) == len(offsets)
+        for line, offset in zip(points, offsets):
+            if line is None:
+                assert offset is None
+            else:
+                npoints = assert_point_array(line)
+                assert_offset_array(offset, npoints)
+    else:
+        raise RuntimeError(f"Unexpected line_type {line_type}")


### PR DESCRIPTION
Fixed a bug due to missing some possible corner starts for a SW corner.

- Added more asserts in `base_impl.h` to check for situations like this in future. 
- Improved testing framework for `lines` and `filled` according to their `line_type`/`fill_type`.
- Added big 1000x1000 filled and line tests.
- Added mask rendering function to `MplDebugRenderer`.