### PR TITLE
Add Anaconda defaults installation docs and github badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ It contains the 2005 and 2014 algorithms used in Matplotlib as well as a newer a
 
 | | |
 | --- | --- |
-| Latest release | [![PyPI version](https://img.shields.io/pypi/v/contourpy.svg?label=pypi&color=fdae61)](https://pypi.python.org/pypi/contourpy) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/contourpy.svg?label=conda-forge&color=a6d96a)](https://anaconda.org/conda-forge/contourpy) |
+| Latest release | [![PyPI version](https://img.shields.io/pypi/v/contourpy.svg?label=pypi&color=fdae61)](https://pypi.python.org/pypi/contourpy) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/contourpy.svg?label=conda-forge&color=a6d96a)](https://anaconda.org/conda-forge/contourpy) [![anaconda version](https://img.shields.io/conda/v/anaconda/contourpy.svg?label=anaconda&color=1a9641)](https://anaconda.org/anaconda/contourpy) |
 | Downloads | [![PyPi downloads](https://img.shields.io/pypi/dm/contourpy?label=pypi&style=flat&color=fdae61)](https://pepy.tech/project/contourpy) [![conda-forge downloads](https://img.shields.io/conda/dn/conda-forge/contourpy?label=conda-forge&color=a6d96a)](https://anaconda.org/conda-forge/contourpy) |
-| Python | [![Python versions](https://img.shields.io/pypi/pyversions/contourpy?color=1a9641)](https://pypi.org/project/contourpy/) |
+| Python version | [![Platforms](https://img.shields.io/pypi/pyversions/contourpy?color=fdae61)](https://pypi.org/project/contourpy/) |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,7 @@ rst_epilog = """
 .. _NumPy: https://numpy.org/
 .. _PyPI: https://pypi.org/project/contourpy/
 .. _conda-forge: https://anaconda.org/conda-forge/contourpy/
+.. _default: https://anaconda.org/anaconda/contourpy/
 .. _github: https://www.github.com/contourpy/contourpy/
 .. _pybind11: https://pybind11.readthedocs.io/
 """

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,8 +4,8 @@ Installation
 Installing from prepackaged binaries
 ------------------------------------
 
-Stable releases of ``contourpy`` are available from both `PyPI`_ and `conda-forge`_ for Linux,
-macOS and Windows.
+Stable releases of ``contourpy`` are available from `PyPI`_, `conda-forge`_, and Anaconda
+`default`_ channels for Linux, macOS and Windows.
 
 #. To install from `PyPI`_:
 
@@ -18,6 +18,12 @@ macOS and Windows.
    .. code-block:: bash
 
       $ conda install -c conda-forge contourpy
+
+#. To install from Anaconda `default`_ channel:
+
+   .. code-block:: bash
+
+      $ conda install contourpy
 
 The only compulsory runtime dependency is `NumPy`_.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ zip_safe = False
 [options.extras_require]
 docs =
     docutils <0.18
-    sphinx
+    sphinx <=5.2.0
     sphinx-rtd-theme
 bokeh =
     bokeh


### PR DESCRIPTION
Now that conda packages have been release on the Anaconda default channel (https://anaconda.org/anaconda/contourpy), this PR adds installation docs and a github badge.