### PR TITLE
Init cache by chunk if more than 1 chunk

### DIFF
--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -120,14 +120,21 @@ void SerialContourGenerator::export_lines(
 
 void SerialContourGenerator::march(std::vector<py::list>& return_lists)
 {
-    // Stage 1: Initialise cache z-levels and starting locations for whole domain.
-    init_cache_levels_and_starts();
+    auto n_chunks = get_n_chunks();
+    bool single_chunk = (n_chunks == 1);
+
+    if (single_chunk) {
+        // Stage 1: If single chunk, initialise cache z-levels and starting locations for whole
+        // domain.
+        init_cache_levels_and_starts();
+    }
 
     // Stage 2: Trace contours.
-    auto n_chunks = get_n_chunks();
     ChunkLocal local;
     for (index_t chunk = 0; chunk < n_chunks; ++chunk) {
         get_chunk_limits(chunk, local);
+        if (!single_chunk)
+            init_cache_levels_and_starts(&local);
         march_chunk(local, return_lists);
         local.clear();
     }


### PR DESCRIPTION
This PR changes the cache initialisation for `name="serial"` to be one chunk at a time rather than all at once if there is more than one chunk. Although doing this a chunk at a time is slightly slower as boundaries between chunks are processed more than once, there is the possibility of a performance improvement as the identification of `NO_STARTS_IN_ROW` and `NO_MORE_STARTS` occur chunk-wise, making them more useful.

There is no significant change in performance for chunked `dataset="random"` benchmarks, but there is a major improvement for `dataset="simple"`. Here is selected output from `asv compare` between `main` and this PR branch:

```
before       after        ratio
78.7±0.4ms   73.3±0.6ms   0.93  time_lines_serial_chunk('serial', 'simple', <LineType.ChunkCombinedOffset: 104>, 'no mask', 1000, 4)
80.0±0.6ms   74.8±0.3ms   0.93  time_lines_serial_chunk('serial', 'simple', <LineType.ChunkCombinedOffset: 104>, 'no mask', 1000, 12)
83.4±4.0ms   74.8±0.4ms   0.90  time_lines_serial_chunk('serial', 'simple', <LineType.ChunkCombinedOffset: 104>, 'no mask', 1000, 40)
84.3±0.3ms   74.2±0.6ms   0.88  time_lines_serial_chunk('serial', 'simple', <LineType.ChunkCombinedOffset: 104>, 'no mask', 1000, 120)

83.0±0.3ms   80.5±0.8ms   0.97  time_filled_serial_chunk('serial', 'simple', <FillType.ChunkCombinedOffsetOffset: 206>, 'no mask', 1000, 4)
85.4±0.5ms   81.1±0.9ms   0.95  time_filled_serial_chunk('serial', 'simple', <FillType.ChunkCombinedOffsetOffset: 206>, 'no mask', 1000, 12)
86.1±0.1ms   81.3±0.3ms   0.94  time_filled_serial_chunk('serial', 'simple', <FillType.ChunkCombinedOffsetOffset: 206>, 'no mask', 1000, 40)
88.2±0.2ms   81.4±0.3ms   0.92  time_filled_serial_chunk('serial', 'simple', <FillType.ChunkCombinedOffsetOffset: 206>, 'no mask', 1000, 120)
```
so that is a performance improvement of 8-12% for 120 chunks.
 