### PR TITLE
Split styling dependencies out of test requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,11 +55,11 @@ jobs:
               python -m pip install pytest
             else
               echo "Install with test dependencies"
-              python -m pip install -ve .[test]
+              python -m pip install -ve .[dev]
             fi
           else
             echo "Install in debug mode with test dependencies"
-            CONTOURPY_DEBUG=1 CONTOURPY_CXX11=1 python -m pip install -ve .[test]
+            CONTOURPY_DEBUG=1 CONTOURPY_CXX11=1 python -m pip install -ve .[dev]
           fi
           python -m pip list
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,11 +43,14 @@ bokeh =
     selenium
     # Also need geckodriver and firefox, or chromedriver and chrome, for export to PNG/SVG/buffer.
 test =
-    flake8
-    isort
     matplotlib
     Pillow
     pytest
+dev =
+    flake8
+    isort
+    %(docs)s
+    %(test)s
 
 [options.packages.find]
 where = lib


### PR DESCRIPTION
In downstream packages, we don't want to check styling in tests because they are really development checks and _should_ be conformant already. And we don't want to have to worry about fixing errors when `flake8`/`isort` change behaviour but a new `contourpy` hasn't been released.