### PR TITLE
Shorter threaded lock

### DIFF
--- a/benchmarks/benchmarks/bench_filled_serial_chunk.py
+++ b/benchmarks/benchmarks/bench_filled_serial_chunk.py
@@ -1,23 +1,23 @@
 from contourpy import FillType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import chunk_counts, corner_masks, datasets
+from .util_bench import corner_masks, datasets, total_chunk_counts
 
 
 class BenchFilledSerialChunk(BenchBase):
     params = (
         ["serial"], datasets(), [FillType.ChunkCombinedOffsetOffset], corner_masks(), [1000],
-        chunk_counts())
-    param_names = ("name", "dataset", "fill_type", "corner_mask", "n", "chunk_count")
+        total_chunk_counts())
+    param_names = ("name", "dataset", "fill_type", "corner_mask", "n", "total_chunk_count")
 
-    def setup(self, name, dataset, fill_type, corner_mask, n, chunk_count):
+    def setup(self, name, dataset, fill_type, corner_mask, n, total_chunk_count):
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_filled_serial_chunk(self, name, dataset, fill_type, corner_mask, n, chunk_count):
+    def time_filled_serial_chunk(self, name, dataset, fill_type, corner_mask, n, total_chunk_count):
         if corner_mask == "no mask":
             corner_mask = False
         cont_gen = contour_generator(
             self.x, self.y, self.z, name=name, fill_type=fill_type, corner_mask=corner_mask,
-            chunk_count=chunk_count)
+            total_chunk_count=total_chunk_count)
         for i in range(len(self.levels)-1):
             cont_gen.filled(self.levels[i], self.levels[i+1])

--- a/benchmarks/benchmarks/bench_filled_threaded.py
+++ b/benchmarks/benchmarks/bench_filled_threaded.py
@@ -1,25 +1,25 @@
 from contourpy import FillType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, problem_sizes, thread_counts
+from .util_bench import corner_masks, datasets, fill_types, problem_sizes, thread_counts
 
 
 class BenchFilledThreaded(BenchBase):
     params = (
-        ["threaded"], datasets(), [FillType.ChunkCombinedOffsetOffset], corner_masks(),
-        problem_sizes(), [40], thread_counts())
+        ["threaded"], datasets(), fill_types(), corner_masks(), problem_sizes(), [40],
+        thread_counts())
     param_names = (
-        "name", "dataset", "fill_type", "corner_mask", "n", "chunk_count", "thread_count")
+        "name", "dataset", "fill_type", "corner_mask", "n", "total_chunk_count", "thread_count")
 
-    def setup(self, name, dataset, fill_type, corner_mask, n, chunk_count, thread_count):
+    def setup(self, name, dataset, fill_type, corner_mask, n, total_chunk_count, thread_count):
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
     def time_filled_threaded(
-            self, name, dataset, fill_type, corner_mask, n, chunk_count, thread_count):
+            self, name, dataset, fill_type, corner_mask, n, total_chunk_count, thread_count):
         if corner_mask == "no mask":
             corner_mask = False
         cont_gen = contour_generator(
             self.x, self.y, self.z, name=name, fill_type=fill_type, corner_mask=corner_mask,
-            chunk_count=chunk_count, thread_count=thread_count)
+            total_chunk_count=total_chunk_count, thread_count=thread_count)
         for i in range(len(self.levels)-1):
             cont_gen.filled(self.levels[i], self.levels[i+1])

--- a/benchmarks/benchmarks/bench_filled_threaded.py
+++ b/benchmarks/benchmarks/bench_filled_threaded.py
@@ -1,4 +1,4 @@
-from contourpy import FillType, contour_generator
+from contourpy import contour_generator
 
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, fill_types, problem_sizes, thread_counts

--- a/benchmarks/benchmarks/bench_lines_serial_chunk.py
+++ b/benchmarks/benchmarks/bench_lines_serial_chunk.py
@@ -1,23 +1,23 @@
 from contourpy import LineType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import chunk_counts, corner_masks, datasets
+from .util_bench import corner_masks, datasets, total_chunk_counts
 
 
 class BenchLinesSerialChunk(BenchBase):
     params = (
         ["serial"], datasets(), [LineType.ChunkCombinedOffset], corner_masks(), [1000],
-        chunk_counts())
-    param_names = ("name", "dataset", "line_type", "corner_mask", "n", "chunk_count")
+        total_chunk_counts())
+    param_names = ("name", "dataset", "line_type", "corner_mask", "n", "total_chunk_count")
 
-    def setup(self, name, dataset, line_type, corner_mask, n, chunk_count):
+    def setup(self, name, dataset, line_type, corner_mask, n, total_chunk_count):
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_lines_serial_chunk(self, name, dataset, line_type, corner_mask, n, chunk_count):
+    def time_lines_serial_chunk(self, name, dataset, line_type, corner_mask, n, total_chunk_count):
         if corner_mask == "no mask":
             corner_mask = False
         cont_gen = contour_generator(
             self.x, self.y, self.z, name=name, line_type=line_type, corner_mask=corner_mask,
-            chunk_count=chunk_count)
+            total_chunk_count=total_chunk_count)
         for level in self.levels:
             cont_gen.lines(level)

--- a/benchmarks/benchmarks/bench_lines_threaded.py
+++ b/benchmarks/benchmarks/bench_lines_threaded.py
@@ -1,4 +1,4 @@
-from contourpy import LineType, contour_generator
+from contourpy import contour_generator
 
 from .bench_base import BenchBase
 from .util_bench import corner_masks, datasets, line_types, problem_sizes, thread_counts

--- a/benchmarks/benchmarks/bench_lines_threaded.py
+++ b/benchmarks/benchmarks/bench_lines_threaded.py
@@ -1,25 +1,25 @@
 from contourpy import LineType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, problem_sizes, thread_counts
+from .util_bench import corner_masks, datasets, line_types, problem_sizes, thread_counts
 
 
 class BenchLinesThreaded(BenchBase):
     params = (
-        ["threaded"], datasets(), [LineType.ChunkCombinedOffset], corner_masks(), problem_sizes(),
-        [40], thread_counts())
+        ["threaded"], datasets(), line_types(), corner_masks(), problem_sizes(), [40],
+        thread_counts())
     param_names = (
-        "name", "dataset", "line_type", "corner_mask", "n", "chunk_count", "thread_count")
+        "name", "dataset", "line_type", "corner_mask", "n", "total_chunk_count", "thread_count")
 
-    def setup(self, name, dataset, line_type, corner_mask, n, chunk_count, thread_count):
+    def setup(self, name, dataset, line_type, corner_mask, n, total_chunk_count, thread_count):
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
     def time_lines_threaded(
-            self, name, dataset, line_type, corner_mask, n, chunk_count, thread_count):
+            self, name, dataset, line_type, corner_mask, n, total_chunk_count, thread_count):
         if corner_mask == "no mask":
             corner_mask = False
         cont_gen = contour_generator(
             self.x, self.y, self.z, name=name, line_type=line_type, corner_mask=corner_mask,
-            chunk_count=chunk_count, thread_count=thread_count)
+            total_chunk_count=total_chunk_count, thread_count=thread_count)
         for level in self.levels:
             cont_gen.lines(level)

--- a/benchmarks/benchmarks/util_bench.py
+++ b/benchmarks/benchmarks/util_bench.py
@@ -1,10 +1,6 @@
 from contourpy import FillType, LineType, max_threads
 
 
-def chunk_counts():
-    return [4, 10, 40, 100]
-
-
 def corner_masks():
     return ["no mask", False, True]
 
@@ -28,3 +24,7 @@ def problem_sizes():
 def thread_counts():
     thread_counts = [1, 2, 4, 6, 8]
     return list(filter(lambda n: n <= max(max_threads(), 1), thread_counts))
+
+
+def total_chunk_counts():
+    return [4, 10, 40, 100]

--- a/benchmarks/benchmarks/util_bench.py
+++ b/benchmarks/benchmarks/util_bench.py
@@ -27,4 +27,4 @@ def thread_counts():
 
 
 def total_chunk_counts():
-    return [4, 10, 40, 100]
+    return [4, 12, 40, 120]

--- a/src/base.h
+++ b/src/base.h
@@ -99,9 +99,6 @@ protected:
     // If point/line/hole counts not consistent, throw runtime error.
     void check_consistent_counts(const ChunkLocal& local) const;
 
-    // Write points and offsets/codes to output numpy arrays.
-    void export_filled(ChunkLocal& local, std::vector<py::list>& return_lists);
-
     index_t find_look_S(index_t look_N_quad) const;
 
     // Return true if finished (i.e. back to start quad, direction and upper).
@@ -135,6 +132,10 @@ protected:
     double get_point_x(index_t point) const;
     double get_point_y(index_t point) const;
     double get_point_z(index_t point) const;
+
+    bool has_direct_line_offsets() const;
+    bool has_direct_outer_offsets() const;
+    bool has_direct_points() const;
 
     void init_cache_grid(const MaskArray& mask);
 
@@ -197,11 +198,9 @@ private:
     // Current contouring operation, based on return type and filled or lines.
     bool _identify_holes;
     bool _output_chunked;             // Implies empty chunks will have py::none().
-protected:  ///////////////////////////////////////////////////////////////////////////
     bool _direct_points;              // Whether points array is written direct to Python.
     bool _direct_line_offsets;        // Whether line offsets array is written direct to Python.
     bool _direct_outer_offsets;       // Whether outer offsets array is written direct to Python.
-private:
     bool _outer_offsets_into_points;  // Otherwise into line offsets.  Only used if _identify_holes.
     unsigned int _return_list_count;
 };

--- a/src/base.h
+++ b/src/base.h
@@ -102,8 +102,6 @@ protected:
     // Write points and offsets/codes to output numpy arrays.
     void export_filled(ChunkLocal& local, std::vector<py::list>& return_lists);
 
-    void export_lines(ChunkLocal& local, std::vector<py::list>& return_lists);
-
     index_t find_look_S(index_t look_N_quad) const;
 
     // Return true if finished (i.e. back to start quad, direction and upper).
@@ -199,9 +197,11 @@ private:
     // Current contouring operation, based on return type and filled or lines.
     bool _identify_holes;
     bool _output_chunked;             // Implies empty chunks will have py::none().
+protected:  ///////////////////////////////////////////////////////////////////////////
     bool _direct_points;              // Whether points array is written direct to Python.
     bool _direct_line_offsets;        // Whether line offsets array is written direct to Python.
     bool _direct_outer_offsets;       // Whether outer offsets array is written direct to Python.
+private:
     bool _outer_offsets_into_points;  // Otherwise into line offsets.  Only used if _identify_holes.
     unsigned int _return_list_count;
 };

--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -349,70 +349,6 @@ LineType BaseContourGenerator<Derived>::default_line_type()
 }
 
 template <typename Derived>
-void BaseContourGenerator<Derived>::export_filled(
-    ChunkLocal& local, std::vector<py::list>& return_lists)
-{
-    assert(local.total_point_count > 0);
-
-    switch (_fill_type)
-    {
-        case FillType::OuterCode:
-        case FillType::OuterOffset: {
-            assert(!_direct_points && !_direct_line_offsets);
-            auto outer_count = local.line_count - local.hole_count;
-
-            typename Derived::Lock lock(static_cast<Derived&>(*this));
-
-            for (decltype(outer_count) i = 0; i < outer_count; ++i) {
-                auto outer_start = local.outer_offsets.start[i];
-                auto outer_end = local.outer_offsets.start[i+1];
-                auto point_start = local.line_offsets.start[outer_start];
-                auto point_end = local.line_offsets.start[outer_end];
-                auto point_count = point_end - point_start;
-                assert(point_count > 2);
-
-                return_lists[0].append(Converter::convert_points(
-                    point_count, local.points.start + 2*point_start));
-
-                if (_fill_type == FillType::OuterCode)
-                    return_lists[1].append(Converter::convert_codes(
-                        point_count, outer_end - outer_start + 1,
-                        local.line_offsets.start + outer_start, point_start));
-                else
-                    return_lists[1].append(Converter::convert_offsets(
-                        outer_end - outer_start + 1, local.line_offsets.start + outer_start,
-                        point_start));
-            }
-            break;
-        }
-        case FillType::ChunkCombinedCode:
-        case FillType::ChunkCombinedCodeOffset: {
-            assert(_direct_points && !_direct_line_offsets);
-
-            typename Derived::Lock lock(static_cast<Derived&>(*this));
-
-            // return_lists[0][local_chunk] already contains combined points.
-            // If ChunkCombinedCodeOffset. return_lists[2][local.chunk] already contains outer
-            //    offsets.
-            return_lists[1][local.chunk] = Converter::convert_codes(
-                local.total_point_count, local.line_count + 1, local.line_offsets.start);
-            break;
-        }
-        case FillType::ChunkCombinedOffset:
-        case FillType::ChunkCombinedOffsetOffset:
-            assert(_direct_points && _direct_line_offsets);
-            if (_fill_type == FillType::ChunkCombinedOffsetOffset) {
-                assert(_direct_outer_offsets);
-            }
-            // return_lists[0][local_chunk] already contains combined points.
-            // return_lists[1][local.chunk] already contains line offsets.
-            // If ChunkCombinedOffsetOffset, return_lists[2][local.chunk] already contains
-            //      outer offsets.
-            break;
-    }
-}
-
-template <typename Derived>
 py::sequence BaseContourGenerator<Derived>::filled(double lower_level, double upper_level)
 {
     if (lower_level > upper_level)
@@ -1140,6 +1076,24 @@ template <typename Derived>
 ZInterp BaseContourGenerator<Derived>::get_z_interp() const
 {
     return _z_interp;
+}
+
+template <typename Derived>
+bool BaseContourGenerator<Derived>::has_direct_line_offsets() const
+{
+    return _direct_line_offsets;
+}
+
+template <typename Derived>
+bool BaseContourGenerator<Derived>::has_direct_outer_offsets() const
+{
+    return _direct_outer_offsets;
+}
+
+template <typename Derived>
+bool BaseContourGenerator<Derived>::has_direct_points() const
+{
+    return _direct_points;
 }
 
 template <typename Derived>
@@ -2192,7 +2146,7 @@ void BaseContourGenerator<Derived>::march_chunk(
         }
     }
     else if (_filled)
-        export_filled(local, return_lists);
+        static_cast<Derived*>(this)->export_filled(local, return_lists);
     else
         static_cast<Derived*>(this)->export_lines(local, return_lists);
 }

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -41,6 +41,7 @@ CodeArray Converter::convert_codes_check_closed(
     count_t point_count, count_t cut_count, const offset_t* cut_start, const double* points)
 {
     assert(point_count > 0 && cut_count > 0);
+    assert(cut_start != nullptr);
     assert(points != nullptr);
 
     index_t codes_shape = static_cast<index_t>(point_count);
@@ -54,6 +55,7 @@ void Converter::convert_codes_check_closed(
     CodeArray::value_type* codes)
 {
     assert(point_count > 0 && cut_count > 0);
+    assert(cut_start != nullptr);
     assert(points != nullptr);
     assert(codes != nullptr);
 
@@ -85,6 +87,7 @@ void Converter::convert_codes_check_closed_single(
     count_t point_count, const double* points, CodeArray::value_type* codes)
 {
     assert(point_count > 0);
+    assert(points != nullptr);
     assert(codes != nullptr);
 
     codes[0] = MOVETO;
@@ -103,9 +106,8 @@ void Converter::convert_codes_check_closed_single(
 OffsetArray Converter::convert_offsets(
     count_t offset_count, const offset_t* start, offset_t subtract)
 {
-    assert(offset_count > 0);
+    assert(offset_count > 0 && subtract >= 0);
     assert(start != nullptr);
-    assert(subtract >= 0);
 
     index_t offsets_shape = static_cast<index_t>(offset_count);
     OffsetArray py_offsets(offsets_shape);
@@ -117,9 +119,8 @@ void Converter::convert_offsets(
     count_t offset_count, const offset_t* start, offset_t subtract,
     OffsetArray::value_type* offsets)
 {
-    assert(offset_count > 0);
+    assert(offset_count > 0 && subtract >= 0);
     assert(start != nullptr);
-    assert(subtract >= 0);
     assert(offsets != nullptr);
 
     check_max_offset(*(start + offset_count - 1) - subtract);

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -96,7 +96,6 @@ void Converter::convert_codes_check_closed_single(
     bool closed = *start == *(end-2) && *(start+1) == *(end-1);
     if (closed) {
         std::fill(codes + 1, codes + point_count - 1, LINETO);
-        // cppcheck-suppress unreadVariable
         codes[point_count-1] = CLOSEPOLY;
     }
     else

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -29,55 +29,75 @@ CodeArray Converter::convert_codes(
 }
 
 CodeArray Converter::convert_codes_check_closed(
-    count_t point_count, count_t cut_count, const offset_t* cut_start, const double* check_closed)
+    count_t point_count, count_t cut_count, const offset_t* cut_start, const double* points)
 {
     assert(point_count > 0 && cut_count > 0);
+    assert(points != nullptr);
 
     index_t codes_shape = static_cast<index_t>(point_count);
-    CodeArray py_codes(codes_shape);
-    auto py_ptr = py_codes.mutable_data();
+    CodeArray codes(codes_shape);
+    convert_codes_check_closed(point_count, cut_count, cut_start, points, codes.mutable_data());
+    return codes;
+}
 
-    std::fill(py_ptr + 1, py_ptr + point_count, LINETO);
+
+void Converter::convert_codes_check_closed(
+    count_t point_count, count_t cut_count, const offset_t* cut_start, const double* points,
+    CodeArray::value_type* codes)
+{
+    assert(point_count > 0 && cut_count > 0);
+    assert(points != nullptr);
+    assert(codes != nullptr);
+
+    std::fill(codes + 1, codes + point_count, LINETO);
     for (decltype(cut_count) i = 0; i < cut_count-1; ++i) {
         auto start = cut_start[i];
         auto end = cut_start[i+1];
-        py_ptr[start] = MOVETO;
-        bool closed = check_closed[2*start] == check_closed[2*end-2] &&
-                      check_closed[2*start+1] == check_closed[2*end-1];
+        codes[start] = MOVETO;
+        bool closed = points[2*start] == points[2*end-2] &&
+                      points[2*start+1] == points[2*end-1];
         if (closed)
-            py_ptr[end-1] = CLOSEPOLY;
+            codes[end-1] = CLOSEPOLY;
     }
-
-    return py_codes;
 }
 
-CodeArray Converter::convert_codes_check_closed_single(count_t point_count, const double* points)
+CodeArray Converter::convert_codes_check_closed_single(
+    count_t point_count, const double* points)
 {
     assert(point_count > 0);
+    assert(points != nullptr);
 
     index_t codes_shape = static_cast<index_t>(point_count);
     CodeArray py_codes(codes_shape);
-    auto py_ptr = py_codes.mutable_data();
+    convert_codes_check_closed_single(point_count, points, py_codes.mutable_data());
+    return py_codes;
+}
 
-    py_ptr[0] = MOVETO;
+
+void Converter::convert_codes_check_closed_single(
+    count_t point_count, const double* points, CodeArray::value_type* codes)
+{
+    assert(point_count > 0);
+    assert(codes != nullptr);
+
+    codes[0] = MOVETO;
     auto start = points;
     auto end = points + 2*point_count;
     bool closed = *start == *(end-2) && *(start+1) == *(end-1);
     if (closed) {
-        std::fill(py_ptr + 1, py_ptr + point_count - 1, LINETO);
+        std::fill(codes + 1, codes + point_count - 1, LINETO);
         // cppcheck-suppress unreadVariable
-        py_ptr[point_count-1] = CLOSEPOLY;
+        codes[point_count-1] = CLOSEPOLY;
     }
     else
-        std::fill(py_ptr + 1, py_ptr + point_count, LINETO);
-
-    return py_codes;
+        std::fill(codes + 1, codes + point_count, LINETO);
 }
 
 OffsetArray Converter::convert_offsets(
     count_t offset_count, const offset_t* start, offset_t subtract)
 {
     assert(offset_count > 0);
+    assert(start != nullptr);
 
     check_max_offset(*(start + offset_count - 1) - subtract);
 
@@ -97,12 +117,21 @@ OffsetArray Converter::convert_offsets(
 PointArray Converter::convert_points(count_t point_count, const double* start)
 {
     assert(point_count > 0);
+    assert(start != nullptr);
 
     index_t points_shape[2] = {static_cast<index_t>(point_count), 2};
     PointArray py_points(points_shape);
-    std::copy(start, start + 2*point_count, py_points.mutable_data());
-
+    convert_points(point_count, start, py_points.mutable_data());
     return py_points;
+}
+
+void Converter::convert_points(count_t point_count, const double* start, double* points)
+{
+    assert(point_count > 0);
+    assert(start != nullptr);
+    assert(points != nullptr);
+
+    std::copy(start, start + 2*point_count, points);
 }
 
 } // namespace contourpy

--- a/src/converter.h
+++ b/src/converter.h
@@ -12,15 +12,31 @@ public:
     static CodeArray convert_codes(
         count_t point_count, count_t cut_count, const offset_t* cut_start, offset_t subtract = 0);
 
+    // Create and populate codes array,
     static CodeArray convert_codes_check_closed(
         count_t point_count, count_t cut_count, const offset_t* cut_start, const double* points);
 
-    static CodeArray convert_codes_check_closed_single(count_t point_count, const double* points);
+    // Populate codes array that has already been created.
+    static void convert_codes_check_closed(
+        count_t point_count, count_t cut_count, const offset_t* cut_start, const double* points,
+        CodeArray::value_type* codes);
+
+    // Create and populate codes array (single line loop/strip).
+    static CodeArray convert_codes_check_closed_single(
+        count_t point_count, const double* points);
+
+    // Populate codes array that has already been created (single line loop/strip).
+    static void convert_codes_check_closed_single(
+        count_t point_count, const double* points, CodeArray::value_type* codes);
 
     static OffsetArray convert_offsets(
         count_t offset_count, const offset_t* start, offset_t subtract);
 
+    // Create and populate points array,
     static PointArray convert_points(count_t point_count, const double* start);
+
+    // Populate points array that has already been created.
+    static void convert_points(count_t point_count, const double* start, double* points);
 
 private:
     static void check_max_offset(count_t max_offset);

--- a/src/converter.h
+++ b/src/converter.h
@@ -5,12 +5,22 @@
 
 namespace contourpy {
 
-// Conversion of C++ object to return to python.
+// Conversion of C++ point/code/offset array to return to Python as a NumPy array.
+// There are two versions of each function, the first creates, populates and returns a NumPy array
+// whereas the second populates one that has already been created. The former are used in serial
+// code and the latter in threaded code where the creation and manipulation of NumPy arrays needs to
+// be threadlocked whereas the population of those arrays does not.
 class Converter
 {
 public:
+    // Create and populate codes array,
     static CodeArray convert_codes(
-        count_t point_count, count_t cut_count, const offset_t* cut_start, offset_t subtract = 0);
+        count_t point_count, count_t cut_count, const offset_t* cut_start, offset_t subtract);
+
+    // Populate codes array that has already been created.
+    static void convert_codes(
+        count_t point_count, count_t cut_count, const offset_t* cut_start, offset_t subtract,
+        CodeArray::value_type* codes);
 
     // Create and populate codes array,
     static CodeArray convert_codes_check_closed(
@@ -29,8 +39,14 @@ public:
     static void convert_codes_check_closed_single(
         count_t point_count, const double* points, CodeArray::value_type* codes);
 
+    // Create and populate offsets array,
     static OffsetArray convert_offsets(
         count_t offset_count, const offset_t* start, offset_t subtract);
+
+    // Populate offsets array that has already been created.
+    static void convert_offsets(
+        count_t offset_count, const offset_t* start, offset_t subtract,
+        OffsetArray::value_type* offsets);
 
     // Create and populate points array,
     static PointArray convert_points(count_t point_count, const double* start);

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -12,6 +12,64 @@ SerialContourGenerator::SerialContourGenerator(
                            x_chunk_size, y_chunk_size)
 {}
 
+void SerialContourGenerator::export_filled(ChunkLocal& local, std::vector<py::list>& return_lists)
+{
+    assert(local.total_point_count > 0);
+
+    switch (get_fill_type())
+    {
+        case FillType::OuterCode:
+        case FillType::OuterOffset: {
+            assert(!has_direct_points() && !has_direct_line_offsets());
+            auto outer_count = local.line_count - local.hole_count;
+
+            for (decltype(outer_count) i = 0; i < outer_count; ++i) {
+                auto outer_start = local.outer_offsets.start[i];
+                auto outer_end = local.outer_offsets.start[i+1];
+                auto point_start = local.line_offsets.start[outer_start];
+                auto point_end = local.line_offsets.start[outer_end];
+                auto point_count = point_end - point_start;
+                assert(point_count > 2);
+
+                return_lists[0].append(Converter::convert_points(
+                    point_count, local.points.start + 2*point_start));
+
+                if (get_fill_type() == FillType::OuterCode)
+                    return_lists[1].append(Converter::convert_codes(
+                        point_count, outer_end - outer_start + 1,
+                        local.line_offsets.start + outer_start, point_start));
+                else
+                    return_lists[1].append(Converter::convert_offsets(
+                        outer_end - outer_start + 1, local.line_offsets.start + outer_start,
+                        point_start));
+            }
+            break;
+        }
+        case FillType::ChunkCombinedCode:
+        case FillType::ChunkCombinedCodeOffset: {
+            assert(has_direct_points() && !has_direct_line_offsets());
+
+            // return_lists[0][local_chunk] already contains combined points.
+            // If ChunkCombinedCodeOffset. return_lists[2][local.chunk] already contains outer
+            //    offsets.
+            return_lists[1][local.chunk] = Converter::convert_codes(
+                local.total_point_count, local.line_count + 1, local.line_offsets.start, 0);
+            break;
+        }
+        case FillType::ChunkCombinedOffset:
+        case FillType::ChunkCombinedOffsetOffset:
+            assert(has_direct_points() && has_direct_line_offsets());
+            if (get_fill_type() == FillType::ChunkCombinedOffsetOffset) {
+                assert(has_direct_outer_offsets());
+            }
+            // return_lists[0][local_chunk] already contains combined points.
+            // return_lists[1][local.chunk] already contains line offsets.
+            // If ChunkCombinedOffsetOffset, return_lists[2][local.chunk] already contains
+            //      outer offsets.
+            break;
+    }
+}
+
 void SerialContourGenerator::export_lines(ChunkLocal& local, std::vector<py::list>& return_lists)
 {
     assert(local.total_point_count > 0);
@@ -20,7 +78,7 @@ void SerialContourGenerator::export_lines(ChunkLocal& local, std::vector<py::lis
     {
         case LineType::Separate:
         case LineType::SeparateCode: {
-            assert(!_direct_points && !_direct_line_offsets);
+            assert(!has_direct_points() && !has_direct_line_offsets());
 
             bool separate_code = (get_line_type() == LineType::SeparateCode);
 
@@ -42,7 +100,7 @@ void SerialContourGenerator::export_lines(ChunkLocal& local, std::vector<py::lis
             break;
         }
         case LineType::ChunkCombinedCode: {
-            assert(_direct_points && !_direct_line_offsets);
+            assert(has_direct_points() && !has_direct_line_offsets());
 
             // return_lists[0][local.chunk] already contains points.
             return_lists[1][local.chunk] = Converter::convert_codes_check_closed(
@@ -51,7 +109,7 @@ void SerialContourGenerator::export_lines(ChunkLocal& local, std::vector<py::lis
             break;
         }
         case LineType::ChunkCombinedOffset:
-            assert(_direct_points && _direct_line_offsets);
+            assert(has_direct_points() && has_direct_line_offsets());
             // return_lists[0][local.chunk] already contains points.
             // return_lists[1][local.chunk] already contains line offsets.
             break;

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -12,7 +12,8 @@ SerialContourGenerator::SerialContourGenerator(
                            x_chunk_size, y_chunk_size)
 {}
 
-void SerialContourGenerator::export_filled(ChunkLocal& local, std::vector<py::list>& return_lists)
+void SerialContourGenerator::export_filled(
+    const ChunkLocal& local, std::vector<py::list>& return_lists)
 {
     assert(local.total_point_count > 0);
 
@@ -70,7 +71,8 @@ void SerialContourGenerator::export_filled(ChunkLocal& local, std::vector<py::li
     }
 }
 
-void SerialContourGenerator::export_lines(ChunkLocal& local, std::vector<py::list>& return_lists)
+void SerialContourGenerator::export_lines(
+    const ChunkLocal& local, std::vector<py::list>& return_lists)
 {
     assert(local.total_point_count > 0);
 

--- a/src/serial.h
+++ b/src/serial.h
@@ -30,10 +30,10 @@ private:
     };
 
     // Write points and offsets/codes to output numpy arrays.
-    void export_filled(ChunkLocal& local, std::vector<py::list>& return_lists);
+    void export_filled(const ChunkLocal& local, std::vector<py::list>& return_lists);
 
     // Write points and offsets/codes to output numpy arrays.
-    void export_lines(ChunkLocal& local, std::vector<py::list>& return_lists);
+    void export_lines(const ChunkLocal& local, std::vector<py::list>& return_lists);
 
     void march(std::vector<py::list>& return_lists);
 };

--- a/src/serial.h
+++ b/src/serial.h
@@ -29,6 +29,10 @@ private:
         {}
     };
 
+    // Write points and offsets/codes to output numpy arrays.
+    void export_filled(ChunkLocal& local, std::vector<py::list>& return_lists);
+
+    // Write points and offsets/codes to output numpy arrays.
     void export_lines(ChunkLocal& local, std::vector<py::list>& return_lists);
 
     void march(std::vector<py::list>& return_lists);

--- a/src/serial.h
+++ b/src/serial.h
@@ -29,6 +29,8 @@ private:
         {}
     };
 
+    void export_lines(ChunkLocal& local, std::vector<py::list>& return_lists);
+
     void march(std::vector<py::list>& return_lists);
 };
 

--- a/src/threaded.cpp
+++ b/src/threaded.cpp
@@ -19,6 +19,10 @@ ThreadedContourGenerator::ThreadedContourGenerator(
 
 void ThreadedContourGenerator::export_filled(ChunkLocal& local, std::vector<py::list>& return_lists)
 {
+    // Reimplementation of SerialContourGenerator::export_filled() to separate out the creation of
+    // numpy arrays (which requires a thread lock) from the population of those arrays (which does
+    // not). This minimises the time that the lock is used for.
+
     assert(local.total_point_count > 0);
 
     switch (get_fill_type())
@@ -91,7 +95,6 @@ void ThreadedContourGenerator::export_filled(ChunkLocal& local, std::vector<py::
             // If ChunkCombinedCodeOffset. return_lists[2][local.chunk] already contains outer
             //    offsets.
 
-            assert(local.total_point_count > 0);
             index_t codes_shape = static_cast<index_t>(local.total_point_count);
 
             Lock lock(*this);
@@ -177,7 +180,6 @@ void ThreadedContourGenerator::export_lines(ChunkLocal& local, std::vector<py::l
             assert(has_direct_points() && !has_direct_line_offsets());
             // return_lists[0][local.chunk] already contains points.
 
-            assert(local.total_point_count > 0);
             index_t codes_shape = static_cast<index_t>(local.total_point_count);
 
             Lock lock(*this);

--- a/src/threaded.cpp
+++ b/src/threaded.cpp
@@ -17,7 +17,8 @@ ThreadedContourGenerator::ThreadedContourGenerator(
       _next_chunk(0)
 {}
 
-void ThreadedContourGenerator::export_filled(ChunkLocal& local, std::vector<py::list>& return_lists)
+void ThreadedContourGenerator::export_filled(
+    const ChunkLocal& local, std::vector<py::list>& return_lists)
 {
     // Reimplementation of SerialContourGenerator::export_filled() to separate out the creation of
     // numpy arrays (which requires a thread lock) from the population of those arrays (which does
@@ -121,7 +122,8 @@ void ThreadedContourGenerator::export_filled(ChunkLocal& local, std::vector<py::
     }
 }
 
-void ThreadedContourGenerator::export_lines(ChunkLocal& local, std::vector<py::list>& return_lists)
+void ThreadedContourGenerator::export_lines(
+    const ChunkLocal& local, std::vector<py::list>& return_lists)
 {
     // Reimplementation of SerialContourGenerator::export_lines() to separate out the creation of
     // numpy arrays (which requires a thread lock) from the population of those arrays (which does

--- a/src/threaded.h
+++ b/src/threaded.h
@@ -31,6 +31,10 @@ private:
         {}
     };
 
+    // Write points and offsets/codes to output numpy arrays.
+    void export_filled(ChunkLocal& local, std::vector<py::list>& return_lists);
+
+    // Write points and offsets/codes to output numpy arrays.
     void export_lines(ChunkLocal& local, std::vector<py::list>& return_lists);
 
     static index_t limit_n_threads(index_t n_threads, index_t n_chunks);

--- a/src/threaded.h
+++ b/src/threaded.h
@@ -32,10 +32,10 @@ private:
     };
 
     // Write points and offsets/codes to output numpy arrays.
-    void export_filled(ChunkLocal& local, std::vector<py::list>& return_lists);
+    void export_filled(const ChunkLocal& local, std::vector<py::list>& return_lists);
 
     // Write points and offsets/codes to output numpy arrays.
-    void export_lines(ChunkLocal& local, std::vector<py::list>& return_lists);
+    void export_lines(const ChunkLocal& local, std::vector<py::list>& return_lists);
 
     static index_t limit_n_threads(index_t n_threads, index_t n_chunks);
 

--- a/src/threaded.h
+++ b/src/threaded.h
@@ -31,6 +31,8 @@ private:
         {}
     };
 
+    void export_lines(ChunkLocal& local, std::vector<py::list>& return_lists);
+
     static index_t limit_n_threads(index_t n_threads, index_t n_chunks);
 
     void march(std::vector<py::list>& return_lists);


### PR DESCRIPTION
Performance improvements for some `LineType` and `FillType` using `threaded` algorithm.

Closes #59.

Moved `export_filled()` and `export_lines()` from `BaseContourGenerator` to `SerialContourGenerator` and `ThreadedContourGenerator`. The `serial` code is essentially unchanged but the `threaded` code now only uses a thread lock for creation of the NumPy arrays and the lock is released before the arrays are populated. This is usually faster, but the code is more complicated as there are essentially 2 passes. `Converter` class now has 2 version of each convert function, one that creates and populates the NumPy array and the other that only populates an array that has already been created.

Also expanded the threaded benchmarks to include all line and fill types, and switched use of `chunk_count` to `total_chunk_count` in these.

Performance improvements from use of the benchmarks for `n=1000`, `total_chunk_count=40`, `thread_count=6`, `random` dataset:

| LineType | Performance improvement |
| -- | -- |
| Separate | 1% |
| SeparateCode | 3% |
| ChunkCombinedCode | no change observed |
| ChunkCombinedOffset | N/A |

| FillType | Performance improvement |
| -- | -- |
| OuterCode | 5% |
| OuterOffset | 4% |
| ChunkCombinedCode | no change observed |
| ChunkCombinedCodeOffset | no change observed |
| ChunkCombinedOffset | N/A |
| ChunkCombinedOffsetOffset | N/A |

Here `N/A` means there is no change to the code for these line/fill types. Performance improvements will be greater for a larger number of threads or chunks, as there will be more chance of multiple threads wanting the lock at the same time.