### PR TITLE
Complete mask render function

### DIFF
--- a/docs/user_guide/z_corner_mask.rst
+++ b/docs/user_guide/z_corner_mask.rst
@@ -91,7 +91,7 @@ If ``corner_mask=False`` all quads that touch a masked out point are completely 
 If ``corner_mask=True`` then only the triangular corners of quads nearest masked out points are
 always masked out, other corners that contain 3 unmasked points are contoured as usual.
 
-Here is an example of the difference:
+Here is an example of the difference, the black circles indicate masked out points:
 
 .. plot::
    :source-position: below
@@ -117,6 +117,7 @@ Here is an example of the difference:
            renderer.filled(filled, cont_gen.fill_type, ax=ax, color=f"C{i}")
 
        renderer.grid(x, y, ax=ax)
+       renderer.mask(x, y, z, ax=ax)
        renderer.title(f"corner_mask = {corner_mask}", ax=ax)
 
    renderer.show()

--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -75,7 +75,7 @@ class BokehRenderer:
                 :func:`~contourpy.SerialContourGenerator.filled`.
             fill_type (FillType): Type of ``filled`` data, as returned by
                 :attr:`~contourpy.SerialContourGenerator.fill_type`.
-            ax (int or Bokeh Figure, optional): Which plot to plot on.
+            ax (int or Bokeh Figure, optional): Which plot to use.
             color (str, optional): Color to plot with. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the
                 ``Category10`` palette. Default ``"C0"``.
@@ -93,7 +93,7 @@ class BokehRenderer:
         Args:
             x (array-like of shape (ny, nx) or (nx,)): The x-coordinates of the grid points.
             y (array-like of shape (ny, nx) or (ny,)): The y-coordinates of the grid points.
-            ax (int or Bokeh Figure, optional): Which plot to plot on.
+            ax (int or Bokeh Figure, optional): Which plot to use.
             color (str, optional): Color to plot grid lines, default ``"black"``.
             alpha (float, optional): Opacity to plot lines with, default ``0.1``.
             point_color (str, optional): Color to plot grid points or ``None`` if grid points
@@ -136,7 +136,7 @@ class BokehRenderer:
                 :func:`~contourpy.SerialContourGenerator.lines`.
             line_type (LineType): Type of ``lines`` data, as returned by
                 :attr:`~contourpy.SerialContourGenerator.line_type`.
-            ax (int or Bokeh Figure, optional): Which plot to plot on.
+            ax (int or Bokeh Figure, optional): Which plot to use.
             color (str, optional): Color to plot lines. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the
                 ``Category10`` palette. Default ``"C0"``.
@@ -151,6 +151,24 @@ class BokehRenderer:
         xs, ys = lines_to_bokeh(lines, line_type)
         if len(xs) > 0:
             fig.multi_line(xs, ys, line_color=color, line_alpha=alpha, line_width=linewidth)
+
+    def mask(self, x, y, z, ax=0, color="black"):
+        """Plot masked out grid points as circles on a single plot.
+
+        Args:
+            x (array-like of shape (ny, nx) or (nx,)): The x-coordinates of the grid points.
+            y (array-like of shape (ny, nx) or (ny,)): The y-coordinates of the grid points.
+            z (masked array of shape (ny, nx): z-values.
+            ax (int or Bokeh Figure, optional): Which plot to use.
+            color (str, optional): Circle color.
+        """
+        mask = np.ma.getmask(z)
+        if mask is np.ma.nomask:
+            return
+        fig = self._get_figure(ax)
+        color = self._convert_color(color)
+        x, y = self._grid_as_2d(x, y)
+        fig.circle(x[mask], y[mask], fill_color=color, size=10)
 
     def save(self, filename):
         """Save plots to SVG or PNG file.
@@ -205,7 +223,7 @@ class BokehRenderer:
             x (array-like of shape (ny, nx) or (nx,)): The x-coordinates of the grid points.
             y (array-like of shape (ny, nx) or (ny,)): The y-coordinates of the grid points.
             z (array-like of shape (ny, nx): z-values.
-            ax (int or Bokeh Figure, optional): Which plot to plot on.
+            ax (int or Bokeh Figure, optional): Which plot to use.
             color (str, optional): Color of added text. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the
                 ``Category10`` palette. Default ``"green"``.

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -143,10 +143,18 @@ class MplRenderer:
         ax._need_autoscale = True
 
     def mask(self, x, y, z, ax=0, color="black"):
+        """Plot masked out grid points as circles on a single Axes.
+
+        Args:
+            x (array-like of shape (ny, nx) or (nx,)): The x-coordinates of the grid points.
+            y (array-like of shape (ny, nx) or (ny,)): The y-coordinates of the grid points.
+            z (masked array of shape (ny, nx): z-values.
+            ax (int or Matplotlib Axes, optional): Which Axes to plot on.
+            color (str, optional): Circle color.
+        """
         mask = np.ma.getmask(z)
         if mask is np.ma.nomask:
             return
-
         ax = self._get_ax(ax)
         x, y = self._grid_as_2d(x, y)
         ax.plot(x[mask], y[mask], 'o', c=color)


### PR DESCRIPTION
Previously had a part-implemented `MplRenderer.mask` function to render masked out points as coloured circles. This PR completes that and the Bokeh equivalent, with docstrings, and updates the `corner_mask` example in the docs to use the mask to make the explanation clearer.