### PR TITLE
Install cppcheck 2.9 from source in Linux CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,13 @@ jobs:
       - name: Install cppcheck
         if: runner.os == 'Linux'
         run: |
-          sudo apt install -y cppcheck
+          CPPCHECK_VERSION=2.9
+          CPPCHECK_TGZ=$CPPCHECK_VERSION.tar.gz
+          cd $RUNNER_TEMP
+          wget --no-verbose https://github.com/danmar/cppcheck/archive/refs/tags/$CPPCHECK_TGZ
+          tar xzf $CPPCHECK_TGZ
+          cd cppcheck-$CPPCHECK_VERSION
+          sudo make install MATCHCOMPILER=yes FILESDIR=/usr/share/cppcheck CXXFLAGS="-O2 -DNDEBUG" -j 2
 
       - name: Run tests
         shell: bash

--- a/src/mpl2014.cpp
+++ b/src/mpl2014.cpp
@@ -1725,7 +1725,7 @@ bool Mpl2014ContourGenerator::start_line(
     return VISITED(quad,1);
 }
 
-void Mpl2014ContourGenerator::write_cache(bool grid_only) const
+/*void Mpl2014ContourGenerator::write_cache(bool grid_only) const
 {
     std::cout << "-----------------------------------------------" << std::endl;
     for (index_t quad = 0; quad < _n; ++quad)
@@ -1753,7 +1753,7 @@ void Mpl2014ContourGenerator::write_cache_quad(
             << VISITED_CORNER(quad);
     }
     std::cout << std::endl;
-}
+}*/
 
 } // namespace mpl2014
 } // namespace contourpy

--- a/src/mpl2014.h
+++ b/src/mpl2014.h
@@ -485,11 +485,11 @@ private:
         const double& level);
 
     // Debug function that writes the cache status to stdout.
-    void write_cache(bool grid_only = false) const;
+    //void write_cache(bool grid_only = false) const;
 
     // Debug function that writes that cache status for a single quad to
     // stdout.
-    void write_cache_quad(index_t quad, bool grid_only) const;
+    //void write_cache_quad(index_t quad, bool grid_only) const;
 
 
 


### PR DESCRIPTION
Fixes issue #167.

Builds and installs the latest `cppcheck` (2.9) in Linux CI, and comments out the unused `mpl2014` cache writing functions.