### PR TITLE
Improved name to class mapping

### DIFF
--- a/docs/sphinxext/name_supports.py
+++ b/docs/sphinxext/name_supports.py
@@ -15,8 +15,8 @@ class NameSupports(Directive):
     }
 
     def run(self):
-        names = contourpy._valid_names
-        classes = [contourpy._name_to_class(name) for name in names]
+        names = list(contourpy._class_lookup)
+        classes = list(contourpy._class_lookup.values())
         function_names = [
             "supports_corner_mask",
             "supports_quad_as_tri",

--- a/docs/sphinxext/name_supports_type.py
+++ b/docs/sphinxext/name_supports_type.py
@@ -19,8 +19,8 @@ class NameSupportsType(Directive):
         supports_func_name = f"supports_{lowercase_name}"
         type_enum = getattr(contourpy, type_name)
 
-        names = contourpy._valid_names
-        classes = [contourpy._name_to_class(name) for name in names]
+        names = list(contourpy._class_lookup)
+        classes = list(contourpy._class_lookup.values())
         default_types = [getattr(cls, default_func_name).name for cls in classes]
 
         table = Table(1 + len(names))

--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -23,13 +23,13 @@ __all__ = [
 ]
 
 
-def _name_to_class(name):
-    class_name = f"{name.capitalize()}ContourGenerator"
-    cls = globals()[class_name]
-    return cls
-
-
-_valid_names = ["mpl2005", "mpl2014", "serial", "threaded"]
+# Simple mapping of algorithm name to class name.
+_class_lookup = dict(
+    mpl2005=Mpl2005ContourGenerator,
+    mpl2014=Mpl2014ContourGenerator,
+    serial=SerialContourGenerator,
+    threaded=ThreadedContourGenerator,
+)
 
 
 def contour_generator(x=None, y=None, z=None, *, name="serial", corner_mask=None, line_type=None,
@@ -141,14 +141,14 @@ def contour_generator(x=None, y=None, z=None, *, name="serial", corner_mask=None
         raise ValueError("If mask is set it must be a 2D array with the same shape as z")
 
     # Check arguments: name.
-    if name not in _valid_names:
+    if name not in _class_lookup:
         raise ValueError(f"Unrecognised contour generator name: {name}")
 
     # Check arguments: chunk_size, chunk_count and total_chunk_count.
     y_chunk_size, x_chunk_size = calc_chunk_sizes(
         chunk_size, chunk_count, total_chunk_count, ny, nx)
 
-    cls = _name_to_class(name)
+    cls = _class_lookup[name]
 
     # Check arguments: corner_mask.
     if corner_mask is None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,4 +65,3 @@ per-file-ignores =
     tests/util_config.py: E402,
     # F401 = module imported but unused.
     docs/conf.py: F401,
-    tests/test_static.py: F401,

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -7,8 +7,16 @@ from contourpy import (
 )
 
 
-def get_class_from_name(name):
-    return globals()[name]
+_lookup = {
+    "Mpl2005ContourGenerator": Mpl2005ContourGenerator,
+    "Mpl2014ContourGenerator": Mpl2014ContourGenerator,
+    "SerialContourGenerator": SerialContourGenerator,
+    "ThreadedContourGenerator": ThreadedContourGenerator,
+}
+
+
+def get_class_from_name(class_name):
+    return _lookup[class_name]
 
 
 @pytest.mark.parametrize("class_name", util_test.all_class_names())


### PR DESCRIPTION
Avoid using `globals` for name to class map when a simple dict suffices.