### PR TITLE
Add PyPy 3.9 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,11 +28,15 @@ jobs:
             test-image: 1
           # PyPy only tested on ubuntu for speed, without image tests.
           - os: ubuntu-latest
-            python-version: 'pypy-3.7'
+            python-version: 'pypy3.7'
             debug: 0
             test-image: 0
           - os: ubuntu-latest
-            python-version: 'pypy-3.8'
+            python-version: 'pypy3.8'
+            debug: 0
+            test-image: 0
+          - os: ubuntu-latest
+            python-version: 'pypy3.9'
             debug: 0
             test-image: 0
           # Pre-release Python version without image tests.


### PR DESCRIPTION
Add a build and test run for PyPy 3.9 to CI.