### PR TITLE
Remove unnecessary `build` dep from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "build",
     "pybind11>=2.6",
     "setuptools>=42",
 ]


### PR DESCRIPTION
Do not specify `build` in `requires` key of `pyproject.toml`.  The key is used to specify packages used by the build *backend*.  However, `build` is the build *frontend*, and only one of the many.  Listing it as a requirement means that all frontends will unnecessary install `build` as part of the build environment, i.e. `build` will install itself inside the venv to build wheel even though it is never used there.  Installing the package from source via `pip` does not require `build` at all.