### PR TITLE
Add isort to pytest

### DIFF
--- a/benchmarks/benchmarks/bench_base.py
+++ b/benchmarks/benchmarks/bench_base.py
@@ -1,5 +1,6 @@
-from contourpy.util.data import random, simple
 import numpy as np
+
+from contourpy.util.data import random, simple
 
 
 class BenchBase:

--- a/benchmarks/benchmarks/bench_filled_mpl20xx.py
+++ b/benchmarks/benchmarks/bench_filled_mpl20xx.py
@@ -1,4 +1,5 @@
-from contourpy import contour_generator, FillType
+from contourpy import FillType, contour_generator
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, problem_sizes
 

--- a/benchmarks/benchmarks/bench_filled_mpl20xx_render.py
+++ b/benchmarks/benchmarks/bench_filled_mpl20xx_render.py
@@ -1,5 +1,6 @@
-from contourpy import contour_generator, FillType
+from contourpy import FillType, contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, problem_sizes
 

--- a/benchmarks/benchmarks/bench_filled_serial.py
+++ b/benchmarks/benchmarks/bench_filled_serial.py
@@ -1,4 +1,5 @@
 from contourpy import contour_generator
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, fill_types, problem_sizes
 

--- a/benchmarks/benchmarks/bench_filled_serial_chunk.py
+++ b/benchmarks/benchmarks/bench_filled_serial_chunk.py
@@ -1,4 +1,5 @@
-from contourpy import contour_generator, FillType
+from contourpy import FillType, contour_generator
+
 from .bench_base import BenchBase
 from .util_bench import chunk_counts, corner_masks, datasets
 

--- a/benchmarks/benchmarks/bench_filled_serial_quad_as_tri.py
+++ b/benchmarks/benchmarks/bench_filled_serial_quad_as_tri.py
@@ -1,4 +1,5 @@
-from contourpy import contour_generator, FillType
+from contourpy import FillType, contour_generator
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, problem_sizes
 

--- a/benchmarks/benchmarks/bench_filled_serial_quad_as_tri_render.py
+++ b/benchmarks/benchmarks/bench_filled_serial_quad_as_tri_render.py
@@ -1,5 +1,6 @@
-from contourpy import contour_generator, FillType
+from contourpy import FillType, contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, problem_sizes
 

--- a/benchmarks/benchmarks/bench_filled_serial_render.py
+++ b/benchmarks/benchmarks/bench_filled_serial_render.py
@@ -1,5 +1,6 @@
 from contourpy import contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, fill_types, problem_sizes
 

--- a/benchmarks/benchmarks/bench_filled_threaded.py
+++ b/benchmarks/benchmarks/bench_filled_threaded.py
@@ -1,4 +1,5 @@
-from contourpy import contour_generator, FillType
+from contourpy import FillType, contour_generator
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, problem_sizes, thread_counts
 

--- a/benchmarks/benchmarks/bench_lines_mpl20xx.py
+++ b/benchmarks/benchmarks/bench_lines_mpl20xx.py
@@ -1,4 +1,5 @@
-from contourpy import contour_generator, LineType
+from contourpy import LineType, contour_generator
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, problem_sizes
 

--- a/benchmarks/benchmarks/bench_lines_mpl20xx_render.py
+++ b/benchmarks/benchmarks/bench_lines_mpl20xx_render.py
@@ -1,5 +1,6 @@
-from contourpy import contour_generator, LineType
+from contourpy import LineType, contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, problem_sizes
 

--- a/benchmarks/benchmarks/bench_lines_serial.py
+++ b/benchmarks/benchmarks/bench_lines_serial.py
@@ -1,4 +1,5 @@
 from contourpy import contour_generator
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, line_types, problem_sizes
 

--- a/benchmarks/benchmarks/bench_lines_serial_chunk.py
+++ b/benchmarks/benchmarks/bench_lines_serial_chunk.py
@@ -1,4 +1,5 @@
-from contourpy import contour_generator, LineType
+from contourpy import LineType, contour_generator
+
 from .bench_base import BenchBase
 from .util_bench import chunk_counts, corner_masks, datasets
 

--- a/benchmarks/benchmarks/bench_lines_serial_quad_as_tri.py
+++ b/benchmarks/benchmarks/bench_lines_serial_quad_as_tri.py
@@ -1,4 +1,5 @@
-from contourpy import contour_generator, LineType
+from contourpy import LineType, contour_generator
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, problem_sizes
 

--- a/benchmarks/benchmarks/bench_lines_serial_quad_as_tri_render.py
+++ b/benchmarks/benchmarks/bench_lines_serial_quad_as_tri_render.py
@@ -1,5 +1,6 @@
-from contourpy import contour_generator, LineType
+from contourpy import LineType, contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, problem_sizes
 

--- a/benchmarks/benchmarks/bench_lines_serial_render.py
+++ b/benchmarks/benchmarks/bench_lines_serial_render.py
@@ -1,5 +1,6 @@
 from contourpy import contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, line_types, problem_sizes
 

--- a/benchmarks/benchmarks/bench_lines_threaded.py
+++ b/benchmarks/benchmarks/bench_lines_threaded.py
@@ -1,4 +1,5 @@
-from contourpy import contour_generator, LineType
+from contourpy import LineType, contour_generator
+
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, problem_sizes, thread_counts
 

--- a/benchmarks/loader.py
+++ b/benchmarks/loader.py
@@ -1,9 +1,11 @@
+from copy import deepcopy
+from datetime import datetime
+
 from asv.benchmarks import Benchmarks
 from asv.config import Config
 from asv.results import iter_results_for_machine
+
 from contourpy import FillType, LineType
-from copy import deepcopy
-from datetime import datetime
 
 
 class Loader:

--- a/benchmarks/plot_benchmarks.py
+++ b/benchmarks/plot_benchmarks.py
@@ -1,10 +1,11 @@
+import re
+
 from asv.util import human_value
-from contourpy import FillType, LineType
 from loader import Loader
 import matplotlib.pyplot as plt
 import numpy as np
-import re
 
+from contourpy import FillType, LineType
 
 # Default fill/line types that exist in all algorithms.
 default_fill_type = FillType.OuterCode

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,10 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import sphinx_rtd_theme
 import sys
+
+import sphinx_rtd_theme
+
 sys.path.append(os.path.abspath("./sphinxext"))
 
 

--- a/docs/sphinxext/name_supports.py
+++ b/docs/sphinxext/name_supports.py
@@ -1,8 +1,10 @@
-import contourpy
+import sys
+
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import unchanged
 
-import sys
+import contourpy
+
 sys.path.insert(0, '.')
 from sphinxext.table import Table
 

--- a/docs/sphinxext/name_supports_type.py
+++ b/docs/sphinxext/name_supports_type.py
@@ -1,7 +1,9 @@
-import contourpy
+import sys
+
 from docutils.parsers.rst import Directive
 
-import sys
+import contourpy
+
 sys.path.insert(0, '.')
 from sphinxext.table import Table
 

--- a/docs/sphinxext/plot_directive.py
+++ b/docs/sphinxext/plot_directive.py
@@ -1,8 +1,10 @@
-from contourpy.util.mpl_renderer import MplRenderer
+import os
+
 from docutils import nodes
 from docutils.parsers.rst.directives import choice
-import os
 from sphinx.directives.code import CodeBlock
+
+from contourpy.util.mpl_renderer import MplRenderer
 
 
 class PlotDirective(CodeBlock):

--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -1,13 +1,12 @@
 import numpy as np
 
-from .chunk import calc_chunk_sizes
 from ._contourpy import (
-    FillType, LineType, ContourGenerator, Mpl2005ContourGenerator, Mpl2014ContourGenerator,
-    SerialContourGenerator, ThreadedContourGenerator, ZInterp, max_threads
+    ContourGenerator, FillType, LineType, Mpl2005ContourGenerator, Mpl2014ContourGenerator,
+    SerialContourGenerator, ThreadedContourGenerator, ZInterp, max_threads,
 )
-from .enum_util import as_fill_type, as_line_type, as_z_interp
 from ._version import __version__
-
+from .chunk import calc_chunk_sizes
+from .enum_util import as_fill_type, as_line_type, as_z_interp
 
 __all__ = [
     "__version__",

--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -1,10 +1,11 @@
+import io
+
 from bokeh.io import export_png, export_svg, show
 from bokeh.io.export import get_screenshot_as_png
 from bokeh.layouts import gridplot
 from bokeh.models import Label
 from bokeh.palettes import Category10
 from bokeh.plotting import figure
-import io
 import numpy as np
 
 from .bokeh_util import filled_to_bokeh, lines_to_bokeh

--- a/lib/contourpy/util/bokeh_util.py
+++ b/lib/contourpy/util/bokeh_util.py
@@ -1,4 +1,5 @@
 from contourpy import FillType, LineType
+
 from .mpl_util import mpl_codes_to_offsets
 
 

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -1,9 +1,11 @@
 import io
-import matplotlib.pyplot as plt
+
 import matplotlib.collections as mcollections
+import matplotlib.pyplot as plt
 import numpy as np
 
 from contourpy import FillType, LineType
+
 from .mpl_util import filled_to_mpl_paths, lines_to_mpl_paths, mpl_codes_to_offsets
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,12 @@ requires = [
     "setuptools>=42",
 ]
 
+[tool.isort]
+force_sort_within_sections = true
+multi_line_output = 5
+profile = "hug"
+skip_gitignore = true
+
 [tool.cibuildwheel]
 build-verbosity = "2"
 build = "cp37-* cp38-* cp39-* cp310-* pp37-* pp38-*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ zip_safe = False
 
 [options.extras_require]
 docs =
+    docutils <0.18
     sphinx
     sphinx-rtd-theme
 bokeh =
@@ -43,6 +44,7 @@ bokeh =
     # Also need geckodriver and firefox, or chromedriver and chrome, for export to PNG/SVG/buffer.
 test =
     flake8
+    isort
     matplotlib
     Pillow
     pytest
@@ -64,4 +66,4 @@ per-file-ignores =
     lib/contourpy/util/mpl_renderer.py: E402,
     tests/util_config.py: E402,
     # F401 = module imported but unused.
-    docs/conf.py: F401,
+    docs/conf.py: E402, F401,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 import os
 import re
+
+from pybind11.setup_helpers import ParallelCompile, Pybind11Extension, build_ext, naive_recompile
 from setuptools import setup
-from pybind11.setup_helpers import build_ext, naive_recompile, ParallelCompile, Pybind11Extension
 
 
 def get_version():

--- a/tests/image_comparison.py
+++ b/tests/image_comparison.py
@@ -1,7 +1,8 @@
-import numpy as np
 import os
-from PIL import Image
 from shutil import copyfile
+
+from PIL import Image
+import numpy as np
 
 
 def compare_images(test_buffer, baseline_filename, test_filename_suffix=None, max_threshold=None,

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -1,6 +1,7 @@
-import pytest
 import re
 from subprocess import run
+
+import pytest
 
 import contourpy
 
@@ -36,6 +37,16 @@ def test_flake8():
         pytest.skip()
 
     assert proc.returncode == 0, f"Flake8 issues:\n{proc.stdout.decode('utf-8')}"
+
+
+def test_isort():
+    cmd = ["isort", ".", "--diff", "--check-only"]
+    try:
+        proc = run(cmd, capture_output=True)
+    except FileNotFoundError:
+        pytest.skip()
+
+    assert proc.returncode == 0, f"isort issues:\n{proc.stderr.decode('utf-8')}"
 
 
 def test_version():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-import util_test
+from . import util_test
 
 
 @pytest.mark.needs_mpl
@@ -8,8 +8,8 @@ import util_test
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.all_names())
 def test_config_filled(show_text, name):
-    from image_comparison import compare_images
-    import util_config
+    from . import util_config
+    from .image_comparison import compare_images
 
     config = util_config.ConfigFilled(name, show_text=show_text)
     image_buffer = config.save_to_buffer()
@@ -22,8 +22,8 @@ def test_config_filled(show_text, name):
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_config_filled_quad_as_tri(show_text, name):
-    from image_comparison import compare_images
-    import util_config
+    from . import util_config
+    from .image_comparison import compare_images
 
     config = util_config.ConfigFilled(name, quad_as_tri=True, show_text=show_text)
     image_buffer = config.save_to_buffer()
@@ -36,8 +36,8 @@ def test_config_filled_quad_as_tri(show_text, name):
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_config_filled_corner(show_text, name):
-    from image_comparison import compare_images
-    import util_config
+    from . import util_config
+    from .image_comparison import compare_images
 
     config = util_config.ConfigFilledCorner(name, show_text=show_text)
     image_buffer = config.save_to_buffer()
@@ -50,8 +50,8 @@ def test_config_filled_corner(show_text, name):
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.all_names())
 def test_config_lines(show_text, name):
-    from image_comparison import compare_images
-    import util_config
+    from . import util_config
+    from .image_comparison import compare_images
 
     if name == "mpl2005":
         pytest.skip()  # Line directions are not consistent.
@@ -66,8 +66,8 @@ def test_config_lines(show_text, name):
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_config_lines_quad_as_tri(show_text, name):
-    from image_comparison import compare_images
-    import util_config
+    from . import util_config
+    from .image_comparison import compare_images
 
     config = util_config.ConfigLines(name, quad_as_tri=True, show_text=show_text)
     image_buffer = config.save_to_buffer()
@@ -80,8 +80,8 @@ def test_config_lines_quad_as_tri(show_text, name):
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_config_lines_corner(show_text, name):
-    from image_comparison import compare_images
-    import util_config
+    from . import util_config
+    from .image_comparison import compare_images
 
     config = util_config.ConfigLinesCorner(name, show_text=show_text)
     image_buffer = config.save_to_buffer()

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 import contourpy
-import util_test
+
+from . import util_test
 
 
 @pytest.fixture

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -2,7 +2,8 @@ import pytest
 
 from contourpy import FillType, LineType, ZInterp
 from contourpy.enum_util import as_fill_type, as_line_type, as_z_interp
-import util_test
+
+from . import util_test
 
 
 @pytest.mark.parametrize("name, value", util_test.all_fill_types_str_value())

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -1,12 +1,14 @@
 from functools import reduce
+from operator import add
+
 import numpy as np
 from numpy.testing import assert_array_equal
-from operator import add
 import pytest
 
-from contourpy import contour_generator, FillType
+from contourpy import FillType, contour_generator
 from contourpy.util.data import random, simple
-import util_test
+
+from . import util_test
 
 
 @pytest.fixture
@@ -22,7 +24,8 @@ def two_outers_one_hole():
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_simple(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40))
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type)
@@ -42,7 +45,8 @@ def test_filled_simple(name, fill_type):
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_simple_chunk(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40))
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, chunk_size=2)
@@ -63,7 +67,8 @@ def test_filled_simple_chunk(name, fill_type):
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_simple_no_corner_mask(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40), want_mask=True)
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, corner_mask=False)
@@ -83,7 +88,8 @@ def test_filled_simple_no_corner_mask(name, fill_type):
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_simple_no_corner_mask_chunk(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40), want_mask=True)
     cont_gen = contour_generator(
@@ -107,7 +113,8 @@ def test_filled_simple_no_corner_mask_chunk(name, fill_type):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_simple_corner_mask(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40), want_mask=True)
     fill_type = FillType.OuterCode
@@ -128,7 +135,8 @@ def test_filled_simple_corner_mask(name):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_simple_corner_mask_chunk(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40), want_mask=True)
     fill_type = FillType.OuterCode
@@ -153,7 +161,8 @@ def test_filled_simple_corner_mask_chunk(name):
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_filled_simple_quad_as_tri(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40))
     cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=True)
@@ -172,7 +181,8 @@ def test_filled_simple_quad_as_tri(name):
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_random(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.0)
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type)
@@ -192,7 +202,8 @@ def test_filled_random(name, fill_type):
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_random_chunk(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.0)
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, chunk_size=2)
@@ -228,7 +239,8 @@ def test_filled_random_chunk(name, fill_type):
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_random_no_corner_mask(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.05)
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, corner_mask=False)
@@ -248,7 +260,8 @@ def test_filled_random_no_corner_mask(name, fill_type):
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_random_no_corner_mask_chunk(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.05)
     cont_gen = contour_generator(
@@ -283,7 +296,8 @@ def test_filled_random_no_corner_mask_chunk(name, fill_type):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_random_corner_mask(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.05)
     fill_type = FillType.OuterCode
@@ -302,7 +316,8 @@ def test_filled_random_corner_mask(name):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_random_corner_mask_chunk(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.05)
     fill_type = FillType.OuterCode
@@ -331,7 +346,8 @@ def test_filled_random_corner_mask_chunk(name):
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_filled_random_quad_as_tri(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.0)
     cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=True)

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -2,9 +2,10 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 
-from contourpy import contour_generator, LineType
+from contourpy import LineType, contour_generator
 from contourpy.util.data import random, simple
-import util_test
+
+from . import util_test
 
 
 @pytest.fixture
@@ -91,7 +92,8 @@ def test_loop(xy_3x3, name):
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_simple(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40))
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type)
@@ -111,7 +113,8 @@ def test_lines_simple(name, line_type):
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_simple_chunk(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40))
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, chunk_size=2)
@@ -131,7 +134,8 @@ def test_lines_simple_chunk(name, line_type):
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_simple_no_corner_mask(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40), want_mask=True)
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, corner_mask=False)
@@ -151,7 +155,8 @@ def test_lines_simple_no_corner_mask(name, line_type):
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_simple_no_corner_mask_chunk(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40), want_mask=True)
     cont_gen = contour_generator(
@@ -172,7 +177,8 @@ def test_lines_simple_no_corner_mask_chunk(name, line_type):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_simple_corner_mask(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40), want_mask=True)
     line_type = LineType.SeparateCode
@@ -193,7 +199,8 @@ def test_lines_simple_corner_mask(name):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_simple_corner_mask_chunk(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40), want_mask=True)
     line_type = LineType.SeparateCode
@@ -215,7 +222,8 @@ def test_lines_simple_corner_mask_chunk(name):
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_lines_simple_quad_as_tri(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = simple((30, 40))
     cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=True)
@@ -234,7 +242,8 @@ def test_lines_simple_quad_as_tri(name):
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_random(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.0)
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type)
@@ -254,7 +263,8 @@ def test_lines_random(name, line_type):
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_random_chunk(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.0)
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, chunk_size=2)
@@ -283,7 +293,8 @@ def test_lines_random_chunk(name, line_type):
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_random_no_corner_mask(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.05)
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, corner_mask=False)
@@ -303,7 +314,8 @@ def test_lines_random_no_corner_mask(name, line_type):
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_random_no_corner_mask_chunk(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     if name in ("mpl2005"):
         pytest.skip()  # mpl2005 does not support chunks for lines.
@@ -325,7 +337,8 @@ def test_lines_random_no_corner_mask_chunk(name, line_type):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_random_corner_mask(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.05)
     line_type = LineType.SeparateCode
@@ -344,7 +357,8 @@ def test_lines_random_corner_mask(name):
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_random_corner_mask_chunk(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.05)
     line_type = LineType.SeparateCode
@@ -363,7 +377,8 @@ def test_lines_random_corner_mask_chunk(name):
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_lines_random_quad_as_tri(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.0)
     cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=True)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,5 +1,6 @@
-from contourpy import max_threads, _remove_z_mask
 import numpy as np
+
+from contourpy import _remove_z_mask, max_threads
 
 
 def test_max_threads():

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from contourpy import contour_generator, FillType, LineType
+from contourpy import FillType, LineType, contour_generator
 from contourpy.util.data import random
 
 
@@ -11,7 +11,8 @@ from contourpy.util.data import random
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 def test_renderer_filled(show_text, fill_type):
     from contourpy.util.mpl_renderer import MplRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((3, 4))
     renderer = MplRenderer(ncols=2, figsize=(8, 3), show_frame=False)
@@ -46,7 +47,8 @@ def test_renderer_filled(show_text, fill_type):
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 def test_renderer_lines(show_text, line_type):
     from contourpy.util.mpl_renderer import MplRenderer
-    from image_comparison import compare_images
+
+    from .image_comparison import compare_images
 
     x, y, z = random((3, 4))
     renderer = MplRenderer(ncols=2, figsize=(8, 3), show_frame=show_text)

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,11 +1,11 @@
 import pytest
-import util_test
 
 from contourpy import (
     FillType, LineType, Mpl2005ContourGenerator, Mpl2014ContourGenerator, SerialContourGenerator,
     ThreadedContourGenerator,
 )
 
+from . import util_test
 
 _lookup = {
     "Mpl2005ContourGenerator": Mpl2005ContourGenerator,

--- a/tests/test_z_interp.py
+++ b/tests/test_z_interp.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
-from contourpy import contour_generator, LineType, ZInterp
+from contourpy import LineType, ZInterp, contour_generator
 
 
 @pytest.fixture

--- a/tests/util_config.py
+++ b/tests/util_config.py
@@ -1,9 +1,10 @@
 from enum import Enum
 import io
+
 import matplotlib.pyplot as plt
 import numpy as np
 
-from contourpy import contour_generator, LineType
+from contourpy import LineType, contour_generator
 
 
 class PointType(Enum):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from contourpy import FillType, LineType
 
-
 point_dtype = np.float64
 code_dtype = np.uint8
 offset_dtype = np.uint32


### PR DESCRIPTION
Reorder python imports using `isort`, and add `isort` to test suite so that it is automatically run as part of `pytest` and hence github actions also.

It does not correct the import ordered, just reports if it is incorrect. To fix the import order use
```
isort .
```