### PR TITLE
Try to avoid the conflict on offset_t on AIX/IBM i

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -13,8 +13,11 @@ typedef py::ssize_t index_t;
 // Count of points, lines and holes.
 typedef py::size_t count_t;
 
+#ifndef _AIX
+//There's a conflict in sys/types.h on AIX/IBM i
 // Offsets into point arrays.
 typedef uint32_t offset_t;
+#endif
 
 // Input numpy array classes.
 typedef py::array_t<double, py::array::c_style | py::array::forcecast> CoordinateArray;


### PR DESCRIPTION
This PR is to make contourpy works on IBM i/AIX operating system. thanks.
Signed-off-by: GavinZhang <zheddie@163.com>