### PR TITLE
Rename license_file to license_files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
     Topic :: Scientific/Engineering :: Visualization
 description = Python library for calculating contours of 2D quadrilateral grids
 license = BSD-3-Clause
-license_file = LICENSE
+license_files = LICENSE
 long_description = file: README.md
 long_description_content_type = text/markdown
 name = contourpy


### PR DESCRIPTION
`license_file` is deprecated in setuptools, use `license_files` instead.