### PR TITLE
Test filled compare slow

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -99,7 +99,7 @@ protected:
     void closed_line_wrapper(
         const Location& start_location, OuterOrHole outer_or_hole, ChunkLocal& local);
 
-    // If point/line/hole counts not consistent, throw runtime_exception.
+    // If point/line/hole counts not consistent, throw runtime error.
     void check_consistent_counts(const ChunkLocal& local) const;
 
     // Write points and offsets/codes to output numpy arrays.

--- a/src/base.h
+++ b/src/base.h
@@ -99,6 +99,9 @@ protected:
     void closed_line_wrapper(
         const Location& start_location, OuterOrHole outer_or_hole, ChunkLocal& local);
 
+    // If point/line/hole counts not consistent, throw runtime_exception.
+    void check_consistent_counts(const ChunkLocal& local) const;
+
     // Write points and offsets/codes to output numpy arrays.
     void export_filled(ChunkLocal& local, std::vector<py::list>& return_lists);
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)


### PR DESCRIPTION
Added `test_filled_compare_slow` which is a 1000 times repeated slow test, to run through lots of random `corner_mask=True` data sets and compare the outputs (number of lines, outers and points) for `mpl2014` and `serial`. This test is not run by default as takes ~30 minutes on my 6-core dev laptop (using `pytest-xdist`).

Also changed asserts that line/outer/hole counts are the same after each pass into exceptions, as they usually indicate a bug in the `serial` code that need to be identified without running in debug mode.