### PR TITLE
Mark tests that need mpl

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     config.addinivalue_line("markers", "text: mark test as outputting text")
+    config.addinivalue_line("markers", "needs_mpl: mark test as needing matplotlib")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -30,7 +30,11 @@ def test_cppcheck():
 
 def test_flake8():
     cmd = ["flake8"]
-    proc = run(cmd, capture_output=True)
+    try:
+        proc = run(cmd, capture_output=True)
+    except FileNotFoundError:
+        pytest.skip()
+
     assert proc.returncode == 0, f"Flake8 issues:\n{proc.stdout.decode('utf-8')}"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,44 +1,58 @@
 import pytest
 
-from image_comparison import compare_images
-import util_config
 import util_test
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.all_names())
 def test_config_filled(show_text, name):
+    from image_comparison import compare_images
+    import util_config
+
     config = util_config.ConfigFilled(name, show_text=show_text)
     image_buffer = config.save_to_buffer()
     suffix = "" if show_text else "_no_text"
     compare_images(image_buffer, f"config_filled{suffix}.png", name)
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_config_filled_quad_as_tri(show_text, name):
+    from image_comparison import compare_images
+    import util_config
+
     config = util_config.ConfigFilled(name, quad_as_tri=True, show_text=show_text)
     image_buffer = config.save_to_buffer()
     suffix = "" if show_text else "_no_text"
     compare_images(image_buffer, f"config_filled_quad_as_tri{suffix}.png", name)
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_config_filled_corner(show_text, name):
+    from image_comparison import compare_images
+    import util_config
+
     config = util_config.ConfigFilledCorner(name, show_text=show_text)
     image_buffer = config.save_to_buffer()
     suffix = "" if show_text else "_no_text"
     compare_images(image_buffer, f"config_filled_corner{suffix}.png", name)
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.all_names())
 def test_config_lines(show_text, name):
+    from image_comparison import compare_images
+    import util_config
+
     if name == "mpl2005":
         pytest.skip()  # Line directions are not consistent.
     config = util_config.ConfigLines(name, show_text=show_text)
@@ -47,20 +61,28 @@ def test_config_lines(show_text, name):
     compare_images(image_buffer, f"config_lines{suffix}.png", name)
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_config_lines_quad_as_tri(show_text, name):
+    from image_comparison import compare_images
+    import util_config
+
     config = util_config.ConfigLines(name, quad_as_tri=True, show_text=show_text)
     image_buffer = config.save_to_buffer()
     suffix = "" if show_text else "_no_text"
     compare_images(image_buffer, f"config_lines_quad_as_tri{suffix}.png", name)
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_config_lines_corner(show_text, name):
+    from image_comparison import compare_images
+    import util_config
+
     config = util_config.ConfigLinesCorner(name, show_text=show_text)
     image_buffer = config.save_to_buffer()
     suffix = "" if show_text else "_no_text"

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -6,8 +6,6 @@ import pytest
 
 from contourpy import contour_generator, FillType
 from contourpy.util.data import random, simple
-from contourpy.util.mpl_renderer import MplTestRenderer
-from image_comparison import compare_images
 import util_test
 
 
@@ -20,8 +18,12 @@ def two_outers_one_hole():
     return x, y, z
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_simple(name, fill_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40))
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type)
     levels = np.arange(-1.0, 1.01, 0.1)
@@ -36,8 +38,12 @@ def test_filled_simple(name, fill_type):
     compare_images(image_buffer, "filled_simple.png", f"{name}_{fill_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_simple_chunk(name, fill_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40))
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, chunk_size=2)
     levels = np.arange(-1.0, 1.01, 0.1)
@@ -53,8 +59,12 @@ def test_filled_simple_chunk(name, fill_type):
         image_buffer, "filled_simple_chunk.png", f"{name}_{fill_type}", mean_threshold=0.12)
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_simple_no_corner_mask(name, fill_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40), want_mask=True)
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, corner_mask=False)
     levels = np.arange(-1.0, 1.01, 0.1)
@@ -69,8 +79,12 @@ def test_filled_simple_no_corner_mask(name, fill_type):
     compare_images(image_buffer, "filled_simple_no_corner_mask.png", f"{name}_{fill_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_simple_no_corner_mask_chunk(name, fill_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40), want_mask=True)
     cont_gen = contour_generator(
         x, y, z, name=name, fill_type=fill_type, corner_mask=False, chunk_size=2)
@@ -89,8 +103,12 @@ def test_filled_simple_no_corner_mask_chunk(name, fill_type):
     )
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_simple_corner_mask(name):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40), want_mask=True)
     fill_type = FillType.OuterCode
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, corner_mask=True)
@@ -106,8 +124,12 @@ def test_filled_simple_corner_mask(name):
     compare_images(image_buffer, "filled_simple_corner_mask.png", f"{name}_{fill_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_simple_corner_mask_chunk(name):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40), want_mask=True)
     fill_type = FillType.OuterCode
     cont_gen = contour_generator(
@@ -127,8 +149,12 @@ def test_filled_simple_corner_mask_chunk(name):
     )
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_filled_simple_quad_as_tri(name):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40))
     cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=True)
     levels = np.arange(-1.0, 1.01, 0.1)
@@ -142,8 +168,12 @@ def test_filled_simple_quad_as_tri(name):
     compare_images(image_buffer, "filled_simple_quad_as_tri.png", f"{name}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_random(name, fill_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.0)
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type)
     levels = np.arange(0.0, 1.01, 0.2)
@@ -158,8 +188,12 @@ def test_filled_random(name, fill_type):
     compare_images(image_buffer, "filled_random.png", f"{name}_{fill_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_random_chunk(name, fill_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.0)
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, chunk_size=2)
     levels = np.arange(0.0, 1.01, 0.2)
@@ -190,8 +224,12 @@ def test_filled_random_chunk(name, fill_type):
         )
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_random_no_corner_mask(name, fill_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.05)
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, corner_mask=False)
     levels = np.arange(0.0, 1.01, 0.2)
@@ -206,8 +244,12 @@ def test_filled_random_no_corner_mask(name, fill_type):
     compare_images(image_buffer, "filled_random_no_corner_mask.png", f"{name}_{fill_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_random_no_corner_mask_chunk(name, fill_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.05)
     cont_gen = contour_generator(
         x, y, z, name=name, fill_type=fill_type, corner_mask=False, chunk_size=2)
@@ -237,8 +279,12 @@ def test_filled_random_no_corner_mask_chunk(name, fill_type):
     )
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_random_corner_mask(name):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.05)
     fill_type = FillType.OuterCode
     cont_gen = contour_generator(x, y, z, name=name, corner_mask=True, fill_type=fill_type)
@@ -252,8 +298,12 @@ def test_filled_random_corner_mask(name):
     compare_images(image_buffer, "filled_random_corner_mask.png", f"{name}_{fill_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_random_corner_mask_chunk(name):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.05)
     fill_type = FillType.OuterCode
     cont_gen = contour_generator(
@@ -277,8 +327,12 @@ def test_filled_random_corner_mask_chunk(name):
     )
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_filled_random_quad_as_tri(name):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.0)
     cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=True)
     levels = np.arange(0.0, 1.01, 0.2)

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -4,8 +4,6 @@ import pytest
 
 from contourpy import contour_generator, LineType
 from contourpy.util.data import random, simple
-from contourpy.util.mpl_renderer import MplTestRenderer
-from image_comparison import compare_images
 import util_test
 
 
@@ -89,8 +87,12 @@ def test_loop(xy_3x3, name):
     assert_array_equal(codes[0], [1, 2, 2, 2, 79])
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_simple(name, line_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40))
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type)
     levels = np.arange(-1.0, 1.01, 0.1)
@@ -105,8 +107,12 @@ def test_lines_simple(name, line_type):
     compare_images(image_buffer, "lines_simple.png", f"{name}_{line_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_simple_chunk(name, line_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40))
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, chunk_size=2)
     levels = np.arange(-1.0, 1.01, 0.1)
@@ -121,8 +127,12 @@ def test_lines_simple_chunk(name, line_type):
     compare_images(image_buffer, "lines_simple_chunk.png", f"{name}_{line_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_simple_no_corner_mask(name, line_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40), want_mask=True)
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, corner_mask=False)
     levels = np.arange(-1.0, 1.01, 0.1)
@@ -137,8 +147,12 @@ def test_lines_simple_no_corner_mask(name, line_type):
     compare_images(image_buffer, "lines_simple_no_corner_mask.png", f"{name}_{line_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_simple_no_corner_mask_chunk(name, line_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40), want_mask=True)
     cont_gen = contour_generator(
         x, y, z, name=name, line_type=line_type, corner_mask=False, chunk_size=2)
@@ -154,8 +168,12 @@ def test_lines_simple_no_corner_mask_chunk(name, line_type):
     compare_images(image_buffer, "lines_simple_no_corner_mask_chunk.png", f"{name}_{line_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_simple_corner_mask(name):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40), want_mask=True)
     line_type = LineType.SeparateCode
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, corner_mask=True)
@@ -171,8 +189,12 @@ def test_lines_simple_corner_mask(name):
     compare_images(image_buffer, "lines_simple_corner_mask.png", f"{name}_{line_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_simple_corner_mask_chunk(name):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40), want_mask=True)
     line_type = LineType.SeparateCode
     cont_gen = contour_generator(
@@ -189,8 +211,12 @@ def test_lines_simple_corner_mask_chunk(name):
     compare_images(image_buffer, "lines_simple_corner_mask_chunk.png", f"{name}_{line_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_lines_simple_quad_as_tri(name):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = simple((30, 40))
     cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=True)
     levels = np.arange(-1.0, 1.01, 0.1)
@@ -204,8 +230,12 @@ def test_lines_simple_quad_as_tri(name):
     compare_images(image_buffer, "lines_simple_quad_as_tri.png", f"{name}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_random(name, line_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.0)
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type)
     levels = np.arange(0.0, 1.01, 0.2)
@@ -220,8 +250,12 @@ def test_lines_random(name, line_type):
     compare_images(image_buffer, "lines_random.png", f"{name}_{line_type}", max_threshold=103)
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_random_chunk(name, line_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.0)
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, chunk_size=2)
     levels = np.arange(0.0, 1.01, 0.2)
@@ -245,8 +279,12 @@ def test_lines_random_chunk(name, line_type):
     )
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_random_no_corner_mask(name, line_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.05)
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, corner_mask=False)
     levels = np.arange(0.0, 1.01, 0.2)
@@ -261,8 +299,12 @@ def test_lines_random_no_corner_mask(name, line_type):
     compare_images(image_buffer, "lines_random_no_corner_mask.png", f"{name}_{line_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_random_no_corner_mask_chunk(name, line_type):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     if name in ("mpl2005"):
         pytest.skip()  # mpl2005 does not support chunks for lines.
 
@@ -279,8 +321,12 @@ def test_lines_random_no_corner_mask_chunk(name, line_type):
     compare_images(image_buffer, "lines_random_no_corner_mask_chunk.png", f"{name}_{line_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_random_corner_mask(name):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.05)
     line_type = LineType.SeparateCode
     cont_gen = contour_generator(x, y, z, name=name, corner_mask=True, line_type=line_type)
@@ -294,8 +340,12 @@ def test_lines_random_corner_mask(name):
     compare_images(image_buffer, "lines_random_corner_mask.png", f"{name}_{line_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_random_corner_mask_chunk(name):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.05)
     line_type = LineType.SeparateCode
     cont_gen = contour_generator(x, y, z, name=name, corner_mask=True, line_type=line_type)
@@ -309,8 +359,12 @@ def test_lines_random_corner_mask_chunk(name):
     compare_images(image_buffer, "lines_random_corner_mask_chunk.png", f"{name}_{line_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_lines_random_quad_as_tri(name):
+    from contourpy.util.mpl_renderer import MplTestRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((30, 40), mask_fraction=0.0)
     cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=True)
     levels = np.arange(0.0, 1.01, 0.2)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -3,14 +3,16 @@ import pytest
 
 from contourpy import contour_generator, FillType, LineType
 from contourpy.util.data import random
-from contourpy.util.mpl_renderer import MplRenderer
-from image_comparison import compare_images
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 def test_renderer_filled(show_text, fill_type):
+    from contourpy.util.mpl_renderer import MplRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((3, 4))
     renderer = MplRenderer(ncols=2, figsize=(8, 3), show_frame=False)
     for ax, quad_as_tri in enumerate((False, True)):
@@ -38,10 +40,14 @@ def test_renderer_filled(show_text, fill_type):
     compare_images(image_buffer, f"renderer_filled_mpl{suffix}.png", f"{fill_type}")
 
 
+@pytest.mark.needs_mpl
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 def test_renderer_lines(show_text, line_type):
+    from contourpy.util.mpl_renderer import MplRenderer
+    from image_comparison import compare_images
+
     x, y, z = random((3, 4))
     renderer = MplRenderer(ncols=2, figsize=(8, 3), show_frame=show_text)
     for ax, quad_as_tri in enumerate((False, True)):


### PR DESCRIPTION
This PR marks tests that require matplotlib with `@pytest.mark.needs_mpl` and moves mpl-related imports to within those test functions. If matplotlib is not installed, the remaining tests can be run using
```
pytest -k "not needs_mpl"
```
This is useful for increased running of tests in CI, such as when building wheels, as the only test dependencies are `numpy` an `pytest` which should be able to be installed and run in a reasonable time even on an emulated platform.