### PR TITLE
Run simple test after building wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.6.1
 
       - uses: actions/upload-artifact@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,11 @@ profile = "hug"
 skip_gitignore = true
 
 [tool.cibuildwheel]
+build-frontend = "build"
 build-verbosity = "2"
 build = "cp37-* cp38-* cp39-* cp310-* pp37-* pp38-*"
+test-command = "python -c 'import contourpy as c; c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9)'"
+test-skip = "*-macosx_universal2"
 
 [tool.cibuildwheel.linux]
 archs = "auto aarch64"


### PR DESCRIPTION
When building wheels using cibuildwheel in github actions, run a simple test to check if the build worked OK. Do not want a big set of tests as running these tests on emulated platforms will be slow.