### PR TITLE
Initialise mpl backend when first needed

### DIFF
--- a/tests/util_config.py
+++ b/tests/util_config.py
@@ -1,6 +1,3 @@
-import matplotlib
-matplotlib.use("Agg")
-
 from enum import Enum
 import io
 import matplotlib.pyplot as plt
@@ -44,6 +41,9 @@ class Config:
         # Set in derived classes.
         self.fig = None
         self.axes = None
+
+        import matplotlib
+        matplotlib.use("Agg")
 
     def __del__(self):
         if self.fig:


### PR DESCRIPTION
In renderer code, set Matplotlib backend when first needed rather than in imports at top of files.