### PR TITLE
Add ContourGenerator base class

### DIFF
--- a/docs/api/top.rst
+++ b/docs/api/top.rst
@@ -15,13 +15,18 @@ contourpy
 .. autofunction:: max_threads
 
 
-.. autoclass:: Mpl2005ContourGenerator
-
-.. autoclass:: Mpl2014ContourGenerator
-
-.. autoclass:: SerialContourGenerator
+.. autoclass:: ContourGenerator
    :members:
-   :special-members: __init__
    :exclude-members: create_contour, create_filled_contour
 
+.. autoclass:: Mpl2005ContourGenerator
+   :show-inheritance:
+
+.. autoclass:: Mpl2014ContourGenerator
+   :show-inheritance:
+
+.. autoclass:: SerialContourGenerator
+   :show-inheritance:
+
 .. autoclass:: ThreadedContourGenerator
+   :show-inheritance:

--- a/docs/benchmarks/threads.rst
+++ b/docs/benchmarks/threads.rst
@@ -8,9 +8,9 @@ Benchmarks for the ``threaded`` algorithm are shown here, for unmasked ``z``, a
 .. image:: ../_static/threaded_simple_1000.svg
 
 For the ``simple`` dataset contour calculations are faster with more threads but only slightly.  The
-speedup with 6 threads is only about 1.8 for both :func:`~contourpy.SerialContourGenerator.lines`
-and :func:`~contourpy.SerialContourGenerator.filled`.  This problem dataset is not computationally
-expensive enough to justify the use of multiple threads.
+speedup with 6 threads is only about 1.8 for both :func:`~contourpy.ContourGenerator.lines` and
+:func:`~contourpy.ContourGenerator.filled`.  This problem dataset is not computationally expensive
+enough to justify the use of multiple threads.
 
 .. image:: ../_static/threaded_random_1000.svg
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,7 +11,7 @@ Firstly create a simple 2x2 grid of ``z`` values using Python lists:
   >>> z = [[0.0, 0.1], [0.2, 0.3]]
 
 Import the :func:`~contourpy.contour_generator` function and call it to create and return the
-``ContourGenerator`` object that will be used to contour the ``z`` values:
+:class:`~contourpy.ContourGenerator` object that will be used to contour the ``z`` values:
 
   >>> from contourpy import contour_generator
   >>> cont_gen = contour_generator(z=z)
@@ -35,7 +35,7 @@ consisting of two ``(x, y)`` points from ``(0.5, 1)`` to ``(1, 0.75)``.
 
 .. note::
 
-   The format of data returned by :meth:`~contourpy.SerialContourGenerator.lines` is controlled by
+   The format of data returned by :meth:`~contourpy.ContourGenerator.lines` is controlled by
    the ``line_type`` argument passed to :func:`~contourpy.contour_generator`.
 
 Filled contours
@@ -62,7 +62,7 @@ explained further in :ref:`fill_type`.
 
 .. note::
 
-   The format of data returned by :meth:`~contourpy.SerialContourGenerator.filled` is controlled by
+   The format of data returned by :meth:`~contourpy.ContourGenerator.filled` is controlled by
    the ``filled_type`` argument passed to :func:`~contourpy.contour_generator`.
 
 Graphical output

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,17 +4,17 @@ Usage
 The standard approach to use ``contourpy`` is to:
 
 #. Call :func:`~contourpy.contour_generator` passing your 2D ``z`` array and optional ``x`` and ``y``
-   arrays as arguments to return a ``ContourGenerator`` object, such as the default
+   arrays as arguments to return a :class:`~contourpy.ContourGenerator` object, such as the default
    :class:`~contourpy.SerialContourGenerator`.
 
-#. Call ``ContourGenerator`` member functions :meth:`~contourpy.SerialContourGenerator.lines` and/or
-   :meth:`~contourpy.SerialContourGenerator.filled` repeatedly to calculate and return contours for
-   that (x, y, z) grid:
+#. Call :class:`~contourpy.ContourGenerator` member functions
+   :meth:`~contourpy.ContourGenerator.lines` and/or :meth:`~contourpy.ContourGenerator.filled`
+   repeatedly to calculate and return contours for that (x, y, z) grid:
 
-    a. :meth:`~contourpy.SerialContourGenerator.lines` calculates contour lines at a particular
+    a. :meth:`~contourpy.ContourGenerator.lines` calculates contour lines at a particular
        z-level.
 
-    b. :meth:`~contourpy.SerialContourGenerator.filled` calculates filled contours (polygons)
+    b. :meth:`~contourpy.ContourGenerator.filled` calculates filled contours (polygons)
        between two z-levels.
 
 There are many arguments for :func:`~contourpy.contour_generator` but only ``z`` is compulsory and
@@ -22,10 +22,10 @@ there are sensible defaults for the others.
 
 .. note::
 
-   Although it is possible to create ``ContourGenerator`` objects directly from the
-   `pybind11`_-wrapped C++ code in ``wrap.cpp``, this is discouraged as
-   :func:`~contourpy.contour_generator` provides better argument checking and also support for
-   numpy masked ``z`` arrays.
+   Although it is possible to create objects of classes derived from
+   :class:`~contourpy.ContourGenerator` directly from the `pybind11`_-wrapped C++ code in
+   ``wrap.cpp``, this is discouraged as :func:`~contourpy.contour_generator` provides better
+   argument checking and also support for numpy masked ``z`` arrays.
 
 There are some utility functions in the :mod:`contourpy.util` module for testing and examples,
 including producing graphical output using `Matplotlib`_ and `Bokeh`_.

--- a/docs/user_guide/fill_type.rst
+++ b/docs/user_guide/fill_type.rst
@@ -5,7 +5,7 @@ Fill type
 
 :class:`~contourpy.FillType` is an enum that is passed as the ``fill_type`` keyword argument to
 :func:`~contourpy.contour_generator()` and is used to specify the format of data returned from calls
-to :func:`~contourpy.SerialContourGenerator.filled`. If not explicitly specified then the default is
+to :func:`~contourpy.ContourGenerator.filled`. If not explicitly specified then the default is
 used for the requested algorithm ``name``.
 
 Supported enum members and the default vary by algorithm:
@@ -23,7 +23,7 @@ A string name can be used instead of the enum member so the following are equiva
    other whereas filled contours consist of polygons that always have an outer (exterior) boundary
    but may also contain any number of holes (interior boundaries). The relationship between outer
    boundaries and their holes is calculated and returned by
-   :func:`~contourpy.SerialContourGenerator.filled` for all :class:`~contourpy.FillType` members
+   :func:`~contourpy.ContourGenerator.filled` for all :class:`~contourpy.FillType` members
    except for ``ChunkCombinedCode`` and ``ChunkCombinedOffset``.
 
 Enum members are a combination of the following words:
@@ -40,7 +40,7 @@ Where **Offset** occurs twice the first refers to the offsets of individual boun
 holes) within a larger collection and the second to which of those boundaries are grouped together
 into polygons.
 
-The format of data returned by :func:`~contourpy.SerialContourGenerator.filled` for each of the
+The format of data returned by :func:`~contourpy.ContourGenerator.filled` for each of the
 possible :class:`~contourpy.FillType` members is best illustrated through an example.  This is the
 same example data used for :ref:`line_type` but calling ``filled(1, 2)`` instead of ``lines(2)``.
 
@@ -236,7 +236,7 @@ subsequent analysis.
 
 .. note::
 
-   The order of boundaries returned by a particular :func:`~contourpy.SerialContourGenerator.filled`
+   The order of boundaries returned by a particular :func:`~contourpy.ContourGenerator.filled`
    call is deterministic except for the combination of ``name="threaded"`` and either
    ``fill_type=FillType.OuterCode`` or ``fill_type=FillType.OuterOffset``. This is because the
    order that the chunks are processed in is not deterministic and boundaries are appended to the

--- a/docs/user_guide/line_type.rst
+++ b/docs/user_guide/line_type.rst
@@ -5,7 +5,7 @@ Line type
 
 :class:`~contourpy.LineType` is an enum that is passed as the ``line_type`` keyword argument to
 :func:`~contourpy.contour_generator()` and is used to specify the format of data returned from calls
-to :func:`~contourpy.SerialContourGenerator.lines`. If not explicitly specified then the default is
+to :func:`~contourpy.ContourGenerator.lines`. If not explicitly specified then the default is
 used for the requested algorithm ``name``.
 
 Supported enum members and the default vary by algorithm:
@@ -25,7 +25,7 @@ Enum members are a combination of the following words:
   * **Code**: includes `Matplotlib`_ kind codes for the previous line array.
   * **Offset**: individual lines are identified via offsets into the previous line array.
 
-The format of data returned by :func:`~contourpy.SerialContourGenerator.lines` for each of the
+The format of data returned by :func:`~contourpy.ContourGenerator.lines` for each of the
 possible :class:`~contourpy.LineType` members is best illustrated through an example.
 
 .. plot::
@@ -148,7 +148,7 @@ analysis.
 
 .. note::
 
-   The order of lines returned by a particular :func:`~contourpy.SerialContourGenerator.lines` call
+   The order of lines returned by a particular :func:`~contourpy.ContourGenerator.lines` call
    is deterministic except for the combination of ``name="threaded"`` and either
    ``line_type=LineType.Separate`` or ``line_type=LineType.SeparateCode``. This is because the
    order that the chunks are processed in is not deterministic and lines are appended to the

--- a/docs/user_guide/x_and_y.rst
+++ b/docs/user_guide/x_and_y.rst
@@ -88,4 +88,4 @@ examples of curved and polar grids:
 
    If ``x`` or ``y`` are 2D contiguous C-ordered ``np.float64`` arrays then they are not copied by
    :func:`~contourpy.contour_generator` and they can be altered in your client code after the
-   ``ContourGenerator`` has been created.  See :ref:`z_array` for more details.
+   :class:`~contourpy.ContourGenerator` has been created.  See :ref:`z_array` for more details.

--- a/docs/user_guide/z_corner_mask.rst
+++ b/docs/user_guide/z_corner_mask.rst
@@ -17,10 +17,10 @@ You can avoid this copy by passing it in the desired format.
 
 .. warning::
 
-   If the ``z`` array does not need to be copied then both the ``ContourGenerator`` and your client
-   code have access to the same shared array. This means that you can purposefully or accidentally
-   alter the data that the ``ContourGenerator`` is using, which is almost certainly not a good idea!
-   Here is an example of this:
+   If the ``z`` array does not need to be copied then both the :class:`~contourpy.ContourGenerator`
+   and your client code have access to the same shared array. This means that you can purposefully
+   or accidentally alter the data that the :class:`~contourpy.ContourGenerator` is using, which is
+   almost certainly not a good idea! Here is an example of this:
 
    >>> from contourpy import contour_generator
    >>> import numpy as np
@@ -33,14 +33,14 @@ You can avoid this copy by passing it in the desired format.
    3
 
    ``z`` is a contiguous C-ordered ``np.float64`` array and the change in reference counts shows
-   that the ``ContourGenerator`` is using this ``z`` array.
+   that the :class:`~contourpy.ContourGenerator` is using this ``z`` array.
 
     >>> cont_gen.lines(0.5)
     [array([[0. , 0.5],
             [1. , 0.5]])]
 
-   Now change an element of the ``z`` array that is used by the ``ContourGenerator`` and repeat the
-   same :func:`~contourpy.SerialContourGenerator.lines` call:
+   Now change an element of the ``z`` array that is used by the :class:`~contourpy.ContourGenerator`
+   and repeat the same :func:`~contourpy.ContourGenerator.lines` call:
 
    >>> z[0, 0] = -1.
    >>> cont_gen.lines(0.5)
@@ -61,9 +61,9 @@ grid points from contour calculations.  In addition, any ``z`` values which are 
 
 .. note::
 
-   The mask of a ``z`` array is used only when constructing a ``ContourGenerator`` object, so there
-   is no danger that a mask shared with client code can subsequently be altered to change the
-   behaviour of the ``ContourGenerator``.
+   The mask of a ``z`` array is used only when constructing a :class:`~contourpy.ContourGenerator`
+   object, so there is no danger that a mask shared with client code can subsequently be altered to
+   change the behaviour of the :class:`~contourpy.ContourGenerator`.
 
 Corner mask
 ^^^^^^^^^^^

--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -2,8 +2,8 @@ import numpy as np
 
 from .chunk import calc_chunk_sizes
 from ._contourpy import (
-    max_threads, FillType, LineType, Mpl2005ContourGenerator, Mpl2014ContourGenerator,
-    SerialContourGenerator, ThreadedContourGenerator, ZInterp
+    FillType, LineType, ContourGenerator, Mpl2005ContourGenerator, Mpl2014ContourGenerator,
+    SerialContourGenerator, ThreadedContourGenerator, ZInterp, max_threads
 )
 from .enum_util import as_fill_type, as_line_type, as_z_interp
 from ._version import __version__
@@ -15,6 +15,7 @@ __all__ = [
     "max_threads",
     "FillType",
     "LineType",
+    "ContourGenerator",
     "Mpl2005ContourGenerator",
     "Mpl2014ContourGenerator",
     "SerialContourGenerator",
@@ -71,11 +72,11 @@ def contour_generator(x=None, y=None, z=None, *, name="serial", corner_mask=None
             out, other triangular corners comprising three unmasked points are contoured as usual.
             If not specified, uses the default provided by the algorithm ``name``.
         line_type (LineType, optional): The format of contour line data returned from calls to
-            :meth:`~contourpy.SerialContourGenerator.lines`. If not specified, uses the default
-            provided by the algorithm ``name``.
+            :meth:`~contourpy.ContourGenerator.lines`. If not specified, uses the default provided
+            by the algorithm ``name``.
         fill_type (FillType, optional): The format of filled contour data returned from calls to
-            :meth:`~contourpy.SerialContourGenerator.filled`. If not specified, uses the default
-            provided by the algorithm ``name``.
+            :meth:`~contourpy.ContourGenerator.filled`. If not specified, uses the default provided
+            by the algorithm ``name``.
         chunk_size (int or tuple(int, int), optional): Chunk size in (y, x) directions, or the same
             size in both directions if only one value is specified.
         chunk_count (int or tuple(int, int), optional): Chunk count in (y, x) directions, or the
@@ -97,8 +98,7 @@ def contour_generator(x=None, y=None, z=None, *, name="serial", corner_mask=None
             as determined by the C++11 call ``std::thread::hardware_concurrency()``.
 
     Return:
-        ContourGenerator: A contour generator object that implements the same interface as
-        :class:`~contourpy._contourpy.SerialContourGenerator`.
+        :class:`~contourpy._contourpy.ContourGenerator`.
 
     Note:
         A maximum of one of ``chunk_size``, ``chunk_count`` and ``total_chunk_count`` may be

--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -72,9 +72,9 @@ class BokehRenderer:
 
         Args:
             filled (sequence of arrays): Filled contour data as returned by
-                :func:`~contourpy.SerialContourGenerator.filled`.
+                :func:`~contourpy.ContourGenerator.filled`.
             fill_type (FillType): Type of ``filled`` data, as returned by
-                :attr:`~contourpy.SerialContourGenerator.fill_type`.
+                :attr:`~contourpy.ContourGenerator.fill_type`.
             ax (int or Bokeh Figure, optional): Which plot to use, default ``0``.
             color (str, optional): Color to plot with. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the
@@ -134,9 +134,9 @@ class BokehRenderer:
 
         Args:
             lines (sequence of arrays): Contour line data as returned by
-                :func:`~contourpy.SerialContourGenerator.lines`.
+                :func:`~contourpy.ContourGenerator.lines`.
             line_type (LineType): Type of ``lines`` data, as returned by
-                :attr:`~contourpy.SerialContourGenerator.line_type`.
+                :attr:`~contourpy.ContourGenerator.line_type`.
             ax (int or Bokeh Figure, optional): Which plot to use, default ``0``.
             color (str, optional): Color to plot lines. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -66,9 +66,9 @@ class MplRenderer:
 
         Args:
             filled (sequence of arrays): Filled contour data as returned by
-                :func:`~contourpy.SerialContourGenerator.filled`.
+                :func:`~contourpy.ContourGenerator.filled`.
             fill_type (FillType): Type of ``filled`` data, as returned by
-                :attr:`~contourpy.SerialContourGenerator.fill_type`.
+                :attr:`~contourpy.ContourGenerator.fill_type`.
             ax (int or Maplotlib Axes, optional): Which axes to plot on, default ``0``.
             color (str, optional): Color to plot with. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the
@@ -125,9 +125,9 @@ class MplRenderer:
 
         Args:
             lines (sequence of arrays): Contour line data as returned by
-                :func:`~contourpy.SerialContourGenerator.lines`.
+                :func:`~contourpy.ContourGenerator.lines`.
             line_type (LineType): Type of ``lines`` data, as returned by
-                :attr:`~contourpy.SerialContourGenerator.line_type`.
+                :attr:`~contourpy.ContourGenerator.line_type`.
             ax (int or Matplotlib Axes, optional): Which Axes to plot on, default ``0``.
             color (str, optional): Color to plot lines. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the

--- a/src/base.h
+++ b/src/base.h
@@ -11,6 +11,7 @@
 #define CONTOURPY_BASE_H
 
 #include "chunk_local.h"
+#include "contour_generator.h"
 #include "fill_type.h"
 #include "line_type.h"
 #include "outer_or_hole.h"
@@ -18,7 +19,7 @@
 #include <vector>
 
 template <typename Derived>
-class BaseContourGenerator
+class BaseContourGenerator : public ContourGenerator
 {
 public:
     ~BaseContourGenerator();
@@ -45,12 +46,6 @@ public:
     static bool supports_line_type(LineType line_type);
 
     void write_cache() const;  // For debug purposes only.
-
-    // Non-copyable and non-moveable.
-    BaseContourGenerator(const BaseContourGenerator& other) = delete;
-    BaseContourGenerator(const BaseContourGenerator&& other) = delete;
-    BaseContourGenerator& operator=(const BaseContourGenerator& other) = delete;
-    BaseContourGenerator& operator=(const BaseContourGenerator&& other) = delete;
 
 protected:
     BaseContourGenerator(

--- a/src/contour_generator.h
+++ b/src/contour_generator.h
@@ -1,0 +1,19 @@
+#ifndef CONTOURPY_CONTOUR_GENERATOR_H
+#define CONTOURPY_CONTOUR_GENERATOR_H
+
+#include "common.h"
+
+class ContourGenerator
+{
+public:
+    // Non-copyable and non-moveable.
+    ContourGenerator(const ContourGenerator& other) = delete;
+    ContourGenerator(const ContourGenerator&& other) = delete;
+    ContourGenerator& operator=(const ContourGenerator& other) = delete;
+    ContourGenerator& operator=(const ContourGenerator&& other) = delete;
+
+protected:
+    ContourGenerator() = default;
+};
+
+#endif // CONTOURPY_CONTOUR_GENERATOR_H

--- a/src/mpl2005.h
+++ b/src/mpl2005.h
@@ -1,21 +1,15 @@
 #ifndef CONTOURPY_MPL_2005_H
 #define CONTOURPY_MPL_2005_H
 
-#include "common.h"
+#include "contour_generator.h"
 #include "mpl2005_original.h"
 
-class Mpl2005ContourGenerator
+class Mpl2005ContourGenerator : public ContourGenerator
 {
 public:
     Mpl2005ContourGenerator(
         const CoordinateArray& x, const CoordinateArray& y, const CoordinateArray& z,
         const MaskArray& mask, index_t x_chunk_size, index_t y_chunk_size);
-
-    // Non-copyable and non-moveable.
-    Mpl2005ContourGenerator(const Mpl2005ContourGenerator& other) = delete;
-    Mpl2005ContourGenerator(const Mpl2005ContourGenerator&& other) = delete;
-    Mpl2005ContourGenerator& operator=(const Mpl2005ContourGenerator& other) = delete;
-    Mpl2005ContourGenerator& operator=(const Mpl2005ContourGenerator&& other) = delete;
 
     ~Mpl2005ContourGenerator();
 

--- a/src/mpl2014.h
+++ b/src/mpl2014.h
@@ -142,7 +142,7 @@
 #ifndef CONTOURPY_MPL_2014_H
 #define CONTOURPY_MPL_2014_H
 
-#include "common.h"
+#include "contour_generator.h"
 #include <list>
 #include <iostream>
 #include <vector>
@@ -262,7 +262,7 @@ private:
 
 
 // See overview of algorithm at top of file.
-class Mpl2014ContourGenerator
+class Mpl2014ContourGenerator : public ContourGenerator
 {
 public:
     // Constructor with optional mask.
@@ -276,12 +276,6 @@ public:
     Mpl2014ContourGenerator(
         const CoordinateArray& x, const CoordinateArray& y, const CoordinateArray& z,
         const MaskArray& mask, bool corner_mask, index_t x_chunk_size, index_t y_chunk_size);
-
-    // Non-copyable and non-moveable.
-    Mpl2014ContourGenerator(const Mpl2014ContourGenerator& other) = delete;
-    Mpl2014ContourGenerator(const Mpl2014ContourGenerator&& other) = delete;
-    Mpl2014ContourGenerator& operator=(const Mpl2014ContourGenerator& other) = delete;
-    Mpl2014ContourGenerator& operator=(const Mpl2014ContourGenerator&& other) = delete;
 
     // Destructor.
     ~Mpl2014ContourGenerator();

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -1,4 +1,5 @@
 #include "base_impl.h"
+#include "contour_generator.h"
 #include "fill_type.h"
 #include "line_type.h"
 #include "mpl2005.h"
@@ -20,9 +21,10 @@ PYBIND11_MODULE(_contourpy, m) {
         ".. note::\n"
         "   It should not be necessary to access classes and functions in this extension module "
         "directly. Instead, :func:`contourpy.contour_generator` should be used to create "
-        "ContourGenerator objects, and the enums (:class:`~contourpy.FillType`, "
-        ":class:`~contourpy.LineType` and :class:`~contourpy.ZInterp`) and "
-        ":func:`contourpy.max_threads` function are all available in the :mod:`contourpy` module.";
+        ":class:`~contourpy.ContourGenerator` objects, and the enums "
+        "(:class:`~contourpy.FillType`, :class:`~contourpy.LineType` and "
+        ":class:`~contourpy.ZInterp`) and :func:`contourpy.max_threads` function are all available "
+        "in the :mod:`contourpy` module.";
 
     m.attr("CONTOURPY_DEBUG") = CONTOURPY_DEBUG;
     m.attr("CONTOURPY_CXX11") = CONTOURPY_CXX11;
@@ -31,7 +33,7 @@ PYBIND11_MODULE(_contourpy, m) {
     py::enum_<FillType>(m, "FillType",
         "Enum used for ``fill_type`` keyword argument in :func:`~contourpy.contour_generator`.\n\n"
         "This controls the format of filled contour data returned from "
-        ":meth:`~contourpy.SerialContourGenerator.filled`.")
+        ":meth:`~contourpy.ContourGenerator.filled`.")
         .value("OuterCode", FillType::OuterCode)
         .value("OuterOffset", FillType::OuterOffset)
         .value("ChunkCombinedCode", FillType::ChunkCombinedCode)
@@ -43,7 +45,7 @@ PYBIND11_MODULE(_contourpy, m) {
     py::enum_<LineType>(m, "LineType",
         "Enum used for ``line_type`` keyword argument in :func:`~contourpy.contour_generator`.\n\n"
         "This controls the format of contour line data returned from "
-        ":meth:`~contourpy.SerialContourGenerator.lines`.")
+        ":meth:`~contourpy.ContourGenerator.lines`.")
         .value("Separate", LineType::Separate)
         .value("SeparateCode", LineType::SeparateCode)
         .value("ChunkCombinedCode", LineType::ChunkCombinedCode)
@@ -64,14 +66,88 @@ PYBIND11_MODULE(_contourpy, m) {
         "This is the number of threads used by a multithreaded ContourGenerator if the kwarg "
         "``threads=0`` is passed to :func:`~contourpy.contour_generator`.");
 
-    py::class_<Mpl2005ContourGenerator>(m, "Mpl2005ContourGenerator",
+    py::class_<ContourGenerator>(m, "ContourGenerator",
+        "Abstract base class for contour generator classes, defining the interface that they all "
+        "implement.")
+        .def("create_contour", [](double level) {return py::make_tuple();},
+            "Synonym for :func:`~contourpy.ContourGenerator.lines` to provide backward "
+            "compatibility with Matplotlib.")
+        .def("create_filled_contour",
+            [](double lower_level, double upper_level) {return py::make_tuple();},
+            "Synonym for :func:`~contourpy.ContourGenerator.filled` to provide backward "
+            "compatibility with Matplotlib.")
+        .def("filled", [](double lower_level, double upper_level) {return py::make_tuple();},
+            "Calculate and return filled contours between two levels.\n\n"
+            "Args:\n"
+            "    lower_level (float): Lower z-level of the filled contours.\n"
+            "    upper_level (float): Upper z-level of the filled contours.\n"
+            "Return:\n"
+            "    Filled contour polygons as one or more sequences of numpy arrays. The exact "
+            "format is determined by the ``fill_type`` used by the ``ContourGenerator``.")
+        .def("lines", [](double level) {return py::make_tuple();},
+            "Calculate and return contour lines at a particular level.\n\n"
+            "Args:\n"
+            "    level (float): z-level to calculate contours at.\n\n"
+            "Return:\n"
+            "    Contour lines (open line strips and closed line loops) as one or more sequences "
+            "of numpy arrays. The exact format is determined by the ``line_type`` used by the "
+            "``ContourGenerator``.")
+        .def_property_readonly(
+            "chunk_count", [](py::object /* self */) {return py::make_tuple(1, 1);},
+            "Return tuple of (y, x) chunk counts.")
+        .def_property_readonly(
+            "chunk_size", [](py::object /* self */) {return py::make_tuple(1, 1);},
+            "Return tuple of (y, x) chunk sizes.")
+        .def_property_readonly(
+            "corner_mask", [](py::object /* self */) {return false;},
+            "Return whether ``corner_mask`` is set or not.")
+        .def_property_readonly(
+            "fill_type", [](py::object /* self */) {return FillType::OuterOffset;},
+            "Return the ``FillType``.")
+        .def_property_readonly(
+            "line_type", [](py::object /* self */) {return LineType::Separate;},
+            "Return the ``LineType``.")
+        .def_property_readonly(
+            "quad_as_tri", [](py::object /* self */) {return false;},
+            "Return whether ``quad_as_tri`` is set or not.")
+        .def_property_readonly(
+            "thread_count", [](py::object /* self */) {return 1;},
+            "Return the number of threads used.")
+        .def_property_readonly(
+            "z_interp", [](py::object /* self */) {return ZInterp::Linear;},
+            "Return the ``ZInterp``.")
+        .def_property_readonly_static(
+            "default_fill_type", [](py::object /* self */) {return FillType::OuterOffset;},
+            "Return the default ``FillType`` used by this algorithm.")
+        .def_property_readonly_static(
+            "default_line_type", [](py::object /* self */) {return LineType::Separate;},
+            "Return the default ``LineType`` used by this algorithm.")
+        .def_static(
+            "supports_corner_mask", []() {return false;},
+            "Return whether this algorithm supports ``corner_mask``.")
+        .def_static(
+            "supports_fill_type", [](FillType /* fill_type */) {return false;},
+            "Return whether this algorithm supports a particular ``FillType``.")
+        .def_static(
+            "supports_line_type", [](LineType /* line_type */) {return false;},
+            "Return whether this algorithm supports a particular ``LineType``.")
+        .def_static(
+            "supports_quad_as_tri", []() {return false;},
+            "Return whether this algorithm supports ``quad_as_tri``.")
+        .def_static(
+            "supports_threads", []() {return false;},
+            "Return whether this algorithm supports the use of threads.")
+        .def_static(
+            "supports_z_interp", []() {return false;},
+            "Return whether this algorithm supports ``z_interp`` values other than "
+            "``ZInterp.Linear`` which all support.");
+
+    py::class_<Mpl2005ContourGenerator, ContourGenerator>(m, "Mpl2005ContourGenerator",
         "ContourGenerator corresponding to ``name=\"mpl2005\"``.\n\n"
         "This is the original 2005 Matplotlib algorithm. "
         "Does not support any of ``corner_mask``, ``quad_as_tri``, ``threads`` or ``z_interp``. "
         "Only supports ``line_type=LineType.SeparateCode`` and ``fill_type=FillType.OuterCode``. "
         "Only supports chunking for filled contours, not contour lines.\n\n"
-        "This class implements the same interface as "
-        ":class:`~contourpy._contourpy.SerialContourGenerator`.\n\n"
         ".. warning::\n"
         "   This algorithm is in ``contourpy`` for historic comparison. No new features or bug "
         "fixes will be added to it, except for security-related bug fixes.")
@@ -98,26 +174,18 @@ PYBIND11_MODULE(_contourpy, m) {
         .def("lines", &Mpl2005ContourGenerator::lines)
         .def_property_readonly("chunk_count", &Mpl2005ContourGenerator::get_chunk_count)
         .def_property_readonly("chunk_size", &Mpl2005ContourGenerator::get_chunk_size)
-        .def_property_readonly("corner_mask", [](py::object /* self */) {return false;})
         .def_property_readonly("fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
         .def_property_readonly("line_type", [](py::object /* self */) {return mpl20xx_line_type;})
-        .def_property_readonly("quad_as_tri", [](py::object /* self */) {return false;})
-        .def_property_readonly("thread_count", [](py::object /* self */) {return 1;})
-        .def_property_readonly("z_interp", [](py::object /* self */) {return ZInterp::Linear;})
-        .def_property_readonly_static("default_fill_type", [](py::object /* self */) {
-            return mpl20xx_fill_type;})
-        .def_property_readonly_static("default_line_type", [](py::object /* self */) {
-            return mpl20xx_line_type;})
-        .def_static("supports_corner_mask", []() {return false;})
-        .def_static("supports_fill_type", [](FillType fill_type) {
-            return fill_type == mpl20xx_fill_type;})
-        .def_static("supports_line_type", [](LineType line_type) {
-            return line_type == mpl20xx_line_type;})
-        .def_static("supports_quad_as_tri", []() {return false;})
-        .def_static("supports_threads", []() {return false;})
-        .def_static("supports_z_interp", []() {return false;});
+        .def_property_readonly_static(
+            "default_fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
+        .def_property_readonly_static(
+            "default_line_type", [](py::object /* self */) {return mpl20xx_line_type;})
+        .def_static(
+            "supports_fill_type", [](FillType fill_type) {return fill_type == mpl20xx_fill_type;})
+        .def_static(
+            "supports_line_type", [](LineType line_type) {return line_type == mpl20xx_line_type;});
 
-    py::class_<mpl2014::Mpl2014ContourGenerator>(m, "Mpl2014ContourGenerator",
+    py::class_<mpl2014::Mpl2014ContourGenerator, ContourGenerator>(m, "Mpl2014ContourGenerator",
         "ContourGenerator corresponding to ``name=\"mpl2014\"``.\n\n"
         "This is the 2014 Matplotlib algorithm, a replacement of the original 2005 algorithm that "
         "added ``corner_mask`` and made the code more maintainable. "
@@ -125,8 +193,6 @@ PYBIND11_MODULE(_contourpy, m) {
         "``z_interp``. \n"
         "Only supports ``line_type=LineType.SeparateCode`` and "
         "``fill_type=FillType.OuterCode``.\n\n"
-        "This class implements the same interface as "
-        ":class:`~contourpy._contourpy.SerialContourGenerator`.\n\n"
         ".. warning::\n"
         "   This algorithm is in ``contourpy`` for historic comparison. No new features or bug "
         "fixes will be added to it, except for security-related bug fixes.")
@@ -158,23 +224,17 @@ PYBIND11_MODULE(_contourpy, m) {
         .def_property_readonly("corner_mask", &mpl2014::Mpl2014ContourGenerator::get_corner_mask)
         .def_property_readonly("fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
         .def_property_readonly("line_type", [](py::object /* self */) {return mpl20xx_line_type;})
-        .def_property_readonly("quad_as_tri", [](py::object /* self */) {return false;})
-        .def_property_readonly("thread_count", [](py::object /* self */) {return 1;})
-        .def_property_readonly("z_interp", [](py::object /* self */) {return ZInterp::Linear;})
-        .def_property_readonly_static("default_fill_type", [](py::object /* self */) {
-            return mpl20xx_fill_type;})
-        .def_property_readonly_static("default_line_type", [](py::object /* self */) {
-            return mpl20xx_line_type;})
+        .def_property_readonly_static(
+            "default_fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
+        .def_property_readonly_static(
+            "default_line_type", [](py::object /* self */) {return mpl20xx_line_type;})
         .def_static("supports_corner_mask", []() {return true;})
-        .def_static("supports_fill_type", [](FillType fill_type) {
-            return fill_type == mpl20xx_fill_type;})
-        .def_static("supports_line_type", [](LineType line_type) {
-            return line_type == mpl20xx_line_type;})
-        .def_static("supports_quad_as_tri", []() {return false;})
-        .def_static("supports_threads", []() {return false;})
-        .def_static("supports_z_interp", []() {return false;});
+        .def_static(
+            "supports_fill_type", [](FillType fill_type) {return fill_type == mpl20xx_fill_type;})
+        .def_static(
+            "supports_line_type", [](LineType line_type) {return line_type == mpl20xx_line_type;});
 
-    py::class_<SerialContourGenerator>(m, "SerialContourGenerator",
+    py::class_<SerialContourGenerator, ContourGenerator>(m, "SerialContourGenerator",
         "ContourGenerator corresponding to ``name=\"serial\"``, the default algorithm for "
         "``contourpy``.\n\n"
         "Supports ``corner_mask``, ``quad_as_tri`` and ``z_interp`` but not ``threads``. "
@@ -203,71 +263,32 @@ PYBIND11_MODULE(_contourpy, m) {
              py::arg("x_chunk_size") = 0,
              py::arg("y_chunk_size") = 0)
         .def("_write_cache", &SerialContourGenerator::write_cache)
-        .def("create_contour", &SerialContourGenerator::lines,
-            "Synonym for :func:`~contourpy.SerialContourGenerator.lines` to provide backward "
-            "compatibility with Matplotlib.")
-        .def("create_filled_contour", &SerialContourGenerator::filled,
-            "Synonym for :func:`~contourpy.SerialContourGenerator.filled` to provide backward "
-            "compatibility with Matplotlib.")
-        .def("filled", &SerialContourGenerator::filled,
-            "Calculate and return filled contours between two levels.\n\n"
-            "Args:\n"
-            "    lower_level (float): Lower z-level of the filled contours.\n"
-            "    upper_level (float): Upper z-level of the filled contours.\n"
-            "Return:\n"
-            "    Filled contour polygons as one or more sequences of numpy arrays. The exact "
-            "format is determined by the ``fill_type`` used by the ``ContourGenerator``.")
-        .def("lines", &SerialContourGenerator::lines,
-            "Calculate and return contour lines at a particular level.\n\n"
-            "Args:\n"
-            "    level (float): z-level to calculate contours at.\n\n"
-            "Return:\n"
-            "    Contour lines (open line strips and closed line loops) as one or more sequences "
-            "of numpy arrays. The exact format is determined by the ``line_type`` used by the "
-            "``ContourGenerator``.")
-        .def_property_readonly("chunk_count", &SerialContourGenerator::get_chunk_count,
-            "Return tuple of (y, x) chunk counts.")
-        .def_property_readonly("chunk_size", &SerialContourGenerator::get_chunk_size,
-            "Return tuple of (y, x) chunk sizes.")
-        .def_property_readonly("corner_mask", &SerialContourGenerator::get_corner_mask,
-            "Return whether ``corner_mask`` is set or not.")
-        .def_property_readonly("fill_type", &SerialContourGenerator::get_fill_type,
-            "Return the ``FillType``.")
-        .def_property_readonly("line_type", &SerialContourGenerator::get_line_type,
-            "Return the ``LineType``.")
-        .def_property_readonly("quad_as_tri", &SerialContourGenerator::get_quad_as_tri,
-            "Return whether ``quad_as_tri`` is set or not.")
-        .def_property_readonly("thread_count", [](py::object /* self */) {return 1;},
-            "Return the number of threads used.")
-        .def_property_readonly("z_interp", &SerialContourGenerator::get_z_interp,
-            "Return the ``ZInterp``.")
+        .def("create_contour", &SerialContourGenerator::lines)
+        .def("create_filled_contour", &SerialContourGenerator::filled)
+        .def("filled", &SerialContourGenerator::filled)
+        .def("lines", &SerialContourGenerator::lines)
+        .def_property_readonly("chunk_count", &SerialContourGenerator::get_chunk_count)
+        .def_property_readonly("chunk_size", &SerialContourGenerator::get_chunk_size)
+        .def_property_readonly("corner_mask", &SerialContourGenerator::get_corner_mask)
+        .def_property_readonly("fill_type", &SerialContourGenerator::get_fill_type)
+        .def_property_readonly("line_type", &SerialContourGenerator::get_line_type)
+        .def_property_readonly("quad_as_tri", &SerialContourGenerator::get_quad_as_tri)
+        .def_property_readonly("z_interp", &SerialContourGenerator::get_z_interp)
         .def_property_readonly_static("default_fill_type", [](py::object /* self */) {
-            return SerialContourGenerator::default_fill_type();},
-            "Return the default ``FillType`` used by this algorithm.")
+            return SerialContourGenerator::default_fill_type();})
         .def_property_readonly_static("default_line_type", [](py::object /* self */) {
-            return SerialContourGenerator::default_line_type();},
-            "Return the default ``LineType`` used by this algorithm.")
-        .def_static("supports_corner_mask", []() {return true;},
-            "Return whether this algorithm supports ``corner_mask``.")
-        .def_static("supports_fill_type", &SerialContourGenerator::supports_fill_type,
-            "Return whether this algorithm supports a particular ``FillType``.")
-        .def_static("supports_line_type", &SerialContourGenerator::supports_line_type,
-            "Return whether this algorithm supports a particular ``LineType``.")
-        .def_static("supports_quad_as_tri", []() {return true;},
-            "Return whether this algorithm supports ``quad_as_tri``.")
-        .def_static("supports_threads", []() {return false;},
-            "Return whether this algorithm supports the use of threads.")
-        .def_static("supports_z_interp", []() {return true;},
-            "Return whether this algorithm supports ``z_interp`` values other than "
-            "``ZInterp.Linear`` which all support.");
+            return SerialContourGenerator::default_line_type();})
+        .def_static("supports_corner_mask", []() {return true;})
+        .def_static("supports_fill_type", &SerialContourGenerator::supports_fill_type)
+        .def_static("supports_line_type", &SerialContourGenerator::supports_line_type)
+        .def_static("supports_quad_as_tri", []() {return true;})
+        .def_static("supports_z_interp", []() {return true;});
 
-    py::class_<ThreadedContourGenerator>(m, "ThreadedContourGenerator",
+    py::class_<ThreadedContourGenerator, ContourGenerator>(m, "ThreadedContourGenerator",
         "ContourGenerator corresponding to ``name=\"threaded\"``, the multithreaded version of "
         ":class:`~contourpy._contourpy.SerialContourGenerator`.\n\n"
         "Supports ``corner_mask``, ``quad_as_tri`` and ``z_interp`` and ``threads``. "
-        "Supports all options for ``line_type`` and ``fill_type``.\n\n"
-        "This class implements the same interface as "
-        ":class:`~contourpy._contourpy.SerialContourGenerator`.")
+        "Supports all options for ``line_type`` and ``fill_type``.")
         .def(py::init<const CoordinateArray&,
                       const CoordinateArray&,
                       const CoordinateArray&,

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -280,3 +280,10 @@ def test_enums_as_strings(xyz_3x3_as_lists):
     assert cg.line_type == contourpy.LineType.SeparateCode
     assert cg.fill_type == contourpy.FillType.ChunkCombinedCodeOffset
     assert cg.z_interp == contourpy.ZInterp.Log
+
+
+@pytest.mark.parametrize("name", util_test.all_names())
+def test_is_contour_generator(name, xyz_3x3_as_lists):
+    x, y, z = xyz_3x3_as_lists
+    cg = contourpy.contour_generator(x, y, z, name=name)
+    assert isinstance(cg, contourpy.ContourGenerator)


### PR DESCRIPTION
This PR adds a `ContourGenerator` base class to all 4 contouring algorithms. The class is abstract so cannot be instantiated. On the C++ side it contains no methods, but in the `pybind11` wrapper it defines all the methods and properties that each of the 4 algorithms implements.

Benefits:

- Can use `isinstance(object, ContourGenerator)` on all objects returned by `contour_generator()`.
- Makes the docs easier to understand.
- Will make type annotations easier to write and understand.