### PR TITLE
Finalise enum spellings

### DIFF
--- a/benchmarks/benchmarks/bench_filled_mpl20xx.py
+++ b/benchmarks/benchmarks/bench_filled_mpl20xx.py
@@ -5,7 +5,7 @@ from .util_bench import corner_masks, datasets, problem_sizes
 
 class BenchFilledMpl20xx(BenchBase):
     params = (
-        ["mpl2005", "mpl2014"], datasets(), [FillType.OuterCodes], corner_masks(), problem_sizes())
+        ["mpl2005", "mpl2014"], datasets(), [FillType.OuterCode], corner_masks(), problem_sizes())
     param_names = ("name", "dataset", "fill_type", "corner_mask", "n")
 
     def setup(self, name, dataset, fill_type, corner_mask, n):

--- a/benchmarks/benchmarks/bench_filled_mpl20xx_render.py
+++ b/benchmarks/benchmarks/bench_filled_mpl20xx_render.py
@@ -6,7 +6,7 @@ from .util_bench import corner_masks, datasets, problem_sizes
 
 class BenchFilledMpl20xxRender(BenchBase):
     params = (
-        ["mpl2005", "mpl2014"], datasets(), [FillType.OuterCodes], corner_masks(), problem_sizes())
+        ["mpl2005", "mpl2014"], datasets(), [FillType.OuterCode], corner_masks(), problem_sizes())
     param_names = ("name", "dataset", "fill_type", "corner_mask", "n")
 
     def setup(self, name, dataset, fill_type, corner_mask, n):

--- a/benchmarks/benchmarks/bench_filled_serial_chunk.py
+++ b/benchmarks/benchmarks/bench_filled_serial_chunk.py
@@ -5,7 +5,7 @@ from .util_bench import chunk_counts, corner_masks, datasets
 
 class BenchFilledSerialChunk(BenchBase):
     params = (
-        ["serial"], datasets(), [FillType.ChunkCombinedOffsets2], corner_masks(), [1000],
+        ["serial"], datasets(), [FillType.ChunkCombinedOffsetOffset], corner_masks(), [1000],
         chunk_counts())
     param_names = ("name", "dataset", "fill_type", "corner_mask", "n", "chunk_count")
 

--- a/benchmarks/benchmarks/bench_filled_serial_quad_as_tri.py
+++ b/benchmarks/benchmarks/bench_filled_serial_quad_as_tri.py
@@ -4,7 +4,7 @@ from .util_bench import corner_masks, datasets, problem_sizes
 
 
 class BenchFilledSerialQuadAsTri(BenchBase):
-    params = (["serial"], datasets(), [FillType.OuterCodes], corner_masks(), problem_sizes())
+    params = (["serial"], datasets(), [FillType.OuterCode], corner_masks(), problem_sizes())
     param_names = ("name", "dataset", "fill_type", "corner_mask", "n")
 
     def setup(self, name, dataset, fill_type, corner_mask, n):

--- a/benchmarks/benchmarks/bench_filled_serial_quad_as_tri_render.py
+++ b/benchmarks/benchmarks/bench_filled_serial_quad_as_tri_render.py
@@ -5,7 +5,7 @@ from .util_bench import corner_masks, datasets, problem_sizes
 
 
 class BenchFilledSerialQuadAsTriRender(BenchBase):
-    params = (["serial"], datasets(), [FillType.OuterCodes], corner_masks(), problem_sizes())
+    params = (["serial"], datasets(), [FillType.OuterCode], corner_masks(), problem_sizes())
     param_names = ("name", "dataset", "fill_type", "corner_mask", "n")
 
     def setup(self, name, dataset, fill_type, corner_mask, n):

--- a/benchmarks/benchmarks/bench_filled_threaded.py
+++ b/benchmarks/benchmarks/bench_filled_threaded.py
@@ -5,7 +5,7 @@ from .util_bench import corner_masks, datasets, problem_sizes, thread_counts
 
 class BenchFilledThreaded(BenchBase):
     params = (
-        ["threaded"], datasets(), [FillType.ChunkCombinedOffsets2], corner_masks(), problem_sizes(),
+        ["threaded"], datasets(), [FillType.ChunkCombinedOffsetOffset], corner_masks(), problem_sizes(),
         [40], thread_counts())
     param_names = (
         "name", "dataset", "fill_type", "corner_mask", "n", "chunk_count", "thread_count")

--- a/benchmarks/benchmarks/bench_lines_mpl20xx.py
+++ b/benchmarks/benchmarks/bench_lines_mpl20xx.py
@@ -5,7 +5,7 @@ from .util_bench import corner_masks, datasets, problem_sizes
 
 class BenchLinesMpl20xx(BenchBase):
     params = (
-        ["mpl2005", "mpl2014"], datasets(), [LineType.SeparateCodes], corner_masks(),
+        ["mpl2005", "mpl2014"], datasets(), [LineType.SeparateCode], corner_masks(),
         problem_sizes())
     param_names = ("name", "dataset", "line_type", "corner_mask", "n")
 

--- a/benchmarks/benchmarks/bench_lines_mpl20xx_render.py
+++ b/benchmarks/benchmarks/bench_lines_mpl20xx_render.py
@@ -6,7 +6,7 @@ from .util_bench import corner_masks, datasets, problem_sizes
 
 class BenchLinesMpl20xxRender(BenchBase):
     params = (
-        ["mpl2005", "mpl2014"], datasets(), [LineType.SeparateCodes], corner_masks(),
+        ["mpl2005", "mpl2014"], datasets(), [LineType.SeparateCode], corner_masks(),
         problem_sizes())
     param_names = ("name", "dataset", "line_type", "corner_mask", "n")
 

--- a/benchmarks/benchmarks/bench_lines_serial_chunk.py
+++ b/benchmarks/benchmarks/bench_lines_serial_chunk.py
@@ -5,7 +5,7 @@ from .util_bench import chunk_counts, corner_masks, datasets
 
 class BenchLinesSerialChunk(BenchBase):
     params = (
-        ["serial"], datasets(), [LineType.ChunkCombinedOffsets], corner_masks(), [1000],
+        ["serial"], datasets(), [LineType.ChunkCombinedOffset], corner_masks(), [1000],
         chunk_counts())
     param_names = ("name", "dataset", "line_type", "corner_mask", "n", "chunk_count")
 

--- a/benchmarks/benchmarks/bench_lines_serial_quad_as_tri.py
+++ b/benchmarks/benchmarks/bench_lines_serial_quad_as_tri.py
@@ -4,7 +4,7 @@ from .util_bench import corner_masks, datasets, problem_sizes
 
 
 class BenchLinesSerialQuadAsTri(BenchBase):
-    params = (["serial"], datasets(), [LineType.SeparateCodes], corner_masks(), problem_sizes())
+    params = (["serial"], datasets(), [LineType.SeparateCode], corner_masks(), problem_sizes())
     param_names = ("name", "dataset", "line_type", "corner_mask", "n")
 
     def setup(self, name, dataset, line_type, corner_mask, n):

--- a/benchmarks/benchmarks/bench_lines_serial_quad_as_tri_render.py
+++ b/benchmarks/benchmarks/bench_lines_serial_quad_as_tri_render.py
@@ -5,7 +5,7 @@ from .util_bench import corner_masks, datasets, problem_sizes
 
 
 class BenchLinesSerialQuadAsTriRender(BenchBase):
-    params = (["serial"], datasets(), [LineType.SeparateCodes], corner_masks(), problem_sizes())
+    params = (["serial"], datasets(), [LineType.SeparateCode], corner_masks(), problem_sizes())
     param_names = ("name", "dataset", "line_type", "corner_mask", "n")
 
     def setup(self, name, dataset, line_type, corner_mask, n):

--- a/benchmarks/benchmarks/bench_lines_threaded.py
+++ b/benchmarks/benchmarks/bench_lines_threaded.py
@@ -5,7 +5,7 @@ from .util_bench import corner_masks, datasets, problem_sizes, thread_counts
 
 class BenchLinesThreaded(BenchBase):
     params = (
-        ["threaded"], datasets(), [LineType.ChunkCombinedOffsets], corner_masks(), problem_sizes(),
+        ["threaded"], datasets(), [LineType.ChunkCombinedOffset], corner_masks(), problem_sizes(),
         [40], thread_counts())
     param_names = (
         "name", "dataset", "line_type", "corner_mask", "n", "chunk_count", "thread_count")

--- a/docs/user_guide/fill_type.rst
+++ b/docs/user_guide/fill_type.rst
@@ -14,8 +14,8 @@ Valid enum members and the default vary by algorithm:
 
 A string name can be used instead of the enum member so the following are equivalent:
 
-   >>> contour_generator(fill_type="OuterOffsets", ...)
-   >>> contour_generator(fill_type=FillType.OuterOffsets, ...)
+   >>> contour_generator(fill_type="OuterOffset", ...)
+   >>> contour_generator(fill_type=FillType.OuterOffset, ...)
 
 .. note::
 
@@ -24,7 +24,7 @@ A string name can be used instead of the enum member so the following are equiva
    but may also contain any number of holes (interior boundaries). The relationship between outer
    boundaries and their holes is calculated and returned by
    :func:`~contourpy.SerialContourGenerator.filled` for all :class:`~contourpy.FillType` members
-   except for ``ChunkCombinedCodes`` and ``ChunkCombinedCodes``.
+   except for ``ChunkCombinedCode`` and ``ChunkCombinedOffset``.
 
 Enum members are a combination of the following words:
 
@@ -33,10 +33,12 @@ Enum members are a combination of the following words:
   * **Combined**: multiple boundaries are concatenated in the same array regardless of whether they
     are outer boundaries or holes.
   * **Chunk**: each chunk is separate, and is ``None`` if the chunk has no polygons.
-  * **Codes**: includes ``matplotlib`` kind codes.
-  * **Offsets**: individual boundaries are identified via offsets into larger arrays.
-  * **Offsets2**: two levels of offsets, first polygon offsets and then boundary offsets into those
-    polygons.
+  * **Code**: includes ``matplotlib`` kind codes for the previous array.
+  * **Offset**: the previous array is divided up using start and end offsets.
+
+Where **Offset** occurs twice the first refers to the offsets of individual boundaries within a
+larger collection and the second to which of those boundaries (outers and holes) are grouped
+together into polygons.
 
 The format of data returned by :func:`~contourpy.SerialContourGenerator.filled` for each of the
 possible :class:`~contourpy.FillType` members is best illustrated through an example.  This is the
@@ -85,10 +87,9 @@ Set up the imports and data:
    >>> np.set_printoptions(precision=2)
    >>> z = [[1.4, 1.2, 0.9, 0], [0.6, 3, 0.4, 0.7], [0.2, 0.2, 0.5, 3]]
 
-OuterCodes
-^^^^^^^^^^
-
-   >>> cont_gen = contour_generator(z=z, fill_type=FillType.OuterCodes)
+OuterCode
+^^^^^^^^^
+   >>> cont_gen = contour_generator(z=z, fill_type=FillType.OuterCode)
    >>> filled = cont_gen.filled(1, 2)
    >>> filled
    ([array([[0., 0.], [1., 0.], [1.67, 0.], [1.77, 1.], [1., 1.71], [0.17, 1.], [0., 0.5],
@@ -105,10 +106,9 @@ the second list their corresponding ``matplotlib`` kind codes. For polygon ``i``
 Here the first polygon has 13 points, 8 for the outer and 5 for the hole. The hole starts at index
 8 which corresponds to a kind code of 1.
 
-OuterOffsets
-^^^^^^^^^^^^
-
-   >>> cont_gen = contour_generator(z=z, fill_type=FillType.OuterCodes)
+OuterOffset
+^^^^^^^^^^^
+   >>> cont_gen = contour_generator(z=z, fill_type=FillType.OuterCode)
    >>> filled = cont_gen.filled(1, 2)
    >>> filled
    ([array([[0., 0.], [1., 0.], [1.67, 0.], [1.77, 1.], [1., 1.71], [0.17, 1.], [0., 0.5],
@@ -126,10 +126,9 @@ Here the first polygon has 13 points, the outer is indices ``0::8`` and the hole
 ``8:13``. The second polygon does not have any holes so its indices ``0:5`` cover the whole of the
 points array.
 
-ChunkCombinedCodes
-^^^^^^^^^^^^^^^^^^
-
-   >>> cont_gen = contour_generator(z=z, fill_type=FillType.ChunkCombinedCodes)
+ChunkCombinedCode
+^^^^^^^^^^^^^^^^^
+   >>> cont_gen = contour_generator(z=z, fill_type=FillType.ChunkCombinedCode)
    >>> filled = cont_gen.filled(1, 2)
    >>> filled
    ([array([[0., 0.], [1., 0.], [1.67, 0.], [1.77, 1.], [1., 1.71], [0.17, 1.], [0., 0.5],
@@ -147,10 +146,9 @@ For chunk ``j`` the combined points are ``filled[0][j]`` and the combined codes 
 ``filled[1][j]``. An empty chunk has ``None`` for each. The start of each polygon boundary is
 identified by a kind code of 1, so here there are three boundaries.
 
-ChunkCombinedOffsets
-^^^^^^^^^^^^^^^^^^^^
-
-   >>> cont_gen = contour_generator(z=z, fill_type=FillType.ChunkCombinedCodes)
+ChunkCombinedOffset
+^^^^^^^^^^^^^^^^^^^
+   >>> cont_gen = contour_generator(z=z, fill_type=FillType.ChunkCombinedCode)
    >>> filled = cont_gen.filled(1, 2)
    >>> filled
    ([array([[0., 0.], [1., 0.], [1.67, 0.], [1.77, 1.], [1., 1.71], [0.17, 1.], [0., 0.5],
@@ -168,10 +166,9 @@ For chunk ``j`` the combined points are ``filled[0][j]`` and the combined offset
 ``filled[1][j]``. An empty chunk has ``None`` for each. Here there are three boundaries
 with point indices ``0:8``, ``8:13`` and ``13:18`` respectively.
 
-ChunkCombinedCodesOffsets
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-   >>> cont_gen = contour_generator(z=z, fill_type=FillType.ChunkCombinedCodesOffsets)
+ChunkCombinedCodeOffset
+^^^^^^^^^^^^^^^^^^^^^^^
+   >>> cont_gen = contour_generator(z=z, fill_type=FillType.ChunkCombinedCodeOffset)
    >>> filled = cont_gen.filled(1, 2)
    >>> filled
    ([array([[0., 0.], [1., 0.], [1.67, 0.], [1.77, 1.], [1., 1.71], [0.17, 1.], [0., 0.5],
@@ -181,7 +178,7 @@ ChunkCombinedCodesOffsets
     [array([ 0, 13, 18], dtype=uint32)])
 
 This returns a tuple of three lists, each list has a length equal to the number of chunks used
-which is one here. The first two lists are the same as for ``ChunkCombinedCodes`` except that each
+which is one here. The first two lists are the same as for ``ChunkCombinedCode`` except that each
 outer and its holes are stored contiguously. The third list is an array of offsets into the points
 and codes arrays to identify the start and end indices of each polygon (outer with its holes) within
 those arrays.
@@ -194,10 +191,9 @@ determined from the kind codes of 1. The polygon offsets arrays indicates that t
 polygons, the first is indices ``0:13`` (so outer plus one hole) and the second is indices ``13:18``
 (outer only).
 
-ChunkCombinedOffsets2
-^^^^^^^^^^^^^^^^^^^^^
-
-   >>> cont_gen = contour_generator(z=z, fill_type=FillType.ChunkCombinedOffsets2)
+ChunkCombinedOffsetOffset
+^^^^^^^^^^^^^^^^^^^^^^^^^
+   >>> cont_gen = contour_generator(z=z, fill_type=FillType.ChunkCombinedOffsetOffset)
    >>> filled = cont_gen.filled(1, 2)
    >>> filled
    ([array([[0., 0.], [1., 0.], [1.67, 0.], [1.77, 1.], [1., 1.71], [0.17, 1.], [0., 0.5],
@@ -207,7 +203,7 @@ ChunkCombinedOffsets2
     [array([0, 2, 3], dtype=uint32)])
 
 This returns a tuple of three lists, each list has a length equal to the number of chunks used
-which is one here. The first two lists are the same as for ``ChunkCombinedOffsets`` except that each
+which is one here. The first two lists are the same as for ``ChunkCombinedOffset`` except that each
 outer and its holes are stored contiguously. The third list is an array of polygon offsets into the
 boundary offsets array to identify the start and end indices of each polygon.
 
@@ -242,6 +238,6 @@ subsequent analysis.
 
    The order of boundaries returned by a particular :func:`~contourpy.SerialContourGenerator.filled`
    call is deterministic except for the combination of ``name="threaded"`` and either
-   ``fill_type=FillType.OuterCodes`` or ``fill_type=FillType.OuterOffsets``. This is because the
+   ``fill_type=FillType.OuterCode`` or ``fill_type=FillType.OuterOffset``. This is because the
    order that the chunks are processed in is not deterministic and boundaries are appended to the
    returned arrays as soon as their chunks are completed.

--- a/docs/user_guide/line_type.rst
+++ b/docs/user_guide/line_type.rst
@@ -14,16 +14,16 @@ Valid enum members and the default vary by algorithm:
 
 A string name can be used instead of the enum member so the following are equivalent:
 
-   >>> contour_generator(line_type="SeparateCodes", ...)
-   >>> contour_generator(line_type=LineType.SeparateCodes, ...)
+   >>> contour_generator(line_type="SeparateCode", ...)
+   >>> contour_generator(line_type=LineType.SeparateCode, ...)
 
 Enum members are a combination of the following words:
 
   * **Separate**: each line is a separate array.
   * **Combined**: multiple lines are concatenated in the same array.
   * **Chunk**: each chunk is separate, and is ``None`` if the chunk has no lines.
-  * **Codes**: includes ``matplotlib`` kind codes.
-  * **Offsets**: individual lines are identified via offsets into larger arrays.
+  * **Code**: includes ``matplotlib`` kind codes for the previous line array.
+  * **Offset**: individual lines are identified via offsets into the previous line array.
 
 The format of data returned by :func:`~contourpy.SerialContourGenerator.lines` for each of the
 possible :class:`~contourpy.LineType` members is best illustrated through an example.
@@ -79,9 +79,9 @@ Separate
 This returns a list of arrays, each array is the 2D points of a single line loop or strip.
 The number of lines is ``len(lines)`` and the points of line ``i`` are ``lines[i]``.
 
-SeparateCodes
-^^^^^^^^^^^^^
-   >>> cont_gen = contour_generator(z=z, line_type=LineType.SeparateCodes)
+SeparateCode
+^^^^^^^^^^^^
+   >>> cont_gen = contour_generator(z=z, line_type=LineType.SeparateCode)
    >>> lines = cont_gen.lines(2)
    >>> lines
    ([array([[0.58, 1.], [1., 0.44], [1.38, 1.], [1., 1.36], [0.58, 1.]]),
@@ -95,9 +95,9 @@ arrays containing the ``matplotlib`` kind codes (1 = start new line loop or stri
 point, 79 = close line loop). For line ``i`` the points are ``lines[0][i]`` and the kind codes are
 ``lines[1][i]``.
 
-ChunkCombinedCodes
-^^^^^^^^^^^^^^^^^^
-   >>> cont_gen = contour_generator(z=z, line_type=LineType.ChunkCombinedCodes)
+ChunkCombinedCode
+^^^^^^^^^^^^^^^^^
+   >>> cont_gen = contour_generator(z=z, line_type=LineType.ChunkCombinedCode)
    >>> lines = cont_gen.lines(2)
    >>> lines
    ([array([[0.58, 1.], [1., 0.44], [1.38, 1.], [1., 1.36], [0.58, 1.], [2.6, 2.], [3., 1.57]])],
@@ -112,9 +112,9 @@ For chunk ``j`` the combined points are ``lines[0][j]`` and the combined codes a
 An empty chunk has ``None`` for each. The start of each line loop/strip is identified by a kind code
 of 1.
 
-ChunkCombinedOffsets
-^^^^^^^^^^^^^^^^^^^^
-   >>> cont_gen = contour_generator(z=z, line_type=LineType.ChunkCombinedOffsets)
+ChunkCombinedOffset
+^^^^^^^^^^^^^^^^^^^
+   >>> cont_gen = contour_generator(z=z, line_type=LineType.ChunkCombinedOffset)
    >>> lines = cont_gen.lines(2)
    >>> lines
    ([array([[0.58, 1.], [1., 0.44], [1.38, 1.], [1., 1.36], [0.58, 1.], [2.6, 2.], [3., 1.57]])],
@@ -149,6 +149,6 @@ analysis.
 
    The order of lines returned by a particular :func:`~contourpy.SerialContourGenerator.lines` call
    is deterministic except for the combination of ``name="threaded"`` and either
-   ``line_type=LineType.Separate`` or ``line_type=LineType.SeparateCodes``. This is because the
+   ``line_type=LineType.Separate`` or ``line_type=LineType.SeparateCode``. This is because the
    order that the chunks are processed in is not deterministic and lines are appended to the
    returned arrays as soon as their chunks are completed.

--- a/docs/user_guide/threads.rst
+++ b/docs/user_guide/threads.rst
@@ -52,4 +52,4 @@ If you request more threads than the number of chunks, the thread count will be 
    The order of processing chunks is not deterministic. If you use a :class:`~contourpy.LineType` or
    :class:`~contourpy.FillType` that do not arrange the results by chunk, the order of
    returned lines/polygons is also not deterministic. This includes ``LineType.Separate``,
-   ``LineType.SeparateCodes``, ``FillType.OuterCodes`` and ``FillType.OuterOffsets``.
+   ``LineType.SeparateCode``, ``FillType.OuterCode`` and ``FillType.OuterOffset``.

--- a/lib/contourpy/util/bokeh_util.py
+++ b/lib/contourpy/util/bokeh_util.py
@@ -5,9 +5,9 @@ from .mpl_util import mpl_codes_to_offsets
 def filled_to_bokeh(filled, fill_type):
     xs = []
     ys = []
-    if fill_type in (FillType.OuterOffsets, FillType.ChunkCombinedOffsets,
-                     FillType.OuterCodes, FillType.ChunkCombinedCodes):
-        have_codes = fill_type in (FillType.OuterCodes, FillType.ChunkCombinedCodes)
+    if fill_type in (FillType.OuterOffset, FillType.ChunkCombinedOffset,
+                     FillType.OuterCode, FillType.ChunkCombinedCode):
+        have_codes = fill_type in (FillType.OuterCode, FillType.ChunkCombinedCode)
 
         for points, offsets in zip(*filled):
             if points is None:
@@ -20,12 +20,12 @@ def filled_to_bokeh(filled, fill_type):
                 xys = points[offsets[i]:offsets[i+1]]
                 xs[-1].append(xys[:, 0])
                 ys[-1].append(xys[:, 1])
-    elif fill_type in (FillType.ChunkCombinedCodesOffsets, FillType.ChunkCombinedOffsets2):
+    elif fill_type in (FillType.ChunkCombinedCodeOffset, FillType.ChunkCombinedOffsetOffset):
         for points, codes_or_offsets, outer_offsets in zip(*filled):
             if points is None:
                 continue
             for j in range(len(outer_offsets)-1):
-                if fill_type == FillType.ChunkCombinedCodesOffsets:
+                if fill_type == FillType.ChunkCombinedCodeOffset:
                     codes = codes_or_offsets[outer_offsets[j]:outer_offsets[j+1]]
                     offsets = mpl_codes_to_offsets(codes) + outer_offsets[j]
                 else:
@@ -50,15 +50,15 @@ def lines_to_bokeh(lines, line_type):
         for line in lines:
             xs.append(line[:, 0])
             ys.append(line[:, 1])
-    elif line_type == LineType.SeparateCodes:
+    elif line_type == LineType.SeparateCode:
         for line in lines[0]:
             xs.append(line[:, 0])
             ys.append(line[:, 1])
-    elif line_type in (LineType.ChunkCombinedCodes, LineType.ChunkCombinedOffsets):
+    elif line_type in (LineType.ChunkCombinedCode, LineType.ChunkCombinedOffset):
         for points, offsets in zip(*lines):
             if points is None:
                 continue
-            if line_type == LineType.ChunkCombinedCodes:
+            if line_type == LineType.ChunkCombinedCode:
                 offsets = mpl_codes_to_offsets(offsets)
 
             for i in range(len(offsets)-1):

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -284,19 +284,19 @@ class MplDebugRenderer(MplRenderer):
 
         ax = self._get_ax(ax)
 
-        if fill_type == FillType.OuterCodes:
+        if fill_type == FillType.OuterCode:
             all_points = filled[0]
             all_offsets = [mpl_codes_to_offsets(codes) for codes in filled[1]]
-        elif fill_type == FillType.ChunkCombinedCodes:
+        elif fill_type == FillType.ChunkCombinedCode:
             all_points = [points for points in filled[0] if points is not None]
             all_offsets = [mpl_codes_to_offsets(codes) for codes in filled[1] if codes is not None]
-        elif fill_type == FillType.OuterOffsets:
+        elif fill_type == FillType.OuterOffset:
             all_points = filled[0]
             all_offsets = filled[1]
-        elif fill_type == FillType.ChunkCombinedOffsets:
+        elif fill_type == FillType.ChunkCombinedOffset:
             all_points = [points for points in filled[0] if points is not None]
             all_offsets = [offsets for offsets in filled[1] if offsets is not None]
-        elif fill_type == FillType.ChunkCombinedCodesOffsets:
+        elif fill_type == FillType.ChunkCombinedCodeOffset:
             all_points = []
             all_offsets = []
             for points, codes, outer_offsets in zip(*filled):
@@ -305,7 +305,7 @@ class MplDebugRenderer(MplRenderer):
                 all_points += np.split(points, outer_offsets[1:-1])
                 codes = np.split(codes, outer_offsets[1:-1])
                 all_offsets += [mpl_codes_to_offsets(codes) for codes in codes]
-        elif fill_type == FillType.ChunkCombinedOffsets2:
+        elif fill_type == FillType.ChunkCombinedOffsetOffset:
             all_points = []
             all_offsets = []
             for points, offsets, outer_offsets in zip(*filled):
@@ -356,16 +356,16 @@ class MplDebugRenderer(MplRenderer):
 
         if line_type == LineType.Separate:
             all_lines = lines
-        elif line_type == LineType.SeparateCodes:
+        elif line_type == LineType.SeparateCode:
             all_lines = lines[0]
-        elif line_type == LineType.ChunkCombinedCodes:
+        elif line_type == LineType.ChunkCombinedCode:
             all_lines = []
             for points, codes in zip(*lines):
                 if points is not None:
                     offsets = mpl_codes_to_offsets(codes)
                     for i in range(len(offsets)-1):
                         all_lines.append(points[offsets[i]:offsets[i+1]])
-        elif line_type == LineType.ChunkCombinedOffsets:
+        elif line_type == LineType.ChunkCombinedOffset:
             all_lines = []
             for points, offsets in zip(*lines):
                 if points is not None:

--- a/lib/contourpy/util/mpl_util.py
+++ b/lib/contourpy/util/mpl_util.py
@@ -5,12 +5,12 @@ from contourpy import FillType, LineType
 
 
 def filled_to_mpl_paths(filled, fill_type):
-    if fill_type in (FillType.OuterCodes, FillType.ChunkCombinedCodes):
+    if fill_type in (FillType.OuterCode, FillType.ChunkCombinedCode):
         paths = [mpath.Path(points, codes) for points, codes in zip(*filled) if points is not None]
-    elif fill_type in (FillType.OuterOffsets, FillType.ChunkCombinedOffsets):
+    elif fill_type in (FillType.OuterOffset, FillType.ChunkCombinedOffset):
         paths = [mpath.Path(points, offsets_to_mpl_codes(offsets))
                  for points, offsets in zip(*filled) if points is not None]
-    elif fill_type == FillType.ChunkCombinedCodesOffsets:
+    elif fill_type == FillType.ChunkCombinedCodeOffset:
         paths = []
         for points, codes, outer_offsets in zip(*filled):
             if points is None:
@@ -18,7 +18,7 @@ def filled_to_mpl_paths(filled, fill_type):
             points = np.split(points, outer_offsets[1:-1])
             codes = np.split(codes, outer_offsets[1:-1])
             paths += [mpath.Path(p, c) for p, c in zip(points, codes)]
-    elif fill_type == FillType.ChunkCombinedOffsets2:
+    elif fill_type == FillType.ChunkCombinedOffsetOffset:
         paths = []
         for points, offsets, outer_offsets in zip(*filled):
             if points is None:
@@ -39,9 +39,9 @@ def lines_to_mpl_paths(lines, line_type):
             # Drawing as Paths so that they can be closed correctly.
             closed = line[0, 0] == line[-1, 0] and line[0, 1] == line[-1, 1]
             paths.append(mpath.Path(line, closed=closed))
-    elif line_type in (LineType.SeparateCodes, LineType.ChunkCombinedCodes):
+    elif line_type in (LineType.SeparateCode, LineType.ChunkCombinedCode):
         paths = [mpath.Path(points, codes) for points, codes in zip(*lines) if points is not None]
-    elif line_type == LineType.ChunkCombinedOffsets:
+    elif line_type == LineType.ChunkCombinedOffset:
         paths = []
         for points, offsets in zip(*lines):
             if points is None:

--- a/src/fill_type.cpp
+++ b/src/fill_type.cpp
@@ -4,23 +4,23 @@
 std::ostream &operator<<(std::ostream &os, const FillType& fill_type)
 {
     switch (fill_type) {
-        case FillType::OuterCodes:
-            os << "OuterCodes";
+        case FillType::OuterCode:
+            os << "OuterCode";
             break;
-        case FillType::OuterOffsets:
-            os << "OuterOffsets";
+        case FillType::OuterOffset:
+            os << "OuterOffset";
             break;
-        case FillType::ChunkCombinedCodes:
-            os << "ChunkCombinedCodes";
+        case FillType::ChunkCombinedCode:
+            os << "ChunkCombinedCode";
             break;
-        case FillType::ChunkCombinedOffsets:
-            os << "ChunkCombinedOffsets";
+        case FillType::ChunkCombinedOffset:
+            os << "ChunkCombinedOffset";
             break;
-        case FillType::ChunkCombinedCodesOffsets:
-            os << "ChunkCombinedCodesOffsets";
+        case FillType::ChunkCombinedCodeOffset:
+            os << "ChunkCombinedCodeOffset";
             break;
-        case FillType::ChunkCombinedOffsets2:
-            os << "ChunkCombinedOffsets2";
+        case FillType::ChunkCombinedOffsetOffset:
+            os << "ChunkCombinedOffsetOffset";
             break;
     }
     return os;

--- a/src/fill_type.h
+++ b/src/fill_type.h
@@ -7,12 +7,12 @@
 // C++11 scoped enum, must be fully qualified to use.
 enum class FillType
 {
-    OuterCodes = 201,
-    OuterOffsets = 202,
-    ChunkCombinedCodes = 203,
-    ChunkCombinedOffsets = 204,
-    ChunkCombinedCodesOffsets = 205,
-    ChunkCombinedOffsets2 = 206,
+    OuterCode= 201,
+    OuterOffset = 202,
+    ChunkCombinedCode = 203,
+    ChunkCombinedOffset= 204,
+    ChunkCombinedCodeOffset = 205,
+    ChunkCombinedOffsetOffset = 206,
 };
 
 std::ostream &operator<<(std::ostream &os, const FillType& fill_type);

--- a/src/line_type.cpp
+++ b/src/line_type.cpp
@@ -7,14 +7,14 @@ std::ostream &operator<<(std::ostream &os, const LineType& line_type)
         case LineType::Separate:
             os << "Separate";
             break;
-        case LineType::SeparateCodes:
-            os << "SeparateCodes";
+        case LineType::SeparateCode:
+            os << "SeparateCode";
             break;
-        case LineType::ChunkCombinedCodes:
-            os << "ChunkCombinedCodes";
+        case LineType::ChunkCombinedCode:
+            os << "ChunkCombinedCode";
             break;
-        case LineType::ChunkCombinedOffsets:
-            os << "ChunkCombinedOffsets";
+        case LineType::ChunkCombinedOffset:
+            os << "ChunkCombinedOffset";
             break;
     }
     return os;

--- a/src/line_type.h
+++ b/src/line_type.h
@@ -8,9 +8,9 @@
 enum class LineType
 {
     Separate = 101,
-    SeparateCodes = 102,
-    ChunkCombinedCodes = 103,
-    ChunkCombinedOffsets = 104,
+    SeparateCode = 102,
+    ChunkCombinedCode = 103,
+    ChunkCombinedOffset= 104,
 };
 
 std::ostream &operator<<(std::ostream &os, const LineType& line_type);

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -11,8 +11,8 @@
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)
 
-static LineType mpl20xx_line_type = LineType::SeparateCodes;
-static FillType mpl20xx_fill_type = FillType::OuterCodes;
+static LineType mpl20xx_line_type = LineType::SeparateCode;
+static FillType mpl20xx_fill_type = FillType::OuterCode;
 
 PYBIND11_MODULE(_contourpy, m) {
     m.doc() =
@@ -33,12 +33,12 @@ PYBIND11_MODULE(_contourpy, m) {
         "Enum used for ``fill_type`` keyword argument in :func:`~contourpy.contour_generator`.\n\n"
         "This controls the format of filled contour data returned from "
         ":meth:`~contourpy.SerialContourGenerator.filled`.")
-        .value("OuterCodes", FillType::OuterCodes, "docstring for individual enum value")
-        .value("OuterOffsets", FillType::OuterOffsets)
-        .value("ChunkCombinedCodes", FillType::ChunkCombinedCodes)
-        .value("ChunkCombinedOffsets", FillType::ChunkCombinedOffsets)
-        .value("ChunkCombinedCodesOffsets", FillType::ChunkCombinedCodesOffsets)
-        .value("ChunkCombinedOffsets2", FillType::ChunkCombinedOffsets2)
+        .value("OuterCode", FillType::OuterCode, "docstring for individual enum value")
+        .value("OuterOffset", FillType::OuterOffset)
+        .value("ChunkCombinedCode", FillType::ChunkCombinedCode)
+        .value("ChunkCombinedOffset", FillType::ChunkCombinedOffset)
+        .value("ChunkCombinedCodeOffset", FillType::ChunkCombinedCodeOffset)
+        .value("ChunkCombinedOffsetOffset", FillType::ChunkCombinedOffsetOffset)
         .export_values();
 
     py::enum_<LineType>(m, "LineType",
@@ -46,9 +46,9 @@ PYBIND11_MODULE(_contourpy, m) {
         "This controls the format of contour line data returned from "
         ":meth:`~contourpy.SerialContourGenerator.lines`.")
         .value("Separate", LineType::Separate)
-        .value("SeparateCodes", LineType::SeparateCodes)
-        .value("ChunkCombinedCodes", LineType::ChunkCombinedCodes)
-        .value("ChunkCombinedOffsets", LineType::ChunkCombinedOffsets)
+        .value("SeparateCode", LineType::SeparateCode)
+        .value("ChunkCombinedCode", LineType::ChunkCombinedCode)
+        .value("ChunkCombinedOffset", LineType::ChunkCombinedOffset)
         .export_values();
 
     py::enum_<ZInterp>(m, "ZInterp",
@@ -69,7 +69,7 @@ PYBIND11_MODULE(_contourpy, m) {
         "ContourGenerator corresponding to ``name=\"mpl2005\"``.\n\n"
         "This is the original 2005 Matplotlib algorithm. "
         "Does not support any of ``corner_mask``, ``quad_as_tri``, ``threads`` or ``z_interp``. "
-        "Only supports ``line_type=LineType.SeparateCodes`` and ``fill_type=FillType.OuterCodes``. "
+        "Only supports ``line_type=LineType.SeparateCode`` and ``fill_type=FillType.OuterCode``. "
         "Only supports chunking for filled contours, not contour lines.\n\n"
         "This class implements the same interface as "
         ":class:`~contourpy._contourpy.SerialContourGenerator`.\n\n"
@@ -121,8 +121,8 @@ PYBIND11_MODULE(_contourpy, m) {
         "added ``corner_mask`` and made the code more maintainable. "
         "Only supports ``corner_mask``, does not support ``quad_as_tri``, ``threads`` or "
         "``z_interp``. \n"
-        "Only supports ``line_type=LineType.SeparateCodes`` and "
-        "``fill_type=FillType.OuterCodes``.\n\n"
+        "Only supports ``line_type=LineType.SeparateCode`` and "
+        "``fill_type=FillType.OuterCode``.\n\n"
         "This class implements the same interface as "
         ":class:`~contourpy._contourpy.SerialContourGenerator`.\n\n"
         ".. warning::\n"

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -276,7 +276,7 @@ def test_thread_count(xyz_7x5_as_arrays, chunk_size, thread_count):
 def test_enums_as_strings(xyz_3x3_as_lists):
     x, y, z = xyz_3x3_as_lists
     cg = contourpy.contour_generator(
-        x, y, z, line_type="SeparateCodes", fill_type="ChunkCombinedCodesOffsets", z_interp="Log")
-    assert cg.line_type == contourpy.LineType.SeparateCodes
-    assert cg.fill_type == contourpy.FillType.ChunkCombinedCodesOffsets
+        x, y, z, line_type="SeparateCode", fill_type="ChunkCombinedCodeOffset", z_interp="Log")
+    assert cg.line_type == contourpy.LineType.SeparateCode
+    assert cg.fill_type == contourpy.FillType.ChunkCombinedCodeOffset
     assert cg.z_interp == contourpy.ZInterp.Log

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -90,7 +90,7 @@ def test_filled_simple_no_corner_mask_chunk(name, fill_type):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_simple_corner_mask(name):
     x, y, z = simple((30, 40), want_mask=True)
-    fill_type = FillType.OuterCodes
+    fill_type = FillType.OuterCode
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, corner_mask=True)
     levels = np.arange(-1.0, 1.01, 0.1)
 
@@ -107,7 +107,7 @@ def test_filled_simple_corner_mask(name):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_simple_corner_mask_chunk(name):
     x, y, z = simple((30, 40), want_mask=True)
-    fill_type = FillType.OuterCodes
+    fill_type = FillType.OuterCode
     cont_gen = contour_generator(
         x, y, z, name=name, fill_type=fill_type, corner_mask=True, chunk_size=2)
     levels = np.arange(-1.0, 1.01, 0.1)
@@ -175,7 +175,7 @@ def test_filled_random_chunk(name, fill_type):
         max_threshold = 128
         mean_threshold = 0.16
     elif name in ("serial", "threaded"):
-        if fill_type in (FillType.ChunkCombinedCodes, FillType.ChunkCombinedOffsets):
+        if fill_type in (FillType.ChunkCombinedCode, FillType.ChunkCombinedOffset):
             max_threshold = 99
             mean_threshold = 0.142
         else:
@@ -222,7 +222,7 @@ def test_filled_random_no_corner_mask_chunk(name, fill_type):
         max_threshold = 128
         mean_threshold = 0.19
     elif name in ("serial", "threaded"):
-        if fill_type in (FillType.ChunkCombinedCodes, FillType.ChunkCombinedOffsets):
+        if fill_type in (FillType.ChunkCombinedCode, FillType.ChunkCombinedOffset):
             max_threshold = 99
             mean_threshold = 0.18
         else:
@@ -238,7 +238,7 @@ def test_filled_random_no_corner_mask_chunk(name, fill_type):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_random_corner_mask(name):
     x, y, z = random((30, 40), mask_fraction=0.05)
-    fill_type = FillType.OuterCodes
+    fill_type = FillType.OuterCode
     cont_gen = contour_generator(x, y, z, name=name, corner_mask=True, fill_type=fill_type)
     levels = np.arange(0.0, 1.01, 0.2)
 
@@ -253,7 +253,7 @@ def test_filled_random_corner_mask(name):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_random_corner_mask_chunk(name):
     x, y, z = random((30, 40), mask_fraction=0.05)
-    fill_type = FillType.OuterCodes
+    fill_type = FillType.OuterCode
     cont_gen = contour_generator(
         x, y, z, name=name, corner_mask=True, fill_type=fill_type, chunk_size=2)
     levels = np.arange(0.0, 1.01, 0.2)
@@ -300,7 +300,7 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
 
     util_test.assert_filled(filled, fill_type)
 
-    if fill_type in (FillType.OuterCodes, FillType.OuterOffsets):
+    if fill_type in (FillType.OuterCode, FillType.OuterOffset):
         points = filled[0]
         assert len(points) == 2
         assert points[0].shape == (13, 2)
@@ -308,7 +308,7 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
         assert_array_equal(points[0][0], points[0][7])
         assert_array_equal(points[0][8], points[0][12])
         assert_array_equal(points[1][0], points[1][3])
-        if fill_type == FillType.OuterCodes:
+        if fill_type == FillType.OuterCode:
             codes = filled[1]
             assert_array_equal(codes[0], [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79])
             assert_array_equal(codes[1], [1, 2, 2, 79])
@@ -324,17 +324,17 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
         assert_array_equal(points[0], points[7])
         assert_array_equal(points[8], points[12])
         assert_array_equal(points[13], points[16])
-        if fill_type in (FillType.ChunkCombinedCodes, FillType.ChunkCombinedCodesOffsets):
+        if fill_type in (FillType.ChunkCombinedCode, FillType.ChunkCombinedCodeOffset):
             codes = filled[1][0]
             assert_array_equal(codes, [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79, 1, 2, 2, 79])
         else:
             offsets = filled[1][0]
             assert_array_equal(offsets, [0, 8, 13, 17])
 
-        if fill_type == FillType.ChunkCombinedCodesOffsets:
+        if fill_type == FillType.ChunkCombinedCodeOffset:
             outer_offsets = filled[2][0]
             assert_array_equal(outer_offsets, [0, 13, 17])
-        elif fill_type == FillType.ChunkCombinedOffsets2:
+        elif fill_type == FillType.ChunkCombinedOffsetOffset:
             outer_offsets = filled[2][0]
             assert_array_equal(outer_offsets, [0, 2, 3])
 

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -33,7 +33,7 @@ def one_loop_one_strip():
 def test_level_outside(xy_2x2, name, zlevel):
     x, y = xy_2x2
     z = x
-    cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCodes)
+    cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCode)
     lines = cont_gen.lines(zlevel)
     assert isinstance(lines, tuple) and len(lines) == 2
     points, codes = lines
@@ -45,7 +45,7 @@ def test_level_outside(xy_2x2, name, zlevel):
 def test_w_to_e(xy_2x2, name):
     x, y = xy_2x2
     z = y.copy()
-    cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCodes)
+    cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCode)
     lines = cont_gen.lines(0.5)
     assert isinstance(lines, tuple) and len(lines) == 2
     points, codes = lines
@@ -59,7 +59,7 @@ def test_w_to_e(xy_2x2, name):
 def test_e_to_w(xy_2x2, name):
     x, y = xy_2x2
     z = 1.0 - y.copy()
-    cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCodes)
+    cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCode)
     lines = cont_gen.lines(0.5)
     assert isinstance(lines, tuple) and len(lines) == 2
     points, codes = lines
@@ -77,7 +77,7 @@ def test_loop(xy_3x3, name):
     x, y = xy_3x3
     z = np.zeros_like(x)
     z[1, 1] = 1.0
-    cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCodes)
+    cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCode)
     lines = cont_gen.lines(0.5)
     assert isinstance(lines, tuple) and len(lines) == 2
     points, codes = lines
@@ -157,7 +157,7 @@ def test_lines_simple_no_corner_mask_chunk(name, line_type):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_simple_corner_mask(name):
     x, y, z = simple((30, 40), want_mask=True)
-    line_type = LineType.SeparateCodes
+    line_type = LineType.SeparateCode
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, corner_mask=True)
     levels = np.arange(-1.0, 1.01, 0.1)
 
@@ -174,7 +174,7 @@ def test_lines_simple_corner_mask(name):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_simple_corner_mask_chunk(name):
     x, y, z = simple((30, 40), want_mask=True)
-    line_type = LineType.SeparateCodes
+    line_type = LineType.SeparateCode
     cont_gen = contour_generator(
         x, y, z, name=name, line_type=line_type, corner_mask=True, chunk_size=2)
     levels = np.arange(-1.0, 1.01, 0.1)
@@ -282,7 +282,7 @@ def test_lines_random_no_corner_mask_chunk(name, line_type):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_random_corner_mask(name):
     x, y, z = random((30, 40), mask_fraction=0.05)
-    line_type = LineType.SeparateCodes
+    line_type = LineType.SeparateCode
     cont_gen = contour_generator(x, y, z, name=name, corner_mask=True, line_type=line_type)
     levels = np.arange(0.0, 1.01, 0.2)
 
@@ -297,7 +297,7 @@ def test_lines_random_corner_mask(name):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_random_corner_mask_chunk(name):
     x, y, z = random((30, 40), mask_fraction=0.05)
-    line_type = LineType.SeparateCodes
+    line_type = LineType.SeparateCode
     cont_gen = contour_generator(x, y, z, name=name, corner_mask=True, line_type=line_type)
     levels = np.arange(0.0, 1.01, 0.2)
 
@@ -339,19 +339,19 @@ def test_return_by_line_type(one_loop_one_strip, name, line_type):
         assert len(points) == 2
         assert points[0].shape == (5, 2)
         assert points[1].shape == (2, 2)
-    elif line_type == LineType.SeparateCodes:
+    elif line_type == LineType.SeparateCode:
         points, codes = lines
         assert len(points) == 2
         assert points[0].shape == (5, 2)
         assert points[1].shape == (2, 2)
         assert_array_equal(codes[0], [1, 2, 2, 2, 79])
         assert_array_equal(codes[1], [1, 2])
-    elif line_type == LineType.ChunkCombinedCodes:
+    elif line_type == LineType.ChunkCombinedCode:
         assert len(lines[0]) == 1  # Single chunk.
         points, codes = lines[0][0], lines[1][0]
         assert points.shape == (7, 2)
         assert_array_equal(codes, [1, 2, 2, 2, 79, 1, 2])
-    elif line_type == LineType.ChunkCombinedOffsets:
+    elif line_type == LineType.ChunkCombinedOffset:
         assert len(lines[0]) == 1  # Single chunk.
         points, offsets = lines[0][0], lines[1][0]
         assert points.shape == (7, 2)

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -17,9 +17,9 @@ def test_default_fill_type(class_name):
     default = cls.default_fill_type
     assert isinstance(default, FillType)
     if class_name in ("Mpl2005ContourGenerator", "Mpl2014ContourGenerator"):
-        expect = FillType.OuterCodes
+        expect = FillType.OuterCode
     else:
-        expect = FillType.OuterOffsets
+        expect = FillType.OuterOffset
     assert default == expect
 
 
@@ -29,7 +29,7 @@ def test_default_line_type(class_name):
     default = cls.default_line_type
     assert isinstance(default, LineType)
     if class_name in ("Mpl2005ContourGenerator", "Mpl2014ContourGenerator"):
-        expect = LineType.SeparateCodes
+        expect = LineType.SeparateCode
     else:
         expect = LineType.Separate
     assert default == expect
@@ -47,11 +47,11 @@ def test_supports_corner_mask(class_name):
 @pytest.mark.parametrize("class_name", util_test.all_class_names())
 def test_supports_fill_type(class_name):
     cls = get_class_from_name(class_name)
-    supports = cls.supports_fill_type(FillType.OuterCodes)
+    supports = cls.supports_fill_type(FillType.OuterCode)
     assert isinstance(supports, bool)
     expect = True
     assert supports == expect
-    supports = cls.supports_fill_type(FillType.ChunkCombinedOffsets2)
+    supports = cls.supports_fill_type(FillType.ChunkCombinedOffsetOffset)
     assert isinstance(supports, bool)
     expect = class_name not in ("Mpl2005ContourGenerator", "Mpl2014ContourGenerator")
     assert supports == expect
@@ -60,11 +60,11 @@ def test_supports_fill_type(class_name):
 @pytest.mark.parametrize("class_name", util_test.all_class_names())
 def test_supports_line_type(class_name):
     cls = get_class_from_name(class_name)
-    supports = cls.supports_line_type(LineType.SeparateCodes)
+    supports = cls.supports_line_type(LineType.SeparateCode)
     assert isinstance(supports, bool)
     expect = True
     assert supports == expect
-    supports = cls.supports_line_type(LineType.ChunkCombinedOffsets)
+    supports = cls.supports_line_type(LineType.ChunkCombinedOffset)
     assert isinstance(supports, bool)
     expect = class_name not in ("Mpl2005ContourGenerator", "Mpl2014ContourGenerator")
     assert supports == expect

--- a/tests/util_config.py
+++ b/tests/util_config.py
@@ -146,7 +146,7 @@ class Config:
             lines = filled[0]
         else:
             lines = cont_gen.lines(zlower)
-            if cont_gen.line_type == LineType.SeparateCodes:
+            if cont_gen.line_type == LineType.SeparateCode:
                 lines = lines[0]
 
         # May be 0..2 polygons, and there cannot be any holes.

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -26,35 +26,35 @@ def all_names(exclude=None):
 
 def all_names_and_fill_types():
     return [
-        ("mpl2005", FillType.OuterCodes),
-        ("mpl2014", FillType.OuterCodes),
-        ("serial", FillType.OuterCodes),
-        ("serial", FillType.OuterOffsets),
-        ("serial", FillType.ChunkCombinedCodes),
-        ("serial", FillType.ChunkCombinedOffsets),
-        ("serial", FillType.ChunkCombinedCodesOffsets),
-        ("serial", FillType.ChunkCombinedOffsets2),
-        ("threaded", FillType.OuterCodes),
-        ("threaded", FillType.OuterOffsets),
-        ("threaded", FillType.ChunkCombinedCodes),
-        ("threaded", FillType.ChunkCombinedOffsets),
-        ("threaded", FillType.ChunkCombinedCodesOffsets),
-        ("threaded", FillType.ChunkCombinedOffsets2),
+        ("mpl2005", FillType.OuterCode),
+        ("mpl2014", FillType.OuterCode),
+        ("serial", FillType.OuterCode),
+        ("serial", FillType.OuterOffset),
+        ("serial", FillType.ChunkCombinedCode),
+        ("serial", FillType.ChunkCombinedOffset),
+        ("serial", FillType.ChunkCombinedCodeOffset),
+        ("serial", FillType.ChunkCombinedOffsetOffset),
+        ("threaded", FillType.OuterCode),
+        ("threaded", FillType.OuterOffset),
+        ("threaded", FillType.ChunkCombinedCode),
+        ("threaded", FillType.ChunkCombinedOffset),
+        ("threaded", FillType.ChunkCombinedCodeOffset),
+        ("threaded", FillType.ChunkCombinedOffsetOffset),
     ]
 
 
 def all_names_and_line_types():
     return [
-        ("mpl2005", LineType.SeparateCodes),
-        ("mpl2014", LineType.SeparateCodes),
+        ("mpl2005", LineType.SeparateCode),
+        ("mpl2014", LineType.SeparateCode),
         ("serial", LineType.Separate),
-        ("serial", LineType.SeparateCodes),
-        ("serial", LineType.ChunkCombinedCodes),
-        ("serial", LineType.ChunkCombinedOffsets),
+        ("serial", LineType.SeparateCode),
+        ("serial", LineType.ChunkCombinedCode),
+        ("serial", LineType.ChunkCombinedOffset),
         ("threaded", LineType.Separate),
-        ("threaded", LineType.SeparateCodes),
-        ("threaded", LineType.ChunkCombinedCodes),
-        ("threaded", LineType.ChunkCombinedOffsets),
+        ("threaded", LineType.SeparateCode),
+        ("threaded", LineType.ChunkCombinedCode),
+        ("threaded", LineType.ChunkCombinedOffset),
     ]
 
 
@@ -68,21 +68,21 @@ def quad_as_tri_names():
 
 def all_fill_types_str_value():
     return [
-        ("OuterCodes", 201),
-        ("OuterOffsets", 202),
-        ("ChunkCombinedCodes", 203),
-        ("ChunkCombinedOffsets", 204),
-        ("ChunkCombinedCodesOffsets", 205),
-        ("ChunkCombinedOffsets2", 206),
+        ("OuterCode", 201),
+        ("OuterOffset", 202),
+        ("ChunkCombinedCode", 203),
+        ("ChunkCombinedOffset", 204),
+        ("ChunkCombinedCodeOffset", 205),
+        ("ChunkCombinedOffsetOffset", 206),
     ]
 
 
 def all_line_types_str_value():
     return [
         ("Separate", 101),
-        ("SeparateCodes", 102),
-        ("ChunkCombinedCodes", 103),
-        ("ChunkCombinedOffsets", 104),
+        ("SeparateCode", 102),
+        ("ChunkCombinedCode", 103),
+        ("ChunkCombinedOffset", 104),
     ]
 
 
@@ -123,7 +123,7 @@ def assert_offset_array(offsets, max_offset):
 
 
 def assert_filled(filled, fill_type):
-    if fill_type == FillType.OuterCodes:
+    if fill_type == FillType.OuterCode:
         assert isinstance(filled, tuple) and len(filled) == 2
         polygons, codes = filled
         assert isinstance(polygons, list)
@@ -132,7 +132,7 @@ def assert_filled(filled, fill_type):
         for polygon, code in zip(polygons, codes):
             npoints = assert_point_array(polygon)
             assert_code_array(code, npoints)
-    elif fill_type == FillType.OuterOffsets:
+    elif fill_type == FillType.OuterOffset:
         assert isinstance(filled, tuple) and len(filled) == 2
         polygons, offsets = filled
         assert isinstance(polygons, list)
@@ -141,7 +141,7 @@ def assert_filled(filled, fill_type):
         for polygon, offset in zip(polygons, offsets):
             npoints = assert_point_array(polygon)
             assert_offset_array(offset, npoints)
-    elif fill_type == FillType.ChunkCombinedCodes:
+    elif fill_type == FillType.ChunkCombinedCode:
         assert isinstance(filled, tuple) and len(filled) == 2
         polygons, codes = filled
         assert isinstance(polygons, list)
@@ -153,7 +153,7 @@ def assert_filled(filled, fill_type):
             else:
                 npoints = assert_point_array(polygon)
                 assert_code_array(code, npoints)
-    elif fill_type == FillType.ChunkCombinedOffsets:
+    elif fill_type == FillType.ChunkCombinedOffset:
         assert isinstance(filled, tuple) and len(filled) == 2
         polygons, offsets = filled
         assert isinstance(polygons, list)
@@ -165,7 +165,7 @@ def assert_filled(filled, fill_type):
             else:
                 npoints = assert_point_array(polygon)
                 assert_offset_array(offset, npoints)
-    elif fill_type == FillType.ChunkCombinedCodesOffsets:
+    elif fill_type == FillType.ChunkCombinedCodeOffset:
         assert isinstance(filled, tuple) and len(filled) == 3
         polygons, codes, outer_offsets = filled
         assert isinstance(polygons, list)
@@ -179,7 +179,7 @@ def assert_filled(filled, fill_type):
                 npoints = assert_point_array(polygon)
                 assert_code_array(code, npoints)
                 assert_offset_array(outer_offset, npoints)
-    elif fill_type == FillType.ChunkCombinedOffsets2:
+    elif fill_type == FillType.ChunkCombinedOffsetOffset:
         assert isinstance(filled, tuple) and len(filled) == 3
         polygons, offsets, outer_offsets = filled
         assert isinstance(polygons, list)
@@ -202,7 +202,7 @@ def assert_lines(lines, line_type):
         assert isinstance(lines, list)
         for line in lines:
             assert_point_array(line)
-    elif line_type == LineType.SeparateCodes:
+    elif line_type == LineType.SeparateCode:
         assert isinstance(lines, tuple) and len(lines) == 2
         lines, codes = lines
         assert isinstance(lines, list)
@@ -211,7 +211,7 @@ def assert_lines(lines, line_type):
         for line, code in zip(lines, codes):
             npoints = assert_point_array(line)
             assert_code_array(code, npoints)
-    elif line_type == LineType.ChunkCombinedCodes:
+    elif line_type == LineType.ChunkCombinedCode:
         assert isinstance(lines, tuple) and len(lines) == 2
         points, codes = lines
         assert isinstance(points, list)
@@ -223,7 +223,7 @@ def assert_lines(lines, line_type):
             else:
                 npoints = assert_point_array(line)
                 assert_code_array(code, npoints)
-    elif line_type == LineType.ChunkCombinedOffsets:
+    elif line_type == LineType.ChunkCombinedOffset:
         assert isinstance(lines, tuple) and len(lines) == 2
         points, offsets = lines
         assert isinstance(points, list)


### PR DESCRIPTION
Finalise the enum spellings. Preferring singular to plural, and avoiding `Offset2` as there is also a valid `Offset` and the single character difference is dangerous.