### PR TITLE
Correct thread count in chunked tests

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -57,6 +57,10 @@ To build in debug mode, which enables ``assert`` statements in the C++ code, use
 
    $ CONTOURPY_DEBUG=1 pip install -ve .
 
+
+Running tests
+-------------
+
 To run the test suite, first ensure that the required dependencies are installed and then run the
 tests using ``pytest``:
 
@@ -64,6 +68,24 @@ tests using ``pytest``:
 
    $ pip install -ve .[test]
    $ pytest
+
+It is possible to exclude certain tests.
+
+#. To exclude image comparison tests (if you do not have ``matplotlib`` installed):
+
+   .. code-block:: console
+
+      $ pytest -k "not image"
+
+#. To exclude threaded tests (because the ``threaded`` algorithm is not yet fully robust):
+
+   .. code-block:: console
+
+      $ pytest -k "not threads"
+
+
+Building the documentation
+--------------------------
 
 To build the documentation:
 

--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -94,7 +94,8 @@ def contour_generator(x=None, y=None, z=None, *, name="serial", corner_mask=None
             only be used with an algorithm ``name`` that supports threads (currently only
             ``name="threaded"``) and there must be at least the same number of chunks as threads.
             If ``thread_count=0`` and ``name="threaded"`` then it uses the maximum number of threads
-            as determined by the C++11 call ``std::thread::hardware_concurrency()``.
+            as determined by the C++11 call ``std::thread::hardware_concurrency()``. If ``name`` is
+            something other than ``"threaded"`` then the ``thread_count`` will be set to ``1``.
 
     Return:
         :class:`~contourpy._contourpy.ContourGenerator`.

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -41,6 +41,7 @@ def test_filled_simple(name, fill_type):
 
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -58,11 +59,14 @@ def test_filled_simple_chunk(name, fill_type):
     from .image_comparison import compare_images
 
     x, y, z = simple((30, 40))
-    cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, chunk_size=2)
+    cont_gen = contour_generator(
+        x, y, z, name=name, fill_type=fill_type, chunk_size=2, thread_count=1,
+    )
     levels = np.arange(-1.0, 1.01, 0.1)
 
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (15, 20)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -116,6 +120,7 @@ def test_filled_simple_no_corner_mask(name, fill_type):
 
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -134,12 +139,13 @@ def test_filled_simple_no_corner_mask_chunk(name, fill_type):
 
     x, y, z = simple((30, 40), want_mask=True)
     cont_gen = contour_generator(
-        x, y, z, name=name, fill_type=fill_type, corner_mask=False, chunk_size=2,
+        x, y, z, name=name, fill_type=fill_type, corner_mask=False, chunk_size=2, thread_count=1,
     )
     levels = np.arange(-1.0, 1.01, 0.1)
 
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (15, 20)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -197,6 +203,7 @@ def test_filled_simple_corner_mask(name):
 
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -216,12 +223,13 @@ def test_filled_simple_corner_mask_chunk(name):
     x, y, z = simple((30, 40), want_mask=True)
     fill_type = FillType.OuterCode
     cont_gen = contour_generator(
-        x, y, z, name=name, fill_type=fill_type, corner_mask=True, chunk_size=2,
+        x, y, z, name=name, fill_type=fill_type, corner_mask=True, chunk_size=2, thread_count=1,
     )
     levels = np.arange(-1.0, 1.01, 0.1)
 
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (15, 20)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -277,6 +285,10 @@ def test_filled_simple_quad_as_tri(name):
     cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=True)
     levels = np.arange(-1.0, 1.01, 0.1)
 
+    assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
+    assert cont_gen.quad_as_tri
+
     fill_type = cont_gen.fill_type
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -299,6 +311,7 @@ def test_filled_random(name, fill_type):
 
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -316,11 +329,14 @@ def test_filled_random_chunk(name, fill_type):
     from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.0)
-    cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type, chunk_size=2)
+    cont_gen = contour_generator(
+        x, y, z, name=name, fill_type=fill_type, chunk_size=2, thread_count=1,
+    )
     levels = np.arange(0.0, 1.01, 0.2)
 
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (15, 20)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -396,6 +412,7 @@ def test_filled_random_no_corner_mask(name, fill_type):
 
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -414,12 +431,13 @@ def test_filled_random_no_corner_mask_chunk(name, fill_type):
 
     x, y, z = random((30, 40), mask_fraction=0.05)
     cont_gen = contour_generator(
-        x, y, z, name=name, fill_type=fill_type, corner_mask=False, chunk_size=2,
+        x, y, z, name=name, fill_type=fill_type, corner_mask=False, chunk_size=2, thread_count=1,
     )
     levels = np.arange(0.0, 1.01, 0.2)
 
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (15, 20)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -497,6 +515,7 @@ def test_filled_random_corner_mask(name):
 
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -516,12 +535,13 @@ def test_filled_random_corner_mask_chunk(name):
     x, y, z = random((30, 40), mask_fraction=0.05)
     fill_type = FillType.OuterCode
     cont_gen = contour_generator(
-        x, y, z, name=name, corner_mask=True, fill_type=fill_type, chunk_size=2,
+        x, y, z, name=name, corner_mask=True, fill_type=fill_type, chunk_size=2, thread_count=1,
     )
     levels = np.arange(0.0, 1.01, 0.2)
 
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (15, 20)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -583,6 +603,9 @@ def test_filled_random_quad_as_tri(name):
     cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=True)
     levels = np.arange(0.0, 1.01, 0.2)
 
+    assert cont_gen.thread_count == 1
+    assert cont_gen.quad_as_tri
+
     fill_type = cont_gen.fill_type
     renderer = MplTestRenderer()
     for i in range(len(levels)-1):
@@ -597,7 +620,10 @@ def test_filled_random_quad_as_tri(name):
 def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
     x, y, z = two_outers_one_hole
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type)
+
     assert cont_gen.fill_type == fill_type
+    assert cont_gen.thread_count == 1
+
     filled = cont_gen.filled(1.0, 2.0)
 
     util_test.assert_filled(filled, fill_type)
@@ -641,6 +667,7 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
             assert_array_equal(outer_offsets, [0, 2, 3])
 
 
+@pytest.mark.threads
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 @pytest.mark.parametrize("name, thread_count",
                          [("serial", 1), ("threaded", 1), ("threaded", 2)])
@@ -649,15 +676,15 @@ def test_return_by_fill_type_chunk(xyz_chunk_test, name, thread_count, fill_type
         pytest.skip()
 
     x, y, z = xyz_chunk_test
-    kwargs = dict(name=name, fill_type=fill_type, chunk_count=2)
-    if name == "threaded":
-        kwargs["thread_count"] = thread_count
-    cont_gen = contour_generator(x, y, z, **kwargs)
+    cont_gen = contour_generator(
+        x, y, z, name=name, fill_type=fill_type, chunk_count=2, thread_count=thread_count,
+    )
+
     assert cont_gen.fill_type == fill_type
     assert cont_gen.chunk_count == (2, 2)
     assert cont_gen.chunk_size == (2, 2)
-    if name == "threaded":
-        assert cont_gen.thread_count == thread_count
+    assert cont_gen.thread_count == thread_count
+
     filled = cont_gen.filled(0.45, 0.55)
 
     util_test.assert_filled(filled, fill_type)

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -110,6 +110,7 @@ def test_lines_simple(name, line_type):
 
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -127,11 +128,14 @@ def test_lines_simple_chunk(name, line_type):
     from .image_comparison import compare_images
 
     x, y, z = simple((30, 40))
-    cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, chunk_size=2)
+    cont_gen = contour_generator(
+        x, y, z, name=name, line_type=line_type, chunk_size=2, thread_count=1,
+    )
     levels = np.arange(-1.0, 1.01, 0.1)
 
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (15, 20)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -181,6 +185,7 @@ def test_lines_simple_no_corner_mask(name, line_type):
 
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -199,11 +204,13 @@ def test_lines_simple_no_corner_mask_chunk(name, line_type):
 
     x, y, z = simple((30, 40), want_mask=True)
     cont_gen = contour_generator(
-        x, y, z, name=name, line_type=line_type, corner_mask=False, chunk_size=2)
+        x, y, z, name=name, line_type=line_type, corner_mask=False, chunk_size=2, thread_count=1,
+    )
     levels = np.arange(-1.0, 1.01, 0.1)
 
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (15, 20)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -257,6 +264,7 @@ def test_lines_simple_corner_mask(name):
 
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -276,12 +284,13 @@ def test_lines_simple_corner_mask_chunk(name):
     x, y, z = simple((30, 40), want_mask=True)
     line_type = LineType.SeparateCode
     cont_gen = contour_generator(
-        x, y, z, name=name, line_type=line_type, corner_mask=True, chunk_size=2,
+        x, y, z, name=name, line_type=line_type, corner_mask=True, chunk_size=2, thread_count=1,
     )
     levels = np.arange(-1.0, 1.01, 0.1)
 
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (15, 20)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -332,6 +341,10 @@ def test_lines_simple_quad_as_tri(name):
     cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=True)
     levels = np.arange(-1.0, 1.01, 0.1)
 
+    assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
+    assert cont_gen.quad_as_tri
+
     line_type = cont_gen.line_type
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -354,6 +367,7 @@ def test_lines_random(name, line_type):
 
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -371,11 +385,14 @@ def test_lines_random_chunk(name, line_type):
     from .image_comparison import compare_images
 
     x, y, z = random((30, 40), mask_fraction=0.0)
-    cont_gen = contour_generator(x, y, z, name=name, line_type=line_type, chunk_size=2)
+    cont_gen = contour_generator(
+        x, y, z, name=name, line_type=line_type, chunk_size=2, thread_count=1,
+    )
     levels = np.arange(0.0, 1.01, 0.2)
 
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (15, 20)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -436,6 +453,7 @@ def test_lines_random_no_corner_mask(name, line_type):
 
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -457,12 +475,13 @@ def test_lines_random_no_corner_mask_chunk(name, line_type):
 
     x, y, z = random((30, 40), mask_fraction=0.05)
     cont_gen = contour_generator(
-        x, y, z, name=name, line_type=line_type, corner_mask=False, chunk_size=2,
+        x, y, z, name=name, line_type=line_type, corner_mask=False, chunk_size=2, thread_count=1,
     )
     levels = np.arange(0.0, 1.01, 0.2)
 
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (15, 20)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -516,6 +535,7 @@ def test_lines_random_corner_mask(name):
 
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -535,12 +555,13 @@ def test_lines_random_corner_mask_chunk(name):
     x, y, z = random((30, 40), mask_fraction=0.05)
     line_type = LineType.SeparateCode
     cont_gen = contour_generator(
-        x, y, z, name=name, corner_mask=True, line_type=line_type, chunk_size=2,
+        x, y, z, name=name, corner_mask=True, line_type=line_type, chunk_size=2, thread_count=1,
     )
     levels = np.arange(0.0, 1.01, 0.2)
 
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (15, 20)
+    assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -591,6 +612,10 @@ def test_lines_random_quad_as_tri(name):
     cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=True)
     levels = np.arange(0.0, 1.01, 0.2)
 
+    assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
+    assert cont_gen.quad_as_tri
+
     line_type = cont_gen.line_type
     renderer = MplTestRenderer()
     for i in range(len(levels)):
@@ -605,7 +630,11 @@ def test_lines_random_quad_as_tri(name):
 def test_return_by_line_type(one_loop_one_strip, name, line_type):
     x, y, z = one_loop_one_strip
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type)
+
     assert cont_gen.line_type == line_type
+    assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
+
     lines = cont_gen.lines(2.0)
 
     util_test.assert_lines(lines, line_type)
@@ -634,6 +663,7 @@ def test_return_by_line_type(one_loop_one_strip, name, line_type):
         assert_array_equal(offsets, [0, 5, 7])
 
 
+@pytest.mark.threads
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 @pytest.mark.parametrize("name, thread_count",
                          [("serial", 1), ("threaded", 1), ("threaded", 2)])
@@ -642,15 +672,15 @@ def test_return_by_line_type_chunk(xyz_chunk_test, name, thread_count, line_type
         pytest.skip()
 
     x, y, z = xyz_chunk_test
-    kwargs = dict(name=name, line_type=line_type, chunk_count=2)
-    if name == "threaded":
-        kwargs["thread_count"] = thread_count
-    cont_gen = contour_generator(x, y, z, **kwargs)
+    cont_gen = contour_generator(
+        x, y, z, name=name, line_type=line_type, chunk_count=2, thread_count=thread_count,
+    )
+
     assert cont_gen.line_type == line_type
     assert cont_gen.chunk_count == (2, 2)
     assert cont_gen.chunk_size == (2, 2)
-    if name == "threaded":
-        assert cont_gen.thread_count == thread_count
+    assert cont_gen.thread_count == thread_count
+
     lines = cont_gen.lines(0.45)
 
     util_test.assert_lines(lines, line_type)
@@ -703,6 +733,8 @@ def test_lines_random_big(name, line_type, corner_mask):
     levels = np.arange(0.0, 1.01, 0.1)
 
     assert cont_gen.line_type == line_type
+    assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
 
     for level in levels:
         lines = cont_gen.lines(level)


### PR DESCRIPTION
This PR corrects the `thread_count` in chunked tests. If unspecified and `name="threaded"` it defaulted to the number of cores available when sometimes it should have been limited to just 1.

Helps but does not fix #163.

Also added docs to show how to exclude image and threaded tests when running `pytest`.