### PR TITLE
Relax numpy version requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ url = https://github.com/contourpy/contourpy
 
 [options]
 install_requires =
-    numpy>=1.20
+    numpy>=1.16
 package_dir =
     = lib
 packages = find:


### PR DESCRIPTION
Relax min numpy version requirement from 1.20 to 1.16.