### PR TITLE
Convert np.nan/np.inf in z to masked array

### DIFF
--- a/docs/user_guide/z_corner_mask.rst
+++ b/docs/user_guide/z_corner_mask.rst
@@ -56,24 +56,8 @@ Mask
 
 The ``z`` array passed to :func:`~contourpy.contour_generator` can be a
 `NumPy masked array <https://numpy.org/doc/stable/reference/maskedarray.html>`_ to mask out specific
-grid points from contour calculations.
-
-A ``z`` that isn't masked but instead contains non-finite values like ``np.nan`` and ``np.inf`` can
-be converted to a masked array using ``np.ma.masked_invalid()``.  For example:
-
-  >>> import numpy as np
-  >>> z = np.asarray([[np.nan, 1.0], [2.0, np.inf]])
-  >>> z
-  array([[nan,  1.],
-         [ 2., inf]])
-  >>> z = np.ma.masked_invalid(z)
-  >>> z
-  masked_array(
-    data=[[--, 1.0],
-          [2.0, --]],
-    mask=[[ True, False],
-          [False,  True]],
-    fill_value=1e+20)
+grid points from contour calculations.  In addition, any ``z`` values which are non-finite
+(``np.inf`` or ``np.nan``) will also be masked out.
 
 .. note::
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,7 +1,48 @@
-from contourpy import max_threads
+from contourpy import max_threads, _remove_z_mask
+import numpy as np
 
 
 def test_max_threads():
     n = max_threads()
     # Assume testing on machine with 2 or more cores.
     assert n > 1
+
+
+def test_remove_z_mask():
+    zlist = [[1.0, 2.0], [3.0, 4.0]]
+
+    zz, mask = _remove_z_mask(zlist)
+    assert isinstance(zz, np.ndarray)
+    assert mask is None
+
+    zarr = np.asarray(zlist)
+    zz, mask = _remove_z_mask(zarr)
+    assert isinstance(zz, np.ndarray)
+    assert mask is None
+
+    z = np.ma.array(zlist, mask=[[0, 0], [0, 0]])
+    zz, mask = _remove_z_mask(zarr)
+    assert isinstance(zz, np.ndarray)
+    assert mask is None
+
+    z = np.ma.array(zlist, mask=[[1, 0], [0, 0]])
+    zz, mask = _remove_z_mask(z)
+    assert isinstance(zz, np.ndarray)
+    assert isinstance(mask, np.ndarray)
+    assert mask.dtype == bool
+    np.testing.assert_array_equal(mask, [[True, False], [False, False]])
+
+    z = [[1.0, np.nan], [2.0, np.inf]]
+    zz, mask = _remove_z_mask(z)
+    assert isinstance(zz, np.ndarray)
+    assert isinstance(mask, np.ndarray)
+    assert mask.dtype == bool
+    np.testing.assert_array_equal(mask, [[False, True], [False, True]])
+
+    z = np.ma.array(zlist, mask=[[1, 0], [0, 0]])
+    z[1][1] = np.nan
+    zz, mask = _remove_z_mask(z)
+    assert isinstance(zz, np.ndarray)
+    assert isinstance(mask, np.ndarray)
+    assert mask.dtype == bool
+    np.testing.assert_array_equal(mask, [[True, False], [False, True]])


### PR DESCRIPTION
As well as supporting `z` being a masked array, also convert `np.nan` and `np.inf` to mask too.