### PR TITLE
Allow install of test dependencies without codebase deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,12 +42,16 @@ bokeh =
     bokeh
     selenium
     # Also need geckodriver and firefox, or chromedriver and chrome, for export to PNG/SVG/buffer.
-test =
-    flake8
-    isort
+test-no-codebase =
+    # Test dependencies excluding codebase tests.
     matplotlib
     Pillow
     pytest
+test =
+    # All test dependencies.
+    %(test-no-codebase)s
+    flake8
+    isort
 
 [options.packages.find]
 where = lib


### PR DESCRIPTION
Allow install of test dependencies without codebase test dependencies.

Supersedes #146, providing the same functionality but without unnecessarily altering the standard dev workflow and without forcing doc deps install.