### PR TITLE
Better sorting in threaded tests

### DIFF
--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -679,8 +679,8 @@ def test_return_by_fill_type_chunk(xyz_chunk_test, name, thread_count, fill_type
         assert len(points) == 4
         if name == "threaded" and cont_gen.thread_count > 1:
             # Polygons may be in any order so sort lines and expected.
-            points = sorted([polygon.tolist() for polygon in points])
-            expected = sorted(expected)
+            points = util_test.sort_by_first_xy(points)
+            expected = util_test.sort_by_first_xy(expected)
         for chunk in range(4):
             assert_allclose(points[chunk], expected[chunk])
 

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -667,17 +667,16 @@ def test_return_by_line_type_chunk(xyz_chunk_test, name, thread_count, line_type
         assert len(lines) == 4
         if name == "threaded" and cont_gen.thread_count > 1:
             # Lines may be in any order so sort lines and expected.
-            lines = sorted([line.tolist() for line in lines])
-            expected = sorted(expected)
+            lines = util_test.sort_by_first_xy(lines)
+            expected = util_test.sort_by_first_xy(expected)
         for chunk in range(4):
             assert_allclose(lines[chunk], expected[chunk])
     elif line_type == LineType.SeparateCode:
         assert len(lines[0]) == 4
         if name == "threaded" and cont_gen.thread_count > 1:
             # Lines may be in any order so sort lines and expected.
-            order = np.argsort([line[0] for line in lines[0]], axis=0)[:, 0]
-            lines = ([lines[0][o] for o in order], [lines[1][o] for o in order])
-            expected = sorted(expected)
+            lines = util_test.sort_by_first_xy(lines[0], lines[1])
+            expected = util_test.sort_by_first_xy(expected)
         for chunk in range(4):
             assert_allclose(lines[0][chunk], expected[chunk])
             assert_array_equal(lines[1][chunk], [1] + [2]*(len(expected[chunk])-1))

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -241,3 +241,14 @@ def assert_lines(lines, line_type):
                 assert_offset_array(offset, npoints)
     else:
         raise RuntimeError(f"Unexpected line_type {line_type}")
+
+
+def sort_by_first_xy(lines, others=None):
+    first_xy = np.array([line[0] for line in lines])
+    order = np.lexsort((first_xy[:, 1], first_xy[:, 0]))
+    lines = [lines[o] for o in order]
+    if others is None:
+        return lines
+    else:
+        others = [others[o] for o in order]
+        return lines, others


### PR DESCRIPTION
In threaded tests that returned non-chunked lines or fill the order of the lines/polygons is not deterministic so they have to be sorted for test comparison. Previously the sorting code wasn't robust enough; it was fine for Linux all the time but there was an occasional erroneous test failure on macOS. This PR makes the test sorting fully robust.