### PR TITLE
Add python 3.11 release candidate to CI

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,20 +17,37 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         debug: [0]
+        test-image: [1]
         include:
           # Add debug build and test to matrix.
           - os: ubuntu-latest
-            python-version: 3.9
+            python-version: '3.10'
             debug: 1
-          # PyPy only tested on ubuntu for speed.
+            test-image: 1
+          # PyPy only tested on ubuntu for speed, without image tests.
           - os: ubuntu-latest
             python-version: 'pypy-3.7'
             debug: 0
+            test-image: 0
           - os: ubuntu-latest
             python-version: 'pypy-3.8'
             debug: 0
+            test-image: 0
+          # Pre-release Python version without image tests.
+          - os: ubuntu-latest
+            python-version: '3.11-dev'
+            debug: 0
+            test-image: 0
+          - os: macos-latest
+            python-version: '3.11-dev'
+            debug: 0
+            test-image: 0
+          - os: windows-latest
+            python-version: '3.11-dev'
+            debug: 0
+            test-image: 0
 
     steps:
       - name: Checkout source
@@ -39,7 +56,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -48,14 +65,13 @@ jobs:
         run: |
           if [[ ${{ matrix.debug }} == 0 ]];
           then
-            if [[ ${{ matrix.python-version }} == pypy* ]];
+            if [[ ${{ matrix.test-image }} == 1 ]];
             then
-              echo "Install without test dependencies"
-              python -m pip install -ve .
-              python -m pip install pytest
-            else
-              echo "Install with test dependencies"
+              echo "Install with full test dependencies"
               python -m pip install -ve .[test]
+            else
+              echo "Install with minimal test dependencies"
+              python -m pip install -ve .[test-minimal]
             fi
           else
             echo "Install in debug mode with test dependencies"
@@ -71,13 +87,13 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          if [[ ${{ matrix.python-version }} == pypy* ]];
+          if [[ ${{ matrix.test-image }} == 1 ]];
           then
-            echo "Run only tests that do not need mpl"
-            python -m pytest -v tests/ -k "not needs_mpl"
-          else
-            echo "Run tests"
+            echo "Run all tests"
             python -m pytest -v tests/
+          else
+            echo "Run only tests that do not generate images"
+            python -m pytest -v tests/ -k "not image"
           fi
 
       - name: Collect test image failures

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,11 +42,13 @@ bokeh =
     bokeh
     selenium
     # Also need geckodriver and firefox, or chromedriver and chrome, for export to PNG/SVG/buffer.
+test-minimal =
+    pytest
 test-no-codebase =
-    # Test dependencies excluding codebase tests.
+    # All test dependencies excluding codebase tests.
+    %(test-minimal)s
     matplotlib
     Pillow
-    pytest
 test =
     # All test dependencies.
     %(test-no-codebase)s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     config.addinivalue_line("markers", "text: mark test as outputting text")
-    config.addinivalue_line("markers", "needs_mpl: mark test as needing matplotlib")
+    config.addinivalue_line("markers", "image: mark test as generating comparison image")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/image_comparison.py
+++ b/tests/image_comparison.py
@@ -1,12 +1,13 @@
 import os
 from shutil import copyfile
 
-from PIL import Image
 import numpy as np
 
 
 def compare_images(test_buffer, baseline_filename, test_filename_suffix=None, max_threshold=None,
                    mean_threshold=None):
+    from PIL import Image
+
     if max_threshold is None:
         max_threshold = 100
     if mean_threshold is None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ import pytest
 from . import util_test
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.all_names())
@@ -17,7 +17,7 @@ def test_config_filled(show_text, name):
     compare_images(image_buffer, f"config_filled{suffix}.png", name)
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
@@ -31,7 +31,7 @@ def test_config_filled_quad_as_tri(show_text, name):
     compare_images(image_buffer, f"config_filled_quad_as_tri{suffix}.png", name)
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
@@ -45,7 +45,7 @@ def test_config_filled_corner(show_text, name):
     compare_images(image_buffer, f"config_filled_corner{suffix}.png", name)
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.all_names())
@@ -61,7 +61,7 @@ def test_config_lines(show_text, name):
     compare_images(image_buffer, f"config_lines{suffix}.png", name)
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
@@ -75,7 +75,7 @@ def test_config_lines_quad_as_tri(show_text, name):
     compare_images(image_buffer, f"config_lines_quad_as_tri{suffix}.png", name)
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.corner_mask_names())

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -20,7 +20,7 @@ def two_outers_one_hole():
     return x, y, z
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_simple(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -41,7 +41,7 @@ def test_filled_simple(name, fill_type):
     compare_images(image_buffer, "filled_simple.png", f"{name}_{fill_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_simple_chunk(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -63,7 +63,7 @@ def test_filled_simple_chunk(name, fill_type):
         image_buffer, "filled_simple_chunk.png", f"{name}_{fill_type}", mean_threshold=0.12)
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_simple_no_corner_mask(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -84,7 +84,7 @@ def test_filled_simple_no_corner_mask(name, fill_type):
     compare_images(image_buffer, "filled_simple_no_corner_mask.png", f"{name}_{fill_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_simple_no_corner_mask_chunk(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -109,7 +109,7 @@ def test_filled_simple_no_corner_mask_chunk(name, fill_type):
     )
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_simple_corner_mask(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -131,7 +131,7 @@ def test_filled_simple_corner_mask(name):
     compare_images(image_buffer, "filled_simple_corner_mask.png", f"{name}_{fill_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_simple_corner_mask_chunk(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -157,7 +157,7 @@ def test_filled_simple_corner_mask_chunk(name):
     )
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_filled_simple_quad_as_tri(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -177,7 +177,7 @@ def test_filled_simple_quad_as_tri(name):
     compare_images(image_buffer, "filled_simple_quad_as_tri.png", f"{name}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_random(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -198,7 +198,7 @@ def test_filled_random(name, fill_type):
     compare_images(image_buffer, "filled_random.png", f"{name}_{fill_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_random_chunk(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -235,7 +235,7 @@ def test_filled_random_chunk(name, fill_type):
         )
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_random_no_corner_mask(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -256,7 +256,7 @@ def test_filled_random_no_corner_mask(name, fill_type):
     compare_images(image_buffer, "filled_random_no_corner_mask.png", f"{name}_{fill_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 def test_filled_random_no_corner_mask_chunk(name, fill_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -292,7 +292,7 @@ def test_filled_random_no_corner_mask_chunk(name, fill_type):
     )
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_random_corner_mask(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -312,7 +312,7 @@ def test_filled_random_corner_mask(name):
     compare_images(image_buffer, "filled_random_corner_mask.png", f"{name}_{fill_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_filled_random_corner_mask_chunk(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -342,7 +342,7 @@ def test_filled_random_corner_mask_chunk(name):
     )
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_filled_random_quad_as_tri(name):
     from contourpy.util.mpl_renderer import MplTestRenderer

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -88,7 +88,7 @@ def test_loop(xy_3x3, name):
     assert_array_equal(codes[0], [1, 2, 2, 2, 79])
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_simple(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -109,7 +109,7 @@ def test_lines_simple(name, line_type):
     compare_images(image_buffer, "lines_simple.png", f"{name}_{line_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_simple_chunk(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -130,7 +130,7 @@ def test_lines_simple_chunk(name, line_type):
     compare_images(image_buffer, "lines_simple_chunk.png", f"{name}_{line_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_simple_no_corner_mask(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -151,7 +151,7 @@ def test_lines_simple_no_corner_mask(name, line_type):
     compare_images(image_buffer, "lines_simple_no_corner_mask.png", f"{name}_{line_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_simple_no_corner_mask_chunk(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -173,7 +173,7 @@ def test_lines_simple_no_corner_mask_chunk(name, line_type):
     compare_images(image_buffer, "lines_simple_no_corner_mask_chunk.png", f"{name}_{line_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_simple_corner_mask(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -195,7 +195,7 @@ def test_lines_simple_corner_mask(name):
     compare_images(image_buffer, "lines_simple_corner_mask.png", f"{name}_{line_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_simple_corner_mask_chunk(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -218,7 +218,7 @@ def test_lines_simple_corner_mask_chunk(name):
     compare_images(image_buffer, "lines_simple_corner_mask_chunk.png", f"{name}_{line_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_lines_simple_quad_as_tri(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -238,7 +238,7 @@ def test_lines_simple_quad_as_tri(name):
     compare_images(image_buffer, "lines_simple_quad_as_tri.png", f"{name}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_random(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -259,7 +259,7 @@ def test_lines_random(name, line_type):
     compare_images(image_buffer, "lines_random.png", f"{name}_{line_type}", max_threshold=103)
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_random_chunk(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -289,7 +289,7 @@ def test_lines_random_chunk(name, line_type):
     )
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_random_no_corner_mask(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -310,7 +310,7 @@ def test_lines_random_no_corner_mask(name, line_type):
     compare_images(image_buffer, "lines_random_no_corner_mask.png", f"{name}_{line_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 def test_lines_random_no_corner_mask_chunk(name, line_type):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -333,7 +333,7 @@ def test_lines_random_no_corner_mask_chunk(name, line_type):
     compare_images(image_buffer, "lines_random_no_corner_mask_chunk.png", f"{name}_{line_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_random_corner_mask(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -353,7 +353,7 @@ def test_lines_random_corner_mask(name):
     compare_images(image_buffer, "lines_random_corner_mask.png", f"{name}_{line_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
 def test_lines_random_corner_mask_chunk(name):
     from contourpy.util.mpl_renderer import MplTestRenderer
@@ -373,7 +373,7 @@ def test_lines_random_corner_mask_chunk(name):
     compare_images(image_buffer, "lines_random_corner_mask_chunk.png", f"{name}_{line_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_lines_random_quad_as_tri(name):
     from contourpy.util.mpl_renderer import MplTestRenderer

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -5,7 +5,7 @@ from contourpy import FillType, LineType, contour_generator
 from contourpy.util.data import random
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
@@ -41,7 +41,7 @@ def test_renderer_filled(show_text, fill_type):
     compare_images(image_buffer, f"renderer_filled_mpl{suffix}.png", f"{fill_type}")
 
 
-@pytest.mark.needs_mpl
+@pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("line_type", LineType.__members__.values())


### PR DESCRIPTION
This PR adds the python 3.11 release candidate to CI, now that NumPy have release wheels for it. Testing for this excludes image tests as MPL and Pillow wheels are not yet available.