### PR TITLE
Run simple test after building wheels attempt 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,10 @@ skip_gitignore = true
 [tool.cibuildwheel]
 build-frontend = "build"
 build-verbosity = "2"
-build = "cp37-* cp38-* cp39-* cp310-* pp37-* pp38-*"
-test-command = "python -c 'import contourpy as c; c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9)'"
-test-skip = "*-macosx_universal2"
+build = "cp37-* cp38-* cp39-* cp310-* pp37-* pp38-* pp39-*"
+test-command = 'python -c "import contourpy as c; c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9)"'
+# Only test combinations for which a numpy wheel exists, and macos universal unnecessary.
+test-skip = "pp37-* pp38-*-aarch64 pp39-* *musllinux* *-macosx_arm64 *-macosx_universal2"
 
 [tool.cibuildwheel.linux]
 archs = "auto aarch64"


### PR DESCRIPTION
Following on from #139, fixing the nested quotes that causes a problem on Windows, and avoid running tests in cibuildwheel for any platform/python combination for which a numpy wheel is not available. Also macos arm64 testing not yet supported in cibuildwheel.