### PR TITLE
Correctly acquire and release GIL in multithreaded code

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,7 +9,7 @@ Installing ASV
 ASV creates virtualenvs to run benchmarks in.  Before using it you need to
 
 ```
-pip install asv virtualenv
+pip install asv==0.4.2 virtualenv
 ```
 or the `conda` equivalent.
 

--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -370,7 +370,7 @@ py::sequence BaseContourGenerator<Derived>::filled(double lower_level, double up
     _return_list_count = (_fill_type == FillType::ChunkCombinedCodeOffset ||
                           _fill_type == FillType::ChunkCombinedOffsetOffset) ? 3 : 2;
 
-    return static_cast<Derived*>(this)->march_wrapper();
+    return march_wrapper();
 }
 
 template <typename Derived>
@@ -1944,7 +1944,7 @@ py::sequence BaseContourGenerator<Derived>::lines(double level)
     _outer_offsets_into_points = false;
     _return_list_count = (_line_type == LineType::Separate) ? 1 : 2;
 
-    return static_cast<Derived*>(this)->march_wrapper();
+    return march_wrapper();
 }
 
 template <typename Derived>

--- a/src/serial.h
+++ b/src/serial.h
@@ -24,9 +24,6 @@ private:
     public:
         explicit Lock(SerialContourGenerator& contour_generator)
         {}
-
-        void unlock()
-        {}
     };
 
     // Write points and offsets/codes to output numpy arrays.

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -1,6 +1,5 @@
 from functools import reduce
 from operator import add
-import platform
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
@@ -672,9 +671,6 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
 @pytest.mark.parametrize("name, thread_count",
                          [("serial", 1), ("threaded", 1), ("threaded", 2)])
 def test_return_by_fill_type_chunk(xyz_chunk_test, name, thread_count, fill_type):
-    if platform.python_implementation() == "PyPy" and thread_count > 1:
-        pytest.skip()
-
     x, y, z = xyz_chunk_test
     cont_gen = contour_generator(
         x, y, z, name=name, fill_type=fill_type, chunk_count=2, thread_count=thread_count,

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -1,5 +1,3 @@
-import platform
-
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
@@ -668,9 +666,6 @@ def test_return_by_line_type(one_loop_one_strip, name, line_type):
 @pytest.mark.parametrize("name, thread_count",
                          [("serial", 1), ("threaded", 1), ("threaded", 2)])
 def test_return_by_line_type_chunk(xyz_chunk_test, name, thread_count, line_type):
-    if platform.python_implementation() == "PyPy" and thread_count > 1:
-        pytest.skip()
-
     x, y, z = xyz_chunk_test
     cont_gen = contour_generator(
         x, y, z, name=name, line_type=line_type, chunk_count=2, thread_count=thread_count,


### PR DESCRIPTION
This PR implements correct acquiring and releasing of the GIL within multithreaded code so that creation of and access to Python objects is restricted to a single thread at a time. Acquiring and releasing the GIL occurs within the lifetime of `ThreadedContourGenerator.Lock` objects.

The `threaded` algorithm is now robust for both CPython and PyPy.

Also re-enabled PyPy threaded tests that were previously skipped when they were not reliable.

Fixes #158 and #163.