### PR TITLE
Update benchmarks in line with recent code changes

### DIFF
--- a/benchmarks/plot_benchmarks.py
+++ b/benchmarks/plot_benchmarks.py
@@ -106,8 +106,11 @@ def by_name_and_type(loader, filled, dataset, render, n):
 
             i += 1
 
-    if filled and not render and dataset == "random":
-        ax.set_ylim(0, 2.7)
+    if filled and not render:
+        if dataset == "random":
+            ax.set_ylim(0, 2.75)
+        else:
+            ax.set_ylim(0, 0.32)
     else:
         ax.set_ylim(0, ax.get_ylim()[1]*1.1)  # Magic number.
 

--- a/docs/_static/chunk_filled_random.svg
+++ b/docs/_static/chunk_filled_random.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:33.786772</dc:date>
+    <dc:date>2022-10-23T17:46:36.222398</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m67cdd9c64e" d="M 0 0 
+       <path id="m58523f2c69" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m67cdd9c64e" x="114.422987" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58523f2c69" x="114.422987" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Outer -->
-      <g transform="translate(100.226112 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(100.226112 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -169,7 +169,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(101.621425 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(101.621425 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -250,12 +250,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m67cdd9c64e" x="199.697792" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58523f2c69" x="199.697792" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Outer -->
-      <g transform="translate(185.500917 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(185.500917 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -263,7 +263,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(184.600136 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(184.600136 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -330,12 +330,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m67cdd9c64e" x="284.972597" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58523f2c69" x="284.972597" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g transform="translate(269.079629 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(269.079629 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -397,7 +397,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(259.568691 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(259.568691 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -479,7 +479,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(272.171035 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(272.171035 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -490,12 +490,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m67cdd9c64e" x="370.247403" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58523f2c69" x="370.247403" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g transform="translate(354.354434 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(354.354434 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -503,7 +503,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(344.843496 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(344.843496 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -514,7 +514,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(355.149746 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(355.149746 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -527,12 +527,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m67cdd9c64e" x="455.522208" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58523f2c69" x="455.522208" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Chunk -->
-      <g transform="translate(439.629239 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(439.629239 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -540,7 +540,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(430.118302 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(430.118302 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -551,14 +551,14 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(442.720645 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(442.720645 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
        <use xlink:href="#DejaVuSans-65" x="194.482422"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(440.424552 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(440.424552 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -571,12 +571,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m67cdd9c64e" x="540.797013" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58523f2c69" x="540.797013" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Chunk -->
-      <g transform="translate(524.904044 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(524.904044 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -584,7 +584,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(515.393107 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(515.393107 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -595,7 +595,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(525.699357 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(525.699357 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -604,7 +604,7 @@ z
        <use xlink:href="#DejaVuSans-74" x="262.744141"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(525.699357 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(525.699357 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -620,21 +620,21 @@ z
      <g id="line2d_7">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#p15afe2c15a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="me8fab0074f" d="M 0 0 
+       <path id="m8102269fd8" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me8fab0074f" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8102269fd8" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.00 -->
-      <g transform="translate(24.754375 372.927219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 372.927219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -676,16 +676,16 @@ z
      <g id="line2d_9">
       <path d="M 54.02 326.347 
 L 601.2 326.347 
-" clip-path="url(#p15afe2c15a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me8fab0074f" x="54.02" y="326.347" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8102269fd8" x="54.02" y="326.347" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 330.146219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 330.146219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -748,16 +748,16 @@ z
      <g id="line2d_11">
       <path d="M 54.02 283.566 
 L 601.2 283.566 
-" clip-path="url(#p15afe2c15a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me8fab0074f" x="54.02" y="283.566" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8102269fd8" x="54.02" y="283.566" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.50 -->
-      <g transform="translate(24.754375 287.365219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 287.365219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -769,16 +769,16 @@ L 601.2 283.566
      <g id="line2d_13">
       <path d="M 54.02 240.785 
 L 601.2 240.785 
-" clip-path="url(#p15afe2c15a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me8fab0074f" x="54.02" y="240.785" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8102269fd8" x="54.02" y="240.785" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.75 -->
-      <g transform="translate(24.754375 244.584219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 244.584219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -802,16 +802,16 @@ z
      <g id="line2d_15">
       <path d="M 54.02 198.004 
 L 601.2 198.004 
-" clip-path="url(#p15afe2c15a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#me8fab0074f" x="54.02" y="198.004" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8102269fd8" x="54.02" y="198.004" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.00 -->
-      <g transform="translate(24.754375 201.803219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 201.803219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -839,16 +839,16 @@ z
      <g id="line2d_17">
       <path d="M 54.02 155.223 
 L 601.2 155.223 
-" clip-path="url(#p15afe2c15a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me8fab0074f" x="54.02" y="155.223" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8102269fd8" x="54.02" y="155.223" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.25 -->
-      <g transform="translate(24.754375 159.022219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 159.022219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -860,16 +860,16 @@ L 601.2 155.223
      <g id="line2d_19">
       <path d="M 54.02 112.442 
 L 601.2 112.442 
-" clip-path="url(#p15afe2c15a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#me8fab0074f" x="54.02" y="112.442" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8102269fd8" x="54.02" y="112.442" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.50 -->
-      <g transform="translate(24.754375 116.241219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 116.241219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -881,16 +881,16 @@ L 601.2 112.442
      <g id="line2d_21">
       <path d="M 54.02 69.661 
 L 601.2 69.661 
-" clip-path="url(#p15afe2c15a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#me8fab0074f" x="54.02" y="69.661" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8102269fd8" x="54.02" y="69.661" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 1.75 -->
-      <g transform="translate(24.754375 73.460219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 73.460219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-37" x="95.410156"/>
@@ -902,16 +902,16 @@ L 601.2 69.661
      <g id="line2d_23">
       <path d="M 54.02 26.88 
 L 601.2 26.88 
-" clip-path="url(#p15afe2c15a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#me8fab0074f" x="54.02" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8102269fd8" x="54.02" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 2.00 -->
-      <g transform="translate(24.754375 30.679219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 30.679219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -921,7 +921,7 @@ L 601.2 26.88
     </g>
     <g id="text_16">
      <!-- Time (seconds) -->
-     <g transform="translate(18.674688 236.165719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.674688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1023,65 +1023,65 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 78.891818 369.128 
 L 93.104286 369.128 
-L 93.104286 77.288363 
-L 78.891818 77.288363 
+L 93.104286 78.86789 
+L 78.891818 78.86789 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 164.166623 369.128 
 L 178.379091 369.128 
-L 178.379091 85.530868 
-L 164.166623 85.530868 
+L 178.379091 87.632457 
+L 164.166623 87.632457 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 249.441429 369.128 
 L 263.653896 369.128 
-L 263.653896 214.551028 
-L 249.441429 214.551028 
+L 263.653896 218.63742 
+L 249.441429 218.63742 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 334.716234 369.128 
 L 348.928701 369.128 
-L 348.928701 216.595534 
-L 334.716234 216.595534 
+L 348.928701 219.064177 
+L 334.716234 219.064177 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 419.991039 369.128 
 L 434.203506 369.128 
-L 434.203506 208.096328 
-L 419.991039 208.096328 
+L 434.203506 211.856975 
+L 419.991039 211.856975 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 505.265844 369.128 
 L 519.478312 369.128 
-L 519.478312 209.898117 
-L 505.265844 209.898117 
+L 519.478312 212.658965 
+L 505.265844 212.658965 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_17">
-    <!-- 1.71 s -->
-    <g transform="translate(88.757427 72.288363)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.70 s -->
+    <g transform="translate(88.757427 73.86789) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_18">
-    <!-- 1.66 s -->
-    <g transform="translate(174.032232 80.530868)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.64 s -->
+    <g transform="translate(174.032232 82.632457) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1113,93 +1113,37 @@ Q 2619 4750 2861 4703
 Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_19">
-    <!-- 903 ms -->
-    <g transform="translate(259.307037 209.551028)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 891 ms -->
-    <g transform="translate(344.581843 211.595534)rotate(-90)scale(0.1 -0.1)">
+    <!-- 879 ms -->
+    <g transform="translate(259.307037 213.63742) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1240,53 +1184,73 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 877 ms -->
+    <g transform="translate(344.581843 214.064177) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- 941 ms -->
-    <g transform="translate(429.856648 203.096328)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 919 ms -->
+    <g transform="translate(429.856648 206.856975) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- 930 ms -->
-    <g transform="translate(515.131453 204.898117)rotate(-90)scale(0.1 -0.1)">
+    <!-- 914 ms -->
+    <g transform="translate(515.131453 207.658965) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1294,42 +1258,42 @@ z
    </g>
    <g id="text_23">
     <!--  1 -->
-    <g transform="translate(88.757427 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(88.757427 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_24">
     <!--  1 -->
-    <g transform="translate(174.032232 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(174.032232 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_25">
     <!--  1 -->
-    <g transform="translate(259.307037 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(259.307037 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_26">
     <!--  1 -->
-    <g transform="translate(344.581843 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(344.581843 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_27">
     <!--  1 -->
-    <g transform="translate(429.856648 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(429.856648 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_28">
     <!--  1 -->
-    <g transform="translate(515.131453 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(515.131453 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
@@ -1337,198 +1301,198 @@ z
    <g id="patch_13">
     <path d="M 93.104286 369.128 
 L 107.316753 369.128 
-L 107.316753 76.19625 
-L 93.104286 76.19625 
+L 107.316753 76.859708 
+L 93.104286 76.859708 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 107.316753 369.128 
 L 121.529221 369.128 
-L 121.529221 77.010349 
-L 107.316753 77.010349 
+L 121.529221 77.876573 
+L 107.316753 77.876573 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 121.529221 369.128 
 L 135.741688 369.128 
-L 135.741688 73.661629 
-L 121.529221 73.661629 
+L 135.741688 74.559861 
+L 121.529221 74.559861 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 135.741688 369.128 
 L 149.954156 369.128 
-L 149.954156 67.640279 
-L 135.741688 67.640279 
+L 149.954156 69.629535 
+L 135.741688 69.629535 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 178.379091 369.128 
 L 192.591558 369.128 
-L 192.591558 82.606998 
-L 178.379091 82.606998 
+L 192.591558 85.147178 
+L 178.379091 85.147178 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 192.591558 369.128 
 L 206.804026 369.128 
-L 206.804026 84.216065 
-L 192.591558 84.216065 
+L 206.804026 86.504914 
+L 192.591558 86.504914 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 206.804026 369.128 
 L 221.016494 369.128 
-L 221.016494 82.025437 
-L 206.804026 82.025437 
+L 221.016494 83.73853 
+L 206.804026 83.73853 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 221.016494 369.128 
 L 235.228961 369.128 
-L 235.228961 75.299631 
-L 221.016494 75.299631 
+L 235.228961 76.291691 
+L 221.016494 76.291691 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 263.653896 369.128 
 L 277.866364 369.128 
-L 277.866364 204.584747 
-L 263.653896 204.584747 
+L 277.866364 208.375611 
+L 263.653896 208.375611 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 277.866364 369.128 
 L 292.078831 369.128 
-L 292.078831 198.625068 
-L 277.866364 198.625068 
+L 292.078831 202.54534 
+L 277.866364 202.54534 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 292.078831 369.128 
 L 306.291299 369.128 
-L 306.291299 197.823947 
-L 292.078831 197.823947 
+L 306.291299 201.762078 
+L 292.078831 201.762078 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 306.291299 369.128 
 L 320.503766 369.128 
-L 320.503766 194.557097 
-L 306.291299 194.557097 
+L 320.503766 198.228685 
+L 306.291299 198.228685 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 348.928701 369.128 
 L 363.141169 369.128 
-L 363.141169 206.949393 
-L 348.928701 206.949393 
+L 363.141169 210.090066 
+L 348.928701 210.090066 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 363.141169 369.128 
 L 377.353636 369.128 
-L 377.353636 200.355552 
-L 363.141169 200.355552 
+L 377.353636 203.374976 
+L 363.141169 203.374976 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 377.353636 369.128 
 L 391.566104 369.128 
-L 391.566104 199.262611 
-L 377.353636 199.262611 
+L 391.566104 202.189832 
+L 377.353636 202.189832 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 391.566104 369.128 
 L 405.778571 369.128 
-L 405.778571 195.968372 
-L 391.566104 195.968372 
+L 405.778571 198.63969 
+L 391.566104 198.63969 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 434.203506 369.128 
 L 448.415974 369.128 
-L 448.415974 198.467993 
-L 434.203506 198.467993 
+L 448.415974 201.859046 
+L 434.203506 201.859046 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 448.415974 369.128 
 L 462.628442 369.128 
-L 462.628442 191.817107 
-L 448.415974 191.817107 
+L 462.628442 196.539674 
+L 448.415974 196.539674 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 462.628442 369.128 
 L 476.840909 369.128 
-L 476.840909 191.273034 
-L 462.628442 191.273034 
+L 476.840909 195.239415 
+L 462.628442 195.239415 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 476.840909 369.128 
 L 491.053377 369.128 
-L 491.053377 201.142643 
-L 476.840909 201.142643 
+L 491.053377 204.637699 
+L 476.840909 204.637699 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 519.478312 369.128 
 L 533.690779 369.128 
-L 533.690779 200.502012 
-L 519.478312 200.502012 
+L 533.690779 204.871635 
+L 519.478312 204.871635 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 533.690779 369.128 
 L 547.903247 369.128 
-L 547.903247 194.090457 
-L 533.690779 194.090457 
+L 547.903247 197.183568 
+L 533.690779 197.183568 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 547.903247 369.128 
 L 562.115714 369.128 
-L 562.115714 192.660951 
-L 547.903247 192.660951 
+L 562.115714 195.767212 
+L 547.903247 195.767212 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 562.115714 369.128 
 L 576.328182 369.128 
-L 576.328182 203.068846 
-L 562.115714 203.068846 
+L 576.328182 205.129134 
+L 562.115714 205.129134 
 z
-" clip-path="url(#p15afe2c15a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdc15b98dc8)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_29">
     <!-- 1.71 s -->
-    <g transform="translate(102.969894 71.19625)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(102.969894 71.859708) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
@@ -1538,41 +1502,63 @@ z
     </g>
    </g>
    <g id="text_30">
-    <!-- 1.71 s -->
-    <g transform="translate(117.182362 72.010349)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.70 s -->
+    <g transform="translate(117.182362 72.876573) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 1.73 s -->
-    <g transform="translate(131.39483 68.661629)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.72 s -->
+    <g transform="translate(131.39483 69.559861) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 1.76 s -->
-    <g transform="translate(145.607297 62.640279)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.75 s -->
+    <g transform="translate(145.607297 64.629535) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_33">
+    <!-- 1.66 s -->
+    <g transform="translate(188.2447 80.147178) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 1.65 s -->
+    <g transform="translate(202.457167 81.504914) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_35">
     <!-- 1.67 s -->
-    <g transform="translate(188.2447 77.606998)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(216.669635 78.73853) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="95.410156"/>
@@ -1581,119 +1567,153 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_34">
-    <!-- 1.66 s -->
-    <g transform="translate(202.457167 79.216065)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 1.68 s -->
-    <g transform="translate(216.669635 77.025437)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
    <g id="text_36">
-    <!-- 1.72 s -->
-    <g transform="translate(230.882102 70.299631)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.71 s -->
+    <g transform="translate(230.882102 71.291691) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 962 ms -->
-    <g transform="translate(273.519505 199.584747)rotate(-90)scale(0.1 -0.1)">
+    <!-- 939 ms -->
+    <g transform="translate(273.519505 203.375611) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 996 ms -->
-    <g transform="translate(287.731972 193.625068)rotate(-90)scale(0.1 -0.1)">
+    <!-- 973 ms -->
+    <g transform="translate(287.731972 197.54534) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- 1.00 s -->
-    <g transform="translate(301.94444 192.823947)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- 1.02 s -->
-    <g transform="translate(316.156907 189.557097)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_41">
-    <!-- 948 ms -->
-    <g transform="translate(358.79431 201.949393)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_42">
-    <!-- 986 ms -->
-    <g transform="translate(373.006778 195.355552)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- 993 ms -->
-    <g transform="translate(387.219245 194.262611)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
+   <g id="text_39">
+    <!-- 978 ms -->
+    <g transform="translate(301.94444 196.762078) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- 999 ms -->
+    <g transform="translate(316.156907 193.228685) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- 929 ms -->
+    <g transform="translate(358.79431 205.090066) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_42">
+    <!-- 969 ms -->
+    <g transform="translate(373.006778 198.374976) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- 976 ms -->
+    <g transform="translate(387.219245 197.189832) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
    <g id="text_44">
+    <!-- 996 ms -->
+    <g transform="translate(401.431713 193.63969) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_45">
+    <!-- 977 ms -->
+    <g transform="translate(444.069115 196.859046) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_46">
     <!-- 1.01 s -->
-    <g transform="translate(401.431713 190.968372)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(458.281583 191.539674) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1702,64 +1722,9 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_45">
-    <!-- 997 ms -->
-    <g transform="translate(444.069115 193.467993)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_46">
-    <!-- 1.04 s -->
-    <g transform="translate(458.281583 186.817107)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
    <g id="text_47">
-    <!-- 1.04 s -->
-    <g transform="translate(472.49405 186.273034)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_48">
-    <!-- 982 ms -->
-    <g transform="translate(486.706518 196.142643)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_49">
-    <!-- 985 ms -->
-    <g transform="translate(529.34392 195.502012)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_50">
     <!-- 1.02 s -->
-    <g transform="translate(543.556388 189.090457)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(472.49405 190.239415) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1768,23 +1733,56 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_51">
-    <!-- 1.03 s -->
-    <g transform="translate(557.768856 187.660951)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_48">
+    <!-- 961 ms -->
+    <g transform="translate(486.706518 199.637699) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_49">
+    <!-- 960 ms -->
+    <g transform="translate(529.34392 199.871635) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_50">
+    <!-- 1.00 s -->
+    <g transform="translate(543.556388 192.183568) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_51">
+    <!-- 1.01 s -->
+    <g transform="translate(557.768856 190.767212) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_52">
-    <!-- 970 ms -->
-    <g transform="translate(571.981323 198.068846)rotate(-90)scale(0.1 -0.1)">
+    <!-- 958 ms -->
+    <g transform="translate(571.981323 200.129134) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1792,14 +1790,14 @@ z
    </g>
    <g id="text_53">
     <!--  4 -->
-    <g transform="translate(102.969894 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(102.969894 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_54">
     <!--  12 -->
-    <g transform="translate(117.182362 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(117.182362 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1807,7 +1805,7 @@ z
    </g>
    <g id="text_55">
     <!--  40 -->
-    <g transform="translate(131.39483 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(131.39483 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1815,7 +1813,7 @@ z
    </g>
    <g id="text_56">
     <!--  120 -->
-    <g transform="translate(145.607297 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(145.607297 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1824,14 +1822,14 @@ z
    </g>
    <g id="text_57">
     <!--  4 -->
-    <g transform="translate(188.2447 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(188.2447 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_58">
     <!--  12 -->
-    <g transform="translate(202.457167 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(202.457167 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1839,7 +1837,7 @@ z
    </g>
    <g id="text_59">
     <!--  40 -->
-    <g transform="translate(216.669635 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(216.669635 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1847,7 +1845,7 @@ z
    </g>
    <g id="text_60">
     <!--  120 -->
-    <g transform="translate(230.882102 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(230.882102 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1856,14 +1854,14 @@ z
    </g>
    <g id="text_61">
     <!--  4 -->
-    <g transform="translate(273.519505 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(273.519505 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_62">
     <!--  12 -->
-    <g transform="translate(287.731972 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(287.731972 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1871,7 +1869,7 @@ z
    </g>
    <g id="text_63">
     <!--  40 -->
-    <g transform="translate(301.94444 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(301.94444 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1879,7 +1877,7 @@ z
    </g>
    <g id="text_64">
     <!--  120 -->
-    <g transform="translate(316.156907 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(316.156907 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1888,14 +1886,14 @@ z
    </g>
    <g id="text_65">
     <!--  4 -->
-    <g transform="translate(358.79431 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(358.79431 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_66">
     <!--  12 -->
-    <g transform="translate(373.006778 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(373.006778 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1903,7 +1901,7 @@ z
    </g>
    <g id="text_67">
     <!--  40 -->
-    <g transform="translate(387.219245 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(387.219245 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1911,7 +1909,7 @@ z
    </g>
    <g id="text_68">
     <!--  120 -->
-    <g transform="translate(401.431713 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(401.431713 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1920,14 +1918,14 @@ z
    </g>
    <g id="text_69">
     <!--  4 -->
-    <g transform="translate(444.069115 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(444.069115 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_70">
     <!--  12 -->
-    <g transform="translate(458.281583 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(458.281583 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1935,7 +1933,7 @@ z
    </g>
    <g id="text_71">
     <!--  40 -->
-    <g transform="translate(472.49405 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(472.49405 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1943,7 +1941,7 @@ z
    </g>
    <g id="text_72">
     <!--  120 -->
-    <g transform="translate(486.706518 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(486.706518 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1952,14 +1950,14 @@ z
    </g>
    <g id="text_73">
     <!--  4 -->
-    <g transform="translate(529.34392 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(529.34392 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_74">
     <!--  12 -->
-    <g transform="translate(543.556388 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(543.556388 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1967,7 +1965,7 @@ z
    </g>
    <g id="text_75">
     <!--  40 -->
-    <g transform="translate(557.768856 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(557.768856 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1975,7 +1973,7 @@ z
    </g>
    <g id="text_76">
     <!--  120 -->
-    <g transform="translate(571.981323 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(571.981323 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1984,7 +1982,7 @@ z
    </g>
    <g id="text_77">
     <!-- filled random n=1000 -->
-    <g transform="translate(261.811563 20.88)scale(0.12 -0.12)">
+    <g transform="translate(261.811563 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -2086,7 +2084,7 @@ z
     </g>
     <g id="text_78">
      <!-- serial no mask -->
-     <g transform="translate(376.146875 43.478437)scale(0.1 -0.1)">
+     <g transform="translate(376.146875 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2103,7 +2101,7 @@ z
       <use xlink:href="#DejaVuSans-6b" x="670.507812"/>
      </g>
      <!-- (total chunk count shown at bottom of bar) -->
-     <g transform="translate(376.146875 54.67625)scale(0.1 -0.1)">
+     <g transform="translate(376.146875 54.67625) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-77" d="M 269 3500 
 L 844 3500 
@@ -2170,7 +2168,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p15afe2c15a">
+  <clipPath id="pdc15b98dc8">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>

--- a/docs/_static/chunk_filled_simple.svg
+++ b/docs/_static/chunk_filled_simple.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:33.980473</dc:date>
+    <dc:date>2022-10-23T17:46:36.388129</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="md6102ea0f0" d="M 0 0 
+       <path id="m8ad2a9e577" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md6102ea0f0" x="120.027532" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ad2a9e577" x="120.027532" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Outer -->
-      <g transform="translate(105.830657 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(105.830657 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -169,7 +169,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(107.22597 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(107.22597 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -250,12 +250,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#md6102ea0f0" x="204.320519" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ad2a9e577" x="204.320519" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Outer -->
-      <g transform="translate(190.123644 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(190.123644 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -263,7 +263,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(189.222863 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(189.222863 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -330,12 +330,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#md6102ea0f0" x="288.613506" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ad2a9e577" x="288.613506" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g transform="translate(272.720538 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(272.720538 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -397,7 +397,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(263.2096 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(263.2096 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -479,7 +479,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(275.811944 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(275.811944 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -490,12 +490,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md6102ea0f0" x="372.906494" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ad2a9e577" x="372.906494" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g transform="translate(357.013525 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(357.013525 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -503,7 +503,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(347.502587 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(347.502587 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -514,7 +514,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(357.808837 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(357.808837 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -527,12 +527,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#md6102ea0f0" x="457.199481" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ad2a9e577" x="457.199481" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Chunk -->
-      <g transform="translate(441.306512 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(441.306512 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -540,7 +540,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(431.795574 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(431.795574 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -551,14 +551,14 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(444.397918 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(444.397918 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
        <use xlink:href="#DejaVuSans-65" x="194.482422"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(442.101824 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(442.101824 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -571,12 +571,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#md6102ea0f0" x="541.492468" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ad2a9e577" x="541.492468" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Chunk -->
-      <g transform="translate(525.599499 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(525.599499 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -584,7 +584,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(516.088561 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(516.088561 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -595,7 +595,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(526.394811 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(526.394811 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -604,7 +604,7 @@ z
        <use xlink:href="#DejaVuSans-74" x="262.744141"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(526.394811 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(526.394811 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -620,21 +620,21 @@ z
      <g id="line2d_7">
       <path d="M 60.32 369.128 
 L 601.2 369.128 
-" clip-path="url(#p8e6de2825e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p388876e8c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="m6c7d6a44b6" d="M 0 0 
+       <path id="m49d85888e0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6c7d6a44b6" x="60.32" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49d85888e0" x="60.32" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.000 -->
-      <g transform="translate(24.691875 372.927219)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 372.927219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -675,18 +675,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 60.32 322.067053 
-L 601.2 322.067053 
-" clip-path="url(#p8e6de2825e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 326.333638 
+L 601.2 326.333638 
+" clip-path="url(#p388876e8c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m6c7d6a44b6" x="60.32" y="322.067053" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49d85888e0" x="60.32" y="326.333638" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.025 -->
-      <g transform="translate(24.691875 325.866272)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 330.132857) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -748,18 +748,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 60.32 275.006107 
-L 601.2 275.006107 
-" clip-path="url(#p8e6de2825e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 283.539276 
+L 601.2 283.539276 
+" clip-path="url(#p388876e8c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6c7d6a44b6" x="60.32" y="275.006107" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49d85888e0" x="60.32" y="283.539276" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.050 -->
-      <g transform="translate(24.691875 278.805326)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 287.338495) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -770,18 +770,18 @@ L 601.2 275.006107
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 60.32 227.94516 
-L 601.2 227.94516 
-" clip-path="url(#p8e6de2825e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 240.744915 
+L 601.2 240.744915 
+" clip-path="url(#p388876e8c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6c7d6a44b6" x="60.32" y="227.94516" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49d85888e0" x="60.32" y="240.744915" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.075 -->
-      <g transform="translate(24.691875 231.744379)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 244.544133) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -804,18 +804,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 60.32 180.884214 
-L 601.2 180.884214 
-" clip-path="url(#p8e6de2825e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 197.950553 
+L 601.2 197.950553 
+" clip-path="url(#p388876e8c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m6c7d6a44b6" x="60.32" y="180.884214" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49d85888e0" x="60.32" y="197.950553" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.100 -->
-      <g transform="translate(24.691875 184.683432)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 201.749771) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -842,18 +842,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 60.32 133.823267 
-L 601.2 133.823267 
-" clip-path="url(#p8e6de2825e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 155.156191 
+L 601.2 155.156191 
+" clip-path="url(#p388876e8c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m6c7d6a44b6" x="60.32" y="133.823267" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49d85888e0" x="60.32" y="155.156191" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.125 -->
-      <g transform="translate(24.691875 137.622486)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 158.95541) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -864,18 +864,18 @@ L 601.2 133.823267
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 60.32 86.762321 
-L 601.2 86.762321 
-" clip-path="url(#p8e6de2825e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 112.361829 
+L 601.2 112.361829 
+" clip-path="url(#p388876e8c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m6c7d6a44b6" x="60.32" y="86.762321" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49d85888e0" x="60.32" y="112.361829" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.150 -->
-      <g transform="translate(24.691875 90.561539)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 116.161048) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -886,18 +886,18 @@ L 601.2 86.762321
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 60.32 39.701374 
-L 601.2 39.701374 
-" clip-path="url(#p8e6de2825e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 69.567467 
+L 601.2 69.567467 
+" clip-path="url(#p388876e8c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m6c7d6a44b6" x="60.32" y="39.701374" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49d85888e0" x="60.32" y="69.567467" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.175 -->
-      <g transform="translate(24.691875 43.500593)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 73.366686) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -908,7 +908,7 @@ L 601.2 39.701374
     </g>
     <g id="text_15">
      <!-- Time (seconds) -->
-     <g transform="translate(18.612188 236.165719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.612188 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1010,85 +1010,372 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 84.905455 369.128 
 L 98.954286 369.128 
-L 98.954286 108.583649 
-L 84.905455 108.583649 
+L 98.954286 111.415682 
+L 84.905455 111.415682 
 z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 169.198442 369.128 
 L 183.247273 369.128 
-L 183.247273 108.430236 
-L 169.198442 108.430236 
+L 183.247273 112.138734 
+L 169.198442 112.138734 
 z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 253.491429 369.128 
 L 267.54026 369.128 
-L 267.54026 109.080512 
-L 253.491429 109.080512 
+L 267.54026 112.199508 
+L 253.491429 112.199508 
 z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 337.784416 369.128 
 L 351.833247 369.128 
-L 351.833247 109.341461 
-L 337.784416 109.341461 
+L 351.833247 111.927596 
+L 337.784416 111.927596 
 z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 422.077403 369.128 
 L 436.126234 369.128 
-L 436.126234 108.986629 
-L 422.077403 108.986629 
+L 436.126234 112.281917 
+L 422.077403 112.281917 
 z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 506.37039 369.128 
 L 520.419221 369.128 
-L 520.419221 109.18047 
-L 506.37039 109.18047 
+L 520.419221 112.197082 
+L 506.37039 112.197082 
 z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_16">
-    <!-- 138 ms -->
-    <g transform="translate(94.689245 103.583649)rotate(-90)scale(0.1 -0.1)">
+    <!-- 151 ms -->
+    <g transform="translate(94.689245 106.415682) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 150 ms -->
+    <g transform="translate(178.982232 107.138734) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 150 ms -->
+    <g transform="translate(263.275219 107.199508) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 150 ms -->
+    <g transform="translate(347.568206 106.927596) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 150 ms -->
+    <g transform="translate(431.861193 107.281917) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 150 ms -->
+    <g transform="translate(516.15418 107.197082) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!--  1 -->
+    <g transform="translate(94.689245 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!--  1 -->
+    <g transform="translate(178.982232 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!--  1 -->
+    <g transform="translate(263.275219 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!--  1 -->
+    <g transform="translate(347.568206 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!--  1 -->
+    <g transform="translate(431.861193 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!--  1 -->
+    <g transform="translate(516.15418 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="patch_13">
+    <path d="M 98.954286 369.128 
+L 113.003117 369.128 
+L 113.003117 115.323994 
+L 98.954286 115.323994 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 113.003117 369.128 
+L 127.051948 369.128 
+L 127.051948 116.745357 
+L 113.003117 116.745357 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 127.051948 369.128 
+L 141.100779 369.128 
+L 141.100779 112.65558 
+L 127.051948 112.65558 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 141.100779 369.128 
+L 155.14961 369.128 
+L 155.14961 109.134131 
+L 141.100779 109.134131 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 183.247273 369.128 
+L 197.296104 369.128 
+L 197.296104 114.913742 
+L 183.247273 114.913742 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 197.296104 369.128 
+L 211.344935 369.128 
+L 211.344935 115.727949 
+L 197.296104 115.727949 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 211.344935 369.128 
+L 225.393766 369.128 
+L 225.393766 112.569488 
+L 211.344935 112.569488 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 225.393766 369.128 
+L 239.442597 369.128 
+L 239.442597 109.157498 
+L 225.393766 109.157498 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 267.54026 369.128 
+L 281.589091 369.128 
+L 281.589091 115.89839 
+L 267.54026 115.89839 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 281.589091 369.128 
+L 295.637922 369.128 
+L 295.637922 116.936878 
+L 281.589091 116.936878 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 295.637922 369.128 
+L 309.686753 369.128 
+L 309.686753 114.541721 
+L 295.637922 114.541721 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 309.686753 369.128 
+L 323.735584 369.128 
+L 323.735584 108.405924 
+L 309.686753 108.405924 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 351.833247 369.128 
+L 365.882078 369.128 
+L 365.882078 115.832744 
+L 351.833247 115.832744 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 365.882078 369.128 
+L 379.930909 369.128 
+L 379.930909 115.328842 
+L 365.882078 115.328842 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 379.930909 369.128 
+L 393.97974 369.128 
+L 393.97974 112.711509 
+L 379.930909 112.711509 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 393.97974 369.128 
+L 408.028571 369.128 
+L 408.028571 109.515463 
+L 393.97974 109.515463 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 436.126234 369.128 
+L 450.175065 369.128 
+L 450.175065 115.469319 
+L 436.126234 115.469319 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 450.175065 369.128 
+L 464.223896 369.128 
+L 464.223896 116.652949 
+L 450.175065 116.652949 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 464.223896 369.128 
+L 478.272727 369.128 
+L 478.272727 114.169628 
+L 464.223896 114.169628 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 478.272727 369.128 
+L 492.321558 369.128 
+L 492.321558 108.367619 
+L 478.272727 108.367619 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 520.419221 369.128 
+L 534.468052 369.128 
+L 534.468052 115.833939 
+L 520.419221 115.833939 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 534.468052 369.128 
+L 548.516883 369.128 
+L 548.516883 115.669324 
+L 534.468052 115.669324 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 548.516883 369.128 
+L 562.565714 369.128 
+L 562.565714 113.439514 
+L 548.516883 113.439514 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 562.565714 369.128 
+L 576.614545 369.128 
+L 576.614545 109.295707 
+L 562.565714 109.295707 
+z
+" clip-path="url(#p388876e8c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_28">
+    <!-- 148 ms -->
+    <g transform="translate(108.738076 110.323994) rotate(-90) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1132,414 +1419,49 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_17">
-    <!-- 138 ms -->
-    <g transform="translate(178.982232 103.430236)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 138 ms -->
-    <g transform="translate(263.275219 104.080512)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 138 ms -->
-    <g transform="translate(347.568206 104.341461)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 138 ms -->
-    <g transform="translate(431.861193 103.986629)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 138 ms -->
-    <g transform="translate(516.15418 104.18047)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!--  1 -->
-    <g transform="translate(94.689245 369.128)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!--  1 -->
-    <g transform="translate(178.982232 369.128)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!--  1 -->
-    <g transform="translate(263.275219 369.128)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!--  1 -->
-    <g transform="translate(347.568206 369.128)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!--  1 -->
-    <g transform="translate(431.861193 369.128)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!--  1 -->
-    <g transform="translate(516.15418 369.128)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="patch_13">
-    <path d="M 98.954286 369.128 
-L 113.003117 369.128 
-L 113.003117 115.486736 
-L 98.954286 115.486736 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 113.003117 369.128 
-L 127.051948 369.128 
-L 127.051948 115.091535 
-L 113.003117 115.091535 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 127.051948 369.128 
-L 141.100779 369.128 
-L 141.100779 112.445241 
-L 127.051948 112.445241 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 141.100779 369.128 
-L 155.14961 369.128 
-L 155.14961 109.860419 
-L 141.100779 109.860419 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 183.247273 369.128 
-L 197.296104 369.128 
-L 197.296104 112.14302 
-L 183.247273 112.14302 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 197.296104 369.128 
-L 211.344935 369.128 
-L 211.344935 115.499309 
-L 197.296104 115.499309 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 211.344935 369.128 
-L 225.393766 369.128 
-L 225.393766 112.164363 
-L 211.344935 112.164363 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 225.393766 369.128 
-L 239.442597 369.128 
-L 239.442597 108.367619 
-L 225.393766 108.367619 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 267.54026 369.128 
-L 281.589091 369.128 
-L 281.589091 115.441041 
-L 267.54026 115.441041 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_22">
-    <path d="M 281.589091 369.128 
-L 295.637922 369.128 
-L 295.637922 115.413543 
-L 281.589091 115.413543 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_23">
-    <path d="M 295.637922 369.128 
-L 309.686753 369.128 
-L 309.686753 112.035835 
-L 295.637922 112.035835 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 309.686753 369.128 
-L 323.735584 369.128 
-L 323.735584 110.479617 
-L 309.686753 110.479617 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 351.833247 369.128 
-L 365.882078 369.128 
-L 365.882078 112.178494 
-L 351.833247 112.178494 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 365.882078 369.128 
-L 379.930909 369.128 
-L 379.930909 112.79268 
-L 365.882078 112.79268 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 379.930909 369.128 
-L 393.97974 369.128 
-L 393.97974 111.130843 
-L 379.930909 111.130843 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 393.97974 369.128 
-L 408.028571 369.128 
-L 408.028571 109.74558 
-L 393.97974 109.74558 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_29">
-    <path d="M 436.126234 369.128 
-L 450.175065 369.128 
-L 450.175065 114.086532 
-L 436.126234 114.086532 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_30">
-    <path d="M 450.175065 369.128 
-L 464.223896 369.128 
-L 464.223896 113.468193 
-L 450.175065 113.468193 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_31">
-    <path d="M 464.223896 369.128 
-L 478.272727 369.128 
-L 478.272727 110.29264 
-L 464.223896 110.29264 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_32">
-    <path d="M 478.272727 369.128 
-L 492.321558 369.128 
-L 492.321558 108.635007 
-L 478.272727 108.635007 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_33">
-    <path d="M 520.419221 369.128 
-L 534.468052 369.128 
-L 534.468052 112.727201 
-L 520.419221 112.727201 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_34">
-    <path d="M 534.468052 369.128 
-L 548.516883 369.128 
-L 548.516883 112.893647 
-L 534.468052 112.893647 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_35">
-    <path d="M 548.516883 369.128 
-L 562.565714 369.128 
-L 562.565714 110.550568 
-L 548.516883 110.550568 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_36">
-    <path d="M 562.565714 369.128 
-L 576.614545 369.128 
-L 576.614545 109.973813 
-L 562.565714 109.973813 
-z
-" clip-path="url(#p8e6de2825e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_28">
-    <!-- 135 ms -->
-    <g transform="translate(108.738076 110.486736)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 135 ms -->
-    <g transform="translate(122.786907 110.091535)rotate(-90)scale(0.1 -0.1)">
+    <!-- 147 ms -->
+    <g transform="translate(122.786907 111.745357) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 136 ms -->
-    <g transform="translate(136.835739 107.445241)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 150 ms -->
+    <g transform="translate(136.835739 107.65558) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 138 ms -->
-    <g transform="translate(150.88457 104.860419)rotate(-90)scale(0.1 -0.1)">
+    <!-- 152 ms -->
+    <g transform="translate(150.88457 104.134131) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 137 ms -->
-    <g transform="translate(193.031063 107.14302)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- 135 ms -->
-    <g transform="translate(207.079894 110.499309)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- 137 ms -->
-    <g transform="translate(221.128726 107.164363)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 139 ms -->
-    <g transform="translate(235.177557 103.367619)rotate(-90)scale(0.1 -0.1)">
+    <!-- 149 ms -->
+    <g transform="translate(193.031063 109.913742) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1573,184 +1495,217 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_36">
-    <!-- 135 ms -->
-    <g transform="translate(277.32405 110.441041)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_33">
+    <!-- 148 ms -->
+    <g transform="translate(207.079894 110.727949) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 150 ms -->
+    <g transform="translate(221.128726 107.569488) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 152 ms -->
+    <g transform="translate(235.177557 104.157498) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 148 ms -->
+    <g transform="translate(277.32405 110.89839) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 135 ms -->
-    <g transform="translate(291.372881 110.413543)rotate(-90)scale(0.1 -0.1)">
+    <!-- 147 ms -->
+    <g transform="translate(291.372881 111.936878) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 137 ms -->
-    <g transform="translate(305.421713 107.035835)rotate(-90)scale(0.1 -0.1)">
+    <!-- 149 ms -->
+    <g transform="translate(305.421713 109.541721) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 137 ms -->
-    <g transform="translate(319.470544 105.479617)rotate(-90)scale(0.1 -0.1)">
+    <!-- 152 ms -->
+    <g transform="translate(319.470544 103.405924) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_40">
-    <!-- 136 ms -->
-    <g transform="translate(361.617037 107.178494)rotate(-90)scale(0.1 -0.1)">
+    <!-- 148 ms -->
+    <g transform="translate(361.617037 110.832744) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- 136 ms -->
-    <g transform="translate(375.665869 107.79268)rotate(-90)scale(0.1 -0.1)">
+    <!-- 148 ms -->
+    <g transform="translate(375.665869 110.328842) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_42">
-    <!-- 137 ms -->
-    <g transform="translate(389.7147 106.130843)rotate(-90)scale(0.1 -0.1)">
+    <!-- 150 ms -->
+    <g transform="translate(389.7147 107.711509) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_43">
-    <!-- 138 ms -->
-    <g transform="translate(403.763531 104.74558)rotate(-90)scale(0.1 -0.1)">
+    <!-- 152 ms -->
+    <g transform="translate(403.763531 104.515463) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- 135 ms -->
-    <g transform="translate(445.910024 109.086532)rotate(-90)scale(0.1 -0.1)">
+    <!-- 148 ms -->
+    <g transform="translate(445.910024 110.469319) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- 136 ms -->
-    <g transform="translate(459.958856 108.468193)rotate(-90)scale(0.1 -0.1)">
+    <!-- 147 ms -->
+    <g transform="translate(459.958856 111.652949) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_46">
-    <!-- 138 ms -->
-    <g transform="translate(474.007687 105.29264)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_47">
-    <!-- 138 ms -->
-    <g transform="translate(488.056518 103.635007)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_48">
-    <!-- 136 ms -->
-    <g transform="translate(530.203011 107.727201)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_49">
-    <!-- 136 ms -->
-    <g transform="translate(544.251843 107.893647)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_50">
-    <!-- 137 ms -->
-    <g transform="translate(558.300674 105.550568)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_51">
-    <!-- 138 ms -->
-    <g transform="translate(572.349505 104.973813)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_46">
+    <!-- 149 ms -->
+    <g transform="translate(474.007687 109.169628) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_47">
+    <!-- 152 ms -->
+    <g transform="translate(488.056518 103.367619) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_48">
+    <!-- 148 ms -->
+    <g transform="translate(530.203011 110.833939) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_49">
+    <!-- 148 ms -->
+    <g transform="translate(544.251843 110.669324) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_50">
+    <!-- 149 ms -->
+    <g transform="translate(558.300674 108.439514) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_51">
+    <!-- 152 ms -->
+    <g transform="translate(572.349505 104.295707) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1758,35 +1713,14 @@ z
    </g>
    <g id="text_52">
     <!--  4 -->
-    <g transform="translate(108.738076 369.128)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(108.738076 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_53">
     <!--  12 -->
-    <g transform="translate(122.786907 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(122.786907 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1794,7 +1728,7 @@ z
    </g>
    <g id="text_54">
     <!--  40 -->
-    <g transform="translate(136.835739 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(136.835739 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1802,7 +1736,7 @@ z
    </g>
    <g id="text_55">
     <!--  120 -->
-    <g transform="translate(150.88457 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(150.88457 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1811,14 +1745,14 @@ z
    </g>
    <g id="text_56">
     <!--  4 -->
-    <g transform="translate(193.031063 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(193.031063 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_57">
     <!--  12 -->
-    <g transform="translate(207.079894 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(207.079894 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1826,7 +1760,7 @@ z
    </g>
    <g id="text_58">
     <!--  40 -->
-    <g transform="translate(221.128726 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(221.128726 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1834,7 +1768,7 @@ z
    </g>
    <g id="text_59">
     <!--  120 -->
-    <g transform="translate(235.177557 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(235.177557 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1843,14 +1777,14 @@ z
    </g>
    <g id="text_60">
     <!--  4 -->
-    <g transform="translate(277.32405 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(277.32405 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_61">
     <!--  12 -->
-    <g transform="translate(291.372881 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(291.372881 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1858,7 +1792,7 @@ z
    </g>
    <g id="text_62">
     <!--  40 -->
-    <g transform="translate(305.421713 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(305.421713 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1866,7 +1800,7 @@ z
    </g>
    <g id="text_63">
     <!--  120 -->
-    <g transform="translate(319.470544 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(319.470544 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1875,14 +1809,14 @@ z
    </g>
    <g id="text_64">
     <!--  4 -->
-    <g transform="translate(361.617037 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(361.617037 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_65">
     <!--  12 -->
-    <g transform="translate(375.665869 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(375.665869 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1890,7 +1824,7 @@ z
    </g>
    <g id="text_66">
     <!--  40 -->
-    <g transform="translate(389.7147 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(389.7147 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1898,7 +1832,7 @@ z
    </g>
    <g id="text_67">
     <!--  120 -->
-    <g transform="translate(403.763531 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(403.763531 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1907,14 +1841,14 @@ z
    </g>
    <g id="text_68">
     <!--  4 -->
-    <g transform="translate(445.910024 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(445.910024 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_69">
     <!--  12 -->
-    <g transform="translate(459.958856 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(459.958856 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1922,7 +1856,7 @@ z
    </g>
    <g id="text_70">
     <!--  40 -->
-    <g transform="translate(474.007687 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(474.007687 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1930,7 +1864,7 @@ z
    </g>
    <g id="text_71">
     <!--  120 -->
-    <g transform="translate(488.056518 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(488.056518 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1939,14 +1873,14 @@ z
    </g>
    <g id="text_72">
     <!--  4 -->
-    <g transform="translate(530.203011 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(530.203011 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_73">
     <!--  12 -->
-    <g transform="translate(544.251843 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(544.251843 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1954,7 +1888,7 @@ z
    </g>
    <g id="text_74">
     <!--  40 -->
-    <g transform="translate(558.300674 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(558.300674 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1962,7 +1896,7 @@ z
    </g>
    <g id="text_75">
     <!--  120 -->
-    <g transform="translate(572.349505 369.128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(572.349505 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1971,7 +1905,7 @@ z
    </g>
    <g id="text_76">
     <!-- filled simple n=1000 -->
-    <g transform="translate(268.4275 20.88)scale(0.12 -0.12)">
+    <g transform="translate(268.4275 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -2066,7 +2000,7 @@ z
     </g>
     <g id="text_77">
      <!-- serial no mask -->
-     <g transform="translate(376.146875 43.478437)scale(0.1 -0.1)">
+     <g transform="translate(376.146875 43.478437) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-61" d="M 2194 1759 
 Q 1497 1759 1228 1600 
@@ -2118,7 +2052,7 @@ z
       <use xlink:href="#DejaVuSans-6b" x="670.507812"/>
      </g>
      <!-- (total chunk count shown at bottom of bar) -->
-     <g transform="translate(376.146875 54.67625)scale(0.1 -0.1)">
+     <g transform="translate(376.146875 54.67625) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-77" d="M 269 3500 
 L 844 3500 
@@ -2185,7 +2119,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p8e6de2825e">
+  <clipPath id="p388876e8c4">
    <rect x="60.32" y="26.88" width="540.88" height="342.248"/>
   </clipPath>
  </defs>

--- a/docs/_static/chunk_lines_random.svg
+++ b/docs/_static/chunk_lines_random.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:33.479147</dc:date>
+    <dc:date>2022-10-23T17:46:35.932894</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me1fc5be152" d="M 0 0 
+       <path id="m747f723218" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me1fc5be152" x="127.569881" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m747f723218" x="127.569881" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Separate -->
-      <g transform="translate(104.924569 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(104.924569 395.390437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
@@ -223,12 +223,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me1fc5be152" x="258.82996" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m747f723218" x="258.82996" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Separate -->
-      <g transform="translate(236.184648 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(236.184648 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -239,7 +239,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(246.028398 406.58825)scale(0.1 -0.1)">
+      <g transform="translate(246.028398 406.58825) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -320,12 +320,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me1fc5be152" x="390.09004" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m747f723218" x="390.09004" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g transform="translate(374.197071 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(374.197071 395.390437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -409,7 +409,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(364.686133 406.58825)scale(0.1 -0.1)">
+      <g transform="translate(364.686133 406.58825) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -491,7 +491,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(377.288477 417.786062)scale(0.1 -0.1)">
+      <g transform="translate(377.288477 417.786062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -502,12 +502,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me1fc5be152" x="521.350119" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m747f723218" x="521.350119" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g transform="translate(505.45715 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(505.45715 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -515,7 +515,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(495.946212 406.58825)scale(0.1 -0.1)">
+      <g transform="translate(495.946212 406.58825) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -526,7 +526,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(506.252462 417.786062)scale(0.1 -0.1)">
+      <g transform="translate(506.252462 417.786062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -617,21 +617,21 @@ z
      <g id="line2d_5">
       <path d="M 47.72 380.792 
 L 601.2 380.792 
-" clip-path="url(#pe43be4e9c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pecec62c202)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="ma3c9dbb528" d="M 0 0 
+       <path id="m475616cbd6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma3c9dbb528" x="47.72" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m475616cbd6" x="47.72" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 0.0 -->
-      <g transform="translate(24.816875 384.591219)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 384.591219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -672,16 +672,16 @@ z
      <g id="line2d_7">
       <path d="M 47.72 330.233143 
 L 601.2 330.233143 
-" clip-path="url(#pe43be4e9c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pecec62c202)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma3c9dbb528" x="47.72" y="330.233143" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m475616cbd6" x="47.72" y="330.233143" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 0.2 -->
-      <g transform="translate(24.816875 334.032362)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 334.032362) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -718,16 +718,16 @@ z
      <g id="line2d_9">
       <path d="M 47.72 279.674286 
 L 601.2 279.674286 
-" clip-path="url(#pe43be4e9c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pecec62c202)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma3c9dbb528" x="47.72" y="279.674286" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m475616cbd6" x="47.72" y="279.674286" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.4 -->
-      <g transform="translate(24.816875 283.473504)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 283.473504) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -759,16 +759,16 @@ z
      <g id="line2d_11">
       <path d="M 47.72 229.115429 
 L 601.2 229.115429 
-" clip-path="url(#pe43be4e9c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pecec62c202)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma3c9dbb528" x="47.72" y="229.115429" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m475616cbd6" x="47.72" y="229.115429" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.6 -->
-      <g transform="translate(24.816875 232.914647)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 232.914647) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -811,16 +811,16 @@ z
      <g id="line2d_13">
       <path d="M 47.72 178.556571 
 L 601.2 178.556571 
-" clip-path="url(#pe43be4e9c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pecec62c202)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma3c9dbb528" x="47.72" y="178.556571" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m475616cbd6" x="47.72" y="178.556571" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.8 -->
-      <g transform="translate(24.816875 182.35579)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 182.35579) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -872,16 +872,16 @@ z
      <g id="line2d_15">
       <path d="M 47.72 127.997714 
 L 601.2 127.997714 
-" clip-path="url(#pe43be4e9c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pecec62c202)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#ma3c9dbb528" x="47.72" y="127.997714" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m475616cbd6" x="47.72" y="127.997714" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 1.0 -->
-      <g transform="translate(24.816875 131.796933)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 131.796933) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -908,16 +908,16 @@ z
      <g id="line2d_17">
       <path d="M 47.72 77.438857 
 L 601.2 77.438857 
-" clip-path="url(#pe43be4e9c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pecec62c202)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma3c9dbb528" x="47.72" y="77.438857" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m475616cbd6" x="47.72" y="77.438857" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.2 -->
-      <g transform="translate(24.816875 81.238076)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 81.238076) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -928,16 +928,16 @@ L 601.2 77.438857
      <g id="line2d_19">
       <path d="M 47.72 26.88 
 L 601.2 26.88 
-" clip-path="url(#pe43be4e9c4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pecec62c202)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma3c9dbb528" x="47.72" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m475616cbd6" x="47.72" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.4 -->
-      <g transform="translate(24.816875 30.679219)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 30.679219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -946,7 +946,7 @@ L 601.2 26.88
     </g>
     <g id="text_13">
      <!-- Time (seconds) -->
-     <g transform="translate(18.737188 241.997719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.737188 241.997719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1048,53 +1048,68 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 72.878182 380.792 
 L 94.754862 380.792 
-L 94.754862 166.598009 
-L 72.878182 166.598009 
+L 94.754862 167.238163 
+L 72.878182 167.238163 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 204.138261 380.792 
 L 226.014941 380.792 
-L 226.014941 79.859613 
-L 204.138261 79.859613 
+L 226.014941 79.910761 
+L 204.138261 79.910761 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 335.39834 380.792 
 L 357.27502 380.792 
-L 357.27502 251.562819 
-L 335.39834 251.562819 
+L 357.27502 253.388642 
+L 335.39834 253.388642 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 466.658419 380.792 
 L 488.535099 380.792 
-L 488.535099 254.573438 
-L 466.658419 254.573438 
+L 488.535099 255.461158 
+L 466.658419 255.461158 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_14">
-    <!-- 847 ms -->
-    <g transform="translate(86.575897 161.598009)rotate(-90)scale(0.1 -0.1)">
+    <!-- 845 ms -->
+    <g transform="translate(86.575897 162.238163) rotate(-90) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1102,7 +1117,7 @@ z
    </g>
    <g id="text_15">
     <!-- 1.19 s -->
-    <g transform="translate(217.835976 74.859613)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(217.835976 74.910761) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1144,49 +1159,22 @@ z
     </g>
    </g>
    <g id="text_16">
-    <!-- 511 ms -->
-    <g transform="translate(349.096055 246.562819)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 504 ms -->
+    <g transform="translate(349.096055 248.388642) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_17">
-    <!-- 499 ms -->
-    <g transform="translate(480.356134 249.573438)rotate(-90)scale(0.1 -0.1)">
+    <!-- 496 ms -->
+    <g transform="translate(480.356134 250.461158) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1194,28 +1182,28 @@ z
    </g>
    <g id="text_18">
     <!--  1 -->
-    <g transform="translate(86.575897 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(86.575897 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_19">
     <!--  1 -->
-    <g transform="translate(217.835976 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(217.835976 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_20">
     <!--  1 -->
-    <g transform="translate(349.096055 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(349.096055 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_21">
     <!--  1 -->
-    <g transform="translate(480.356134 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(480.356134 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
@@ -1223,178 +1211,201 @@ z
    <g id="patch_11">
     <path d="M 94.754862 380.792 
 L 116.631542 380.792 
-L 116.631542 164.919388 
-L 94.754862 164.919388 
+L 116.631542 167.014543 
+L 94.754862 167.014543 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 116.631542 380.792 
 L 138.508221 380.792 
-L 138.508221 164.535502 
-L 116.631542 164.535502 
+L 138.508221 166.740633 
+L 116.631542 166.740633 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 138.508221 380.792 
 L 160.384901 380.792 
-L 160.384901 162.952498 
-L 138.508221 162.952498 
+L 160.384901 164.322635 
+L 138.508221 164.322635 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 160.384901 380.792 
 L 182.261581 380.792 
-L 182.261581 159.409925 
-L 160.384901 159.409925 
+L 182.261581 160.727704 
+L 160.384901 160.727704 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 226.014941 380.792 
 L 247.891621 380.792 
-L 247.891621 76.770499 
-L 226.014941 76.770499 
+L 247.891621 79.206964 
+L 226.014941 79.206964 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 247.891621 380.792 
 L 269.7683 380.792 
-L 269.7683 75.432114 
-L 247.891621 75.432114 
+L 269.7683 77.816806 
+L 247.891621 77.816806 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 269.7683 380.792 
 L 291.64498 380.792 
-L 291.64498 72.233121 
-L 269.7683 72.233121 
+L 291.64498 74.299056 
+L 269.7683 74.299056 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 291.64498 380.792 
 L 313.52166 380.792 
-L 313.52166 66.497704 
-L 291.64498 66.497704 
+L 313.52166 67.956269 
+L 291.64498 67.956269 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 357.27502 380.792 
 L 379.1517 380.792 
-L 379.1517 241.113424 
-L 357.27502 241.113424 
+L 379.1517 243.928213 
+L 357.27502 243.928213 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 379.1517 380.792 
 L 401.028379 380.792 
-L 401.028379 240.70133 
-L 379.1517 240.70133 
+L 401.028379 243.483881 
+L 379.1517 243.483881 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 401.028379 380.792 
 L 422.905059 380.792 
-L 422.905059 240.718717 
-L 401.028379 240.718717 
+L 422.905059 242.94633 
+L 401.028379 242.94633 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 422.905059 380.792 
 L 444.781739 380.792 
-L 444.781739 239.068309 
-L 422.905059 239.068309 
+L 444.781739 241.349908 
+L 422.905059 241.349908 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 488.535099 380.792 
 L 510.411779 380.792 
-L 510.411779 247.134895 
-L 488.535099 247.134895 
+L 510.411779 248.812779 
+L 488.535099 248.812779 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 510.411779 380.792 
 L 532.288458 380.792 
-L 532.288458 245.587227 
-L 510.411779 245.587227 
+L 532.288458 247.440961 
+L 510.411779 247.440961 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 532.288458 380.792 
 L 554.165138 380.792 
-L 554.165138 245.501482 
-L 532.288458 245.501482 
+L 554.165138 247.026871 
+L 532.288458 247.026871 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 554.165138 380.792 
 L 576.041818 380.792 
-L 576.041818 243.815084 
-L 554.165138 243.815084 
+L 576.041818 244.979632 
+L 554.165138 244.979632 
 z
-" clip-path="url(#pe43be4e9c4)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pecec62c202)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_22">
-    <!-- 854 ms -->
-    <g transform="translate(108.452577 159.919388)rotate(-90)scale(0.1 -0.1)">
+    <!-- 846 ms -->
+    <g transform="translate(108.452577 162.014543) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 855 ms -->
-    <g transform="translate(130.329256 159.535502)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 862 ms -->
-    <g transform="translate(152.205936 157.952498)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 876 ms -->
-    <g transform="translate(174.082616 154.409925)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
+   <g id="text_23">
+    <!-- 847 ms -->
+    <g transform="translate(130.329256 161.740633) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 856 ms -->
+    <g transform="translate(152.205936 159.322635) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 871 ms -->
+    <g transform="translate(174.082616 155.727704) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
    <g id="text_26">
+    <!-- 1.19 s -->
+    <g transform="translate(239.712656 74.206964) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_27">
     <!-- 1.20 s -->
-    <g transform="translate(239.712656 71.770499)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(261.589335 72.816806) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1403,9 +1414,9 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_27">
+   <g id="text_28">
     <!-- 1.21 s -->
-    <g transform="translate(261.589335 70.432114)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(283.466015 69.299056) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1414,20 +1425,9 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- 1.22 s -->
-    <g transform="translate(283.466015 67.233121)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
    <g id="text_29">
     <!-- 1.24 s -->
-    <g transform="translate(305.342695 61.497704)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(305.342695 62.956269) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1437,8 +1437,19 @@ z
     </g>
    </g>
    <g id="text_30">
-    <!-- 553 ms -->
-    <g transform="translate(370.972735 236.113424)rotate(-90)scale(0.1 -0.1)">
+    <!-- 541 ms -->
+    <g transform="translate(370.972735 238.928213) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 543 ms -->
+    <g transform="translate(392.849415 238.483881) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1474,49 +1485,60 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- 554 ms -->
-    <g transform="translate(392.849415 235.70133)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
    <g id="text_32">
-    <!-- 554 ms -->
-    <g transform="translate(414.726094 235.718717)rotate(-90)scale(0.1 -0.1)">
+    <!-- 545 ms -->
+    <g transform="translate(414.726094 237.94633) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 561 ms -->
-    <g transform="translate(436.602774 234.068309)rotate(-90)scale(0.1 -0.1)">
+    <!-- 552 ms -->
+    <g transform="translate(436.602774 236.349908) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_34">
+    <!-- 522 ms -->
+    <g transform="translate(502.232814 243.812779) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 528 ms -->
+    <g transform="translate(524.109494 242.440961) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_36">
     <!-- 529 ms -->
-    <g transform="translate(502.232814 242.134895)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(545.986173 242.026871) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
@@ -1525,34 +1547,12 @@ z
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_35">
-    <!-- 535 ms -->
-    <g transform="translate(524.109494 240.587227)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 535 ms -->
-    <g transform="translate(545.986173 240.501482)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
    <g id="text_37">
-    <!-- 542 ms -->
-    <g transform="translate(567.862853 238.815084)rotate(-90)scale(0.1 -0.1)">
+    <!-- 537 ms -->
+    <g transform="translate(567.862853 239.979632) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1560,14 +1560,14 @@ z
    </g>
    <g id="text_38">
     <!--  4 -->
-    <g transform="translate(108.452577 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(108.452577 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_39">
     <!--  12 -->
-    <g transform="translate(130.329256 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(130.329256 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1575,7 +1575,7 @@ z
    </g>
    <g id="text_40">
     <!--  40 -->
-    <g transform="translate(152.205936 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(152.205936 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1583,7 +1583,7 @@ z
    </g>
    <g id="text_41">
     <!--  120 -->
-    <g transform="translate(174.082616 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(174.082616 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1592,14 +1592,14 @@ z
    </g>
    <g id="text_42">
     <!--  4 -->
-    <g transform="translate(239.712656 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(239.712656 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_43">
     <!--  12 -->
-    <g transform="translate(261.589335 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(261.589335 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1607,7 +1607,7 @@ z
    </g>
    <g id="text_44">
     <!--  40 -->
-    <g transform="translate(283.466015 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(283.466015 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1615,7 +1615,7 @@ z
    </g>
    <g id="text_45">
     <!--  120 -->
-    <g transform="translate(305.342695 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(305.342695 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1624,14 +1624,14 @@ z
    </g>
    <g id="text_46">
     <!--  4 -->
-    <g transform="translate(370.972735 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(370.972735 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_47">
     <!--  12 -->
-    <g transform="translate(392.849415 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(392.849415 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1639,7 +1639,7 @@ z
    </g>
    <g id="text_48">
     <!--  40 -->
-    <g transform="translate(414.726094 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(414.726094 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1647,7 +1647,7 @@ z
    </g>
    <g id="text_49">
     <!--  120 -->
-    <g transform="translate(436.602774 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(436.602774 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1656,14 +1656,14 @@ z
    </g>
    <g id="text_50">
     <!--  4 -->
-    <g transform="translate(502.232814 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(502.232814 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_51">
     <!--  12 -->
-    <g transform="translate(524.109494 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(524.109494 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1671,7 +1671,7 @@ z
    </g>
    <g id="text_52">
     <!--  40 -->
-    <g transform="translate(545.986173 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(545.986173 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1679,7 +1679,7 @@ z
    </g>
    <g id="text_53">
     <!--  120 -->
-    <g transform="translate(567.862853 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(567.862853 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1688,7 +1688,7 @@ z
    </g>
    <g id="text_54">
     <!-- lines random n=1000 -->
-    <g transform="translate(259.321562 20.88)scale(0.12 -0.12)">
+    <g transform="translate(259.321562 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -1756,7 +1756,7 @@ z
     </g>
     <g id="text_55">
      <!-- serial no mask -->
-     <g transform="translate(376.146875 43.478437)scale(0.1 -0.1)">
+     <g transform="translate(376.146875 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1773,7 +1773,7 @@ z
       <use xlink:href="#DejaVuSans-6b" x="670.507812"/>
      </g>
      <!-- (total chunk count shown at bottom of bar) -->
-     <g transform="translate(376.146875 54.67625)scale(0.1 -0.1)">
+     <g transform="translate(376.146875 54.67625) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-77" d="M 269 3500 
 L 844 3500 
@@ -1840,7 +1840,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pe43be4e9c4">
+  <clipPath id="pecec62c202">
    <rect x="47.72" y="26.88" width="553.48" height="353.912"/>
   </clipPath>
  </defs>

--- a/docs/_static/chunk_lines_simple.svg
+++ b/docs/_static/chunk_lines_simple.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:33.623917</dc:date>
+    <dc:date>2022-10-23T17:46:36.068851</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -31,11 +31,11 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 54.11 380.792 
+    <path d="M 60.32 380.792 
 L 601.2 380.792 
 L 601.2 26.88 
-L 54.11 26.88 
-L 54.11 380.792 
+L 60.32 26.88 
+L 60.32 380.792 
 z
 " style="fill: none"/>
    </g>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m43f37847a7" d="M 0 0 
+       <path id="mf1ce163f9b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m43f37847a7" x="133.038004" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1ce163f9b" x="138.352095" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Separate -->
-      <g transform="translate(110.392691 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(115.706782 395.390437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
@@ -223,12 +223,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m43f37847a7" x="262.782668" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1ce163f9b" x="266.624032" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Separate -->
-      <g transform="translate(240.137355 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(243.978719 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -239,7 +239,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(249.981105 406.58825)scale(0.1 -0.1)">
+      <g transform="translate(253.822469 406.58825) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -320,12 +320,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m43f37847a7" x="392.527332" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1ce163f9b" x="394.895968" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g transform="translate(376.634363 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(379.003 395.390437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -409,7 +409,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(367.123426 406.58825)scale(0.1 -0.1)">
+      <g transform="translate(369.492062 406.58825) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -491,7 +491,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(379.72577 417.786062)scale(0.1 -0.1)">
+      <g transform="translate(382.094406 417.786062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -502,12 +502,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m43f37847a7" x="522.271996" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1ce163f9b" x="523.167905" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g transform="translate(506.379027 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(507.274936 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -515,7 +515,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(496.86809 406.58825)scale(0.1 -0.1)">
+      <g transform="translate(497.763999 406.58825) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -526,7 +526,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(507.17434 417.786062)scale(0.1 -0.1)">
+      <g transform="translate(508.070249 417.786062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -615,23 +615,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_5">
-      <path d="M 54.11 380.792 
+      <path d="M 60.32 380.792 
 L 601.2 380.792 
-" clip-path="url(#p77b00db637)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p520f8ba062)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m77369b3511" d="M 0 0 
+       <path id="m73e6b3fad2" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m77369b3511" x="54.11" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73e6b3fad2" x="60.32" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
-      <!-- 0.00 -->
-      <g transform="translate(24.844375 384.591219)scale(0.1 -0.1)">
+      <!-- 0.000 -->
+      <g transform="translate(24.691875 384.591219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -666,23 +666,24 @@ z
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
        <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_7">
-      <path d="M 54.11 338.510941 
-L 601.2 338.510941 
-" clip-path="url(#p77b00db637)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 331.641369 
+L 601.2 331.641369 
+" clip-path="url(#p520f8ba062)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m77369b3511" x="54.11" y="338.510941" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73e6b3fad2" x="60.32" y="331.641369" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
-      <!-- 0.02 -->
-      <g transform="translate(24.844375 342.31016)scale(0.1 -0.1)">
+      <!-- 0.025 -->
+      <g transform="translate(24.691875 335.440588) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -708,185 +709,110 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
        <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_9">
-      <path d="M 54.11 296.229882 
-L 601.2 296.229882 
-" clip-path="url(#p77b00db637)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 282.490738 
+L 601.2 282.490738 
+" clip-path="url(#p520f8ba062)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m77369b3511" x="54.11" y="296.229882" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73e6b3fad2" x="60.32" y="282.490738" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
-      <!-- 0.04 -->
-      <g transform="translate(24.844375 300.029101)scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
+      <!-- 0.050 -->
+      <g transform="translate(24.691875 286.289957) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_11">
-      <path d="M 54.11 253.948824 
-L 601.2 253.948824 
-" clip-path="url(#p77b00db637)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 233.340107 
+L 601.2 233.340107 
+" clip-path="url(#p520f8ba062)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m77369b3511" x="54.11" y="253.948824" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73e6b3fad2" x="60.32" y="233.340107" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
-      <!-- 0.06 -->
-      <g transform="translate(24.844375 257.748042)scale(0.1 -0.1)">
+      <!-- 0.075 -->
+      <g transform="translate(24.691875 237.139326) scale(0.1 -0.1)">
        <defs>
-        <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_13">
-      <path d="M 54.11 211.667765 
-L 601.2 211.667765 
-" clip-path="url(#p77b00db637)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 184.189477 
+L 601.2 184.189477 
+" clip-path="url(#p520f8ba062)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m77369b3511" x="54.11" y="211.667765" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73e6b3fad2" x="60.32" y="184.189477" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
-      <!-- 0.08 -->
-      <g transform="translate(24.844375 215.466983)scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_15">
-      <path d="M 54.11 169.386706 
-L 601.2 169.386706 
-" clip-path="url(#p77b00db637)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_16">
-      <g>
-       <use xlink:href="#m77369b3511" x="54.11" y="169.386706" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_10">
-      <!-- 0.10 -->
-      <g transform="translate(24.844375 173.185925)scale(0.1 -0.1)">
+      <!-- 0.100 -->
+      <g transform="translate(24.691875 187.988695) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -907,75 +833,79 @@ z
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
        <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <path d="M 60.32 135.038846 
+L 601.2 135.038846 
+" clip-path="url(#p520f8ba062)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m73e6b3fad2" x="60.32" y="135.038846" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.125 -->
+      <g transform="translate(24.691875 138.838064) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_17">
-      <path d="M 54.11 127.105647 
-L 601.2 127.105647 
-" clip-path="url(#p77b00db637)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 85.888215 
+L 601.2 85.888215 
+" clip-path="url(#p520f8ba062)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m77369b3511" x="54.11" y="127.105647" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73e6b3fad2" x="60.32" y="85.888215" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
-      <!-- 0.12 -->
-      <g transform="translate(24.844375 130.904866)scale(0.1 -0.1)">
+      <!-- 0.150 -->
+      <g transform="translate(24.691875 89.687434) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_19">
-      <path d="M 54.11 84.824588 
-L 601.2 84.824588 
-" clip-path="url(#p77b00db637)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 36.737584 
+L 601.2 36.737584 
+" clip-path="url(#p520f8ba062)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m77369b3511" x="54.11" y="84.824588" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73e6b3fad2" x="60.32" y="36.737584" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
-      <!-- 0.14 -->
-      <g transform="translate(24.844375 88.623807)scale(0.1 -0.1)">
+      <!-- 0.175 -->
+      <g transform="translate(24.691875 40.536803) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_21">
-      <path d="M 54.11 42.543529 
-L 601.2 42.543529 
-" clip-path="url(#p77b00db637)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_22">
-      <g>
-       <use xlink:href="#m77369b3511" x="54.11" y="42.543529" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_13">
-      <!-- 0.16 -->
-      <g transform="translate(24.844375 46.342748)scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_14">
+    <g id="text_13">
      <!-- Time (seconds) -->
-     <g transform="translate(18.764688 241.997719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.612188 241.997719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1055,8 +985,8 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 54.11 380.792 
-L 54.11 26.88 
+    <path d="M 60.32 380.792 
+L 60.32 26.88 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
@@ -1065,291 +995,318 @@ L 601.2 26.88
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 54.11 380.792 
+    <path d="M 60.32 380.792 
 L 601.2 380.792 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 54.11 26.88 
+    <path d="M 60.32 26.88 
 L 601.2 26.88 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 78.977727 380.792 
-L 100.601838 380.792 
-L 100.601838 113.01906 
-L 78.977727 113.01906 
+    <path d="M 84.905455 380.792 
+L 106.284111 380.792 
+L 106.284111 115.533548 
+L 84.905455 115.533548 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 208.722391 380.792 
-L 230.346502 380.792 
-L 230.346502 112.658377 
-L 208.722391 112.658377 
+    <path d="M 213.177391 380.792 
+L 234.556047 380.792 
+L 234.556047 116.107848 
+L 213.177391 116.107848 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 338.467055 380.792 
-L 360.091166 380.792 
-L 360.091166 113.221636 
-L 338.467055 113.221636 
+    <path d="M 341.449328 380.792 
+L 362.827984 380.792 
+L 362.827984 116.201606 
+L 341.449328 116.201606 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 468.211719 380.792 
-L 489.83583 380.792 
-L 489.83583 113.157329 
-L 468.211719 113.157329 
+    <path d="M 469.721265 380.792 
+L 491.099921 380.792 
+L 491.099921 115.15012 
+L 469.721265 115.15012 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_15">
-    <!-- 127 ms -->
-    <g transform="translate(92.549158 108.01906)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_14">
+    <!-- 135 ms -->
+    <g transform="translate(98.354158 110.533548) rotate(-90) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- 135 ms -->
+    <g transform="translate(226.626094 111.107848) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 127 ms -->
-    <g transform="translate(222.293822 107.658377)rotate(-90)scale(0.1 -0.1)">
+    <!-- 135 ms -->
+    <g transform="translate(354.898031 111.201606) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_17">
-    <!-- 127 ms -->
-    <g transform="translate(352.038486 108.221636)rotate(-90)scale(0.1 -0.1)">
+    <!-- 135 ms -->
+    <g transform="translate(483.169968 110.15012) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_18">
-    <!-- 127 ms -->
-    <g transform="translate(481.78315 108.157329)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    <!--  1 -->
+    <g transform="translate(98.354158 380.792) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_19">
     <!--  1 -->
-    <g transform="translate(92.549158 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(226.626094 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_20">
     <!--  1 -->
-    <g transform="translate(222.293822 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(354.898031 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_21">
     <!--  1 -->
-    <g transform="translate(352.038486 380.792)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!--  1 -->
-    <g transform="translate(481.78315 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(483.169968 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="patch_11">
-    <path d="M 100.601838 380.792 
-L 122.225949 380.792 
-L 122.225949 115.615233 
-L 100.601838 115.615233 
+    <path d="M 106.284111 380.792 
+L 127.662767 380.792 
+L 127.662767 117.757893 
+L 106.284111 117.757893 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 122.225949 380.792 
-L 143.850059 380.792 
-L 143.850059 116.384473 
-L 122.225949 116.384473 
+    <path d="M 127.662767 380.792 
+L 149.041423 380.792 
+L 149.041423 115.103785 
+L 127.662767 115.103785 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 143.850059 380.792 
-L 165.47417 380.792 
-L 165.47417 112.852342 
-L 143.850059 112.852342 
+    <path d="M 149.041423 380.792 
+L 170.420079 380.792 
+L 170.420079 112.899577 
+L 149.041423 112.899577 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 165.47417 380.792 
-L 187.098281 380.792 
-L 187.098281 111.928451 
-L 165.47417 111.928451 
+    <path d="M 170.420079 380.792 
+L 191.798735 380.792 
+L 191.798735 113.556432 
+L 170.420079 113.556432 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 230.346502 380.792 
-L 251.970613 380.792 
-L 251.970613 117.123334 
-L 230.346502 117.123334 
+    <path d="M 234.556047 380.792 
+L 255.934704 380.792 
+L 255.934704 119.726205 
+L 234.556047 119.726205 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 251.970613 380.792 
-L 273.594723 380.792 
-L 273.594723 116.564758 
-L 251.970613 116.564758 
+    <path d="M 255.934704 380.792 
+L 277.31336 380.792 
+L 277.31336 118.105228 
+L 255.934704 118.105228 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 273.594723 380.792 
-L 295.218834 380.792 
-L 295.218834 112.066394 
-L 273.594723 112.066394 
+    <path d="M 277.31336 380.792 
+L 298.692016 380.792 
+L 298.692016 112.339569 
+L 277.31336 112.339569 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 295.218834 380.792 
-L 316.842945 380.792 
-L 316.842945 111.322492 
-L 295.218834 111.322492 
+    <path d="M 298.692016 380.792 
+L 320.070672 380.792 
+L 320.070672 113.254561 
+L 298.692016 113.254561 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 360.091166 380.792 
-L 381.715277 380.792 
-L 381.715277 117.945126 
-L 360.091166 117.945126 
+    <path d="M 362.827984 380.792 
+L 384.20664 380.792 
+L 384.20664 117.566092 
+L 362.827984 117.566092 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 381.715277 380.792 
-L 403.339387 380.792 
-L 403.339387 113.192001 
-L 381.715277 113.192001 
+    <path d="M 384.20664 380.792 
+L 405.585296 380.792 
+L 405.585296 117.804151 
+L 384.20664 117.804151 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 403.339387 380.792 
-L 424.963498 380.792 
-L 424.963498 112.209352 
-L 403.339387 112.209352 
+    <path d="M 405.585296 380.792 
+L 426.963953 380.792 
+L 426.963953 111.144762 
+L 405.585296 111.144762 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 424.963498 380.792 
-L 446.587609 380.792 
-L 446.587609 111.144762 
-L 424.963498 111.144762 
+    <path d="M 426.963953 380.792 
+L 448.342609 380.792 
+L 448.342609 113.079383 
+L 426.963953 113.079383 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 489.83583 380.792 
-L 511.459941 380.792 
-L 511.459941 115.584357 
-L 489.83583 115.584357 
+    <path d="M 491.099921 380.792 
+L 512.478577 380.792 
+L 512.478577 116.633257 
+L 491.099921 116.633257 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 511.459941 380.792 
-L 533.084051 380.792 
-L 533.084051 114.766309 
-L 511.459941 114.766309 
+    <path d="M 512.478577 380.792 
+L 533.857233 380.792 
+L 533.857233 117.879409 
+L 512.478577 117.879409 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 533.084051 380.792 
-L 554.708162 380.792 
-L 554.708162 112.535075 
-L 533.084051 112.535075 
+    <path d="M 533.857233 380.792 
+L 555.235889 380.792 
+L 555.235889 111.328212 
+L 533.857233 111.328212 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 554.708162 380.792 
-L 576.332273 380.792 
-L 576.332273 111.358284 
-L 554.708162 111.358284 
+    <path d="M 555.235889 380.792 
+L 576.614545 380.792 
+L 576.614545 112.895774 
+L 555.235889 112.895774 
 z
-" clip-path="url(#p77b00db637)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p520f8ba062)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_23">
-    <!-- 125 ms -->
-    <g transform="translate(114.173268 110.615233)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_22">
+    <!-- 134 ms -->
+    <g transform="translate(119.732814 112.757893) rotate(-90) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 135 ms -->
+    <g transform="translate(141.11147 110.103785) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1357,87 +1314,119 @@ z
     </g>
    </g>
    <g id="text_24">
-    <!-- 125 ms -->
-    <g transform="translate(135.797379 111.384473)rotate(-90)scale(0.1 -0.1)">
+    <!-- 136 ms -->
+    <g transform="translate(162.490126 107.899577) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 127 ms -->
-    <g transform="translate(157.42149 107.852342)rotate(-90)scale(0.1 -0.1)">
+    <!-- 136 ms -->
+    <g transform="translate(183.868782 108.556432) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 127 ms -->
-    <g transform="translate(179.0456 106.928451)rotate(-90)scale(0.1 -0.1)">
+    <!-- 133 ms -->
+    <g transform="translate(248.00475 114.726205) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- 125 ms -->
-    <g transform="translate(243.917932 112.123334)rotate(-90)scale(0.1 -0.1)">
+    <!-- 134 ms -->
+    <g transform="translate(269.383407 113.105228) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 125 ms -->
-    <g transform="translate(265.542043 111.564758)rotate(-90)scale(0.1 -0.1)">
+    <!-- 137 ms -->
+    <g transform="translate(290.762063 107.339569) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 127 ms -->
-    <g transform="translate(287.166154 107.066394)rotate(-90)scale(0.1 -0.1)">
+    <!-- 136 ms -->
+    <g transform="translate(312.140719 108.254561) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 127 ms -->
-    <g transform="translate(308.790264 106.322492)rotate(-90)scale(0.1 -0.1)">
+    <!-- 134 ms -->
+    <g transform="translate(376.276687 112.566092) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 124 ms -->
-    <g transform="translate(373.662596 112.945126)rotate(-90)scale(0.1 -0.1)">
+    <!-- 134 ms -->
+    <g transform="translate(397.655343 112.804151) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1445,10 +1434,10 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 127 ms -->
-    <g transform="translate(395.286707 108.192001)rotate(-90)scale(0.1 -0.1)">
+    <!-- 137 ms -->
+    <g transform="translate(419.034 106.144762) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1456,202 +1445,191 @@ z
     </g>
    </g>
    <g id="text_33">
-    <!-- 127 ms -->
-    <g transform="translate(416.910818 107.209352)rotate(-90)scale(0.1 -0.1)">
+    <!-- 136 ms -->
+    <g transform="translate(440.412656 108.079383) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- 128 ms -->
-    <g transform="translate(438.534928 106.144762)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 125 ms -->
-    <g transform="translate(503.40726 110.584357)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 126 ms -->
-    <g transform="translate(525.031371 109.766309)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_37">
-    <!-- 127 ms -->
-    <g transform="translate(546.655482 107.535075)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_34">
+    <!-- 134 ms -->
+    <g transform="translate(504.548624 111.633257) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 134 ms -->
+    <g transform="translate(525.92728 112.879409) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 137 ms -->
+    <g transform="translate(547.305936 106.328212) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- 136 ms -->
+    <g transform="translate(568.684592 107.895774) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 127 ms -->
-    <g transform="translate(568.279592 106.358284)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    <!--  4 -->
+    <g transform="translate(119.732814 380.792) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_39">
-    <!--  4 -->
-    <g transform="translate(114.173268 380.792)rotate(-90)scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(141.11147 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_40">
-    <!--  12 -->
-    <g transform="translate(135.797379 380.792)rotate(-90)scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(162.490126 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_41">
-    <!--  40 -->
-    <g transform="translate(157.42149 380.792)rotate(-90)scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(183.868782 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_42">
-    <!--  120 -->
-    <g transform="translate(179.0456 380.792)rotate(-90)scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(248.00475 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_43">
-    <!--  4 -->
-    <g transform="translate(243.917932 380.792)rotate(-90)scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(269.383407 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_44">
-    <!--  12 -->
-    <g transform="translate(265.542043 380.792)rotate(-90)scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(290.762063 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_45">
-    <!--  40 -->
-    <g transform="translate(287.166154 380.792)rotate(-90)scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(312.140719 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_46">
-    <!--  120 -->
-    <g transform="translate(308.790264 380.792)rotate(-90)scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(376.276687 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_47">
-    <!--  4 -->
-    <g transform="translate(373.662596 380.792)rotate(-90)scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(397.655343 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_48">
-    <!--  12 -->
-    <g transform="translate(395.286707 380.792)rotate(-90)scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(419.034 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_49">
-    <!--  40 -->
-    <g transform="translate(416.910818 380.792)rotate(-90)scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(440.412656 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_50">
-    <!--  120 -->
-    <g transform="translate(438.534928 380.792)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-    </g>
-   </g>
-   <g id="text_51">
     <!--  4 -->
-    <g transform="translate(503.40726 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(504.548624 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_52">
+   <g id="text_51">
     <!--  12 -->
-    <g transform="translate(525.031371 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(525.92728 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_53">
+   <g id="text_52">
     <!--  40 -->
-    <g transform="translate(546.655482 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(547.305936 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_54">
+   <g id="text_53">
     <!--  120 -->
-    <g transform="translate(568.279592 380.792)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(568.684592 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_55">
+   <g id="text_54">
     <!-- lines simple n=1000 -->
-    <g transform="translate(265.9825 20.88)scale(0.12 -0.12)">
+    <g transform="translate(269.0875 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -1717,9 +1695,9 @@ L 348.146875 43.117188
 z
 " style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_56">
+    <g id="text_55">
      <!-- serial no mask -->
-     <g transform="translate(376.146875 43.478437)scale(0.1 -0.1)">
+     <g transform="translate(376.146875 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1736,7 +1714,7 @@ z
       <use xlink:href="#DejaVuSans-6b" x="670.507812"/>
      </g>
      <!-- (total chunk count shown at bottom of bar) -->
-     <g transform="translate(376.146875 54.67625)scale(0.1 -0.1)">
+     <g transform="translate(376.146875 54.67625) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-77" d="M 269 3500 
 L 844 3500 
@@ -1803,8 +1781,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p77b00db637">
-   <rect x="54.11" y="26.88" width="547.09" height="353.912"/>
+  <clipPath id="p520f8ba062">
+   <rect x="60.32" y="26.88" width="540.88" height="353.912"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/_static/filled_random_1000.svg
+++ b/docs/_static/filled_random_1000.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:32.810134</dc:date>
+    <dc:date>2022-10-23T17:46:35.307273</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m96e16a35b1" d="M 0 0 
+       <path id="m36a2edbd51" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m96e16a35b1" x="97.224809" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a2edbd51" x="97.224809" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- mpl2005 -->
-      <g transform="translate(75.066216 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(75.066216 372.062437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -198,7 +198,7 @@ z
        <use xlink:href="#DejaVuSans-35" x="379.541016"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(83.027934 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(83.027934 383.26025) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -314,7 +314,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(84.423247 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(84.423247 394.458062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -395,12 +395,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m96e16a35b1" x="162.14915" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a2edbd51" x="162.14915" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- mpl2014 -->
-      <g transform="translate(139.990556 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(139.990556 372.062437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -445,7 +445,7 @@ z
        <use xlink:href="#DejaVuSans-34" x="379.541016"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(147.952275 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(147.952275 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -453,7 +453,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(149.347587 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(149.347587 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -464,12 +464,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m96e16a35b1" x="227.07349" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a2edbd51" x="227.07349" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- serial -->
-      <g transform="translate(213.494583 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(213.494583 372.062437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
@@ -557,7 +557,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(212.876615 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(212.876615 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -565,7 +565,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(214.271927 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(214.271927 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -576,12 +576,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m96e16a35b1" x="291.99783" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a2edbd51" x="291.99783" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- serial -->
-      <g transform="translate(278.418924 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(278.418924 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -590,7 +590,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(277.800955 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(277.800955 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -598,7 +598,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(276.900174 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(276.900174 394.458062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -634,12 +634,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m96e16a35b1" x="356.92217" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a2edbd51" x="356.92217" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- serial -->
-      <g transform="translate(343.343264 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(343.343264 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -648,7 +648,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(341.029201 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(341.029201 383.26025) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -710,7 +710,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(331.518264 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(331.518264 394.458062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -749,7 +749,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(344.120608 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(344.120608 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -760,12 +760,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m96e16a35b1" x="421.84651" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a2edbd51" x="421.84651" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- serial -->
-      <g transform="translate(408.267604 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(408.267604 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -774,7 +774,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(405.953542 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(405.953542 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -782,7 +782,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(396.442604 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(396.442604 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -793,7 +793,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(406.748854 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(406.748854 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -806,12 +806,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m96e16a35b1" x="486.77085" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a2edbd51" x="486.77085" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- serial -->
-      <g transform="translate(473.191944 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(473.191944 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -820,7 +820,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(470.877882 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(470.877882 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -828,7 +828,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(461.366944 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(461.366944 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -839,14 +839,14 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(473.969288 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(473.969288 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
        <use xlink:href="#DejaVuSans-65" x="194.482422"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(471.673194 416.853687)scale(0.1 -0.1)">
+      <g transform="translate(471.673194 416.853687) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -859,12 +859,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m96e16a35b1" x="551.695191" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a2edbd51" x="551.695191" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- serial -->
-      <g transform="translate(538.116284 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(538.116284 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -873,7 +873,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(535.802222 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(535.802222 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -881,7 +881,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(526.291284 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(526.291284 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -892,7 +892,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(536.597534 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(536.597534 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -901,7 +901,7 @@ z
        <use xlink:href="#DejaVuSans-74" x="262.744141"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(536.597534 416.853687)scale(0.1 -0.1)">
+      <g transform="translate(536.597534 416.853687) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -917,21 +917,21 @@ z
      <g id="line2d_9">
       <path d="M 47.72 357.464 
 L 601.2 357.464 
-" clip-path="url(#p232ed53a35)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <defs>
-       <path id="md1629783c2" d="M 0 0 
+       <path id="ma91ed26f99" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md1629783c2" x="47.72" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma91ed26f99" x="47.72" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.0 -->
-      <g transform="translate(24.816875 361.263219)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 361.263219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -949,18 +949,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_11">
-      <path d="M 47.72 296.244741 
-L 601.2 296.244741 
-" clip-path="url(#p232ed53a35)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 297.357818 
+L 601.2 297.357818 
+" clip-path="url(#p0ba9d812d2)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#md1629783c2" x="47.72" y="296.244741" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma91ed26f99" x="47.72" y="297.357818" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.5 -->
-      <g transform="translate(24.816875 300.043959)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 301.157037) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -969,18 +969,18 @@ L 601.2 296.244741
     </g>
     <g id="ytick_3">
      <g id="line2d_13">
-      <path d="M 47.72 235.025481 
-L 601.2 235.025481 
-" clip-path="url(#p232ed53a35)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 237.251636 
+L 601.2 237.251636 
+" clip-path="url(#p0ba9d812d2)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md1629783c2" x="47.72" y="235.025481" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma91ed26f99" x="47.72" y="237.251636" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.0 -->
-      <g transform="translate(24.816875 238.8247)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 241.050855) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -989,18 +989,18 @@ L 601.2 235.025481
     </g>
     <g id="ytick_4">
      <g id="line2d_15">
-      <path d="M 47.72 173.806222 
-L 601.2 173.806222 
-" clip-path="url(#p232ed53a35)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 177.145455 
+L 601.2 177.145455 
+" clip-path="url(#p0ba9d812d2)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md1629783c2" x="47.72" y="173.806222" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma91ed26f99" x="47.72" y="177.145455" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.5 -->
-      <g transform="translate(24.816875 177.605441)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 180.944673) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -1009,18 +1009,18 @@ L 601.2 173.806222
     </g>
     <g id="ytick_5">
      <g id="line2d_17">
-      <path d="M 47.72 112.586963 
-L 601.2 112.586963 
-" clip-path="url(#p232ed53a35)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 117.039273 
+L 601.2 117.039273 
+" clip-path="url(#p0ba9d812d2)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md1629783c2" x="47.72" y="112.586963" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma91ed26f99" x="47.72" y="117.039273" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 2.0 -->
-      <g transform="translate(24.816875 116.386182)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 120.838491) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1029,18 +1029,18 @@ L 601.2 112.586963
     </g>
     <g id="ytick_6">
      <g id="line2d_19">
-      <path d="M 47.72 51.367704 
-L 601.2 51.367704 
-" clip-path="url(#p232ed53a35)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 56.933091 
+L 601.2 56.933091 
+" clip-path="url(#p0ba9d812d2)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md1629783c2" x="47.72" y="51.367704" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma91ed26f99" x="47.72" y="56.933091" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 2.5 -->
-      <g transform="translate(24.816875 55.166922)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 60.73231) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -1049,7 +1049,7 @@ L 601.2 51.367704
     </g>
     <g id="text_15">
      <!-- Time (seconds) -->
-     <g transform="translate(18.737188 230.333719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.737188 230.333719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1131,104 +1131,22 @@ z
    <g id="patch_3">
     <path d="M 72.878182 357.464 
 L 89.109267 357.464 
-L 89.109267 -1092.260717 
-L 72.878182 -1092.260717 
+L 89.109267 -1012.354464 
+L 72.878182 -1012.354464 
 z
-" clip-path="url(#p232ed53a35)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 89.109267 357.464 
 L 105.340352 357.464 
-L 105.340352 100.423615 
-L 89.109267 100.423615 
+L 105.340352 106.21383 
+L 89.109267 106.21383 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#h865b7f8ea7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h4133adbd33); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_16">
-    <!-- 2.10 s -->
-    <g transform="translate(99.984184 95.423615)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 137.802522 357.464 
-L 154.033607 357.464 
-L 154.033607 66.896389 
-L 137.802522 66.896389 
-z
-" clip-path="url(#p232ed53a35)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_17">
-    <!-- 2.37 s -->
-    <g transform="translate(148.67744 61.896389)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 154.033607 357.464 
-L 170.264692 357.464 
-L 170.264692 65.143552 
-L 154.033607 65.143552 
-z
-" clip-path="url(#p232ed53a35)" style="fill: url(#h6d0e70c2ae); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_18">
-    <!-- 2.39 s -->
-    <g transform="translate(164.908525 60.143552)rotate(-90)scale(0.1 -0.1)">
+    <!-- 2.09 s -->
+    <g transform="translate(99.984184 101.21383) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1263,6 +1181,78 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 137.802522 357.464 
+L 154.033607 357.464 
+L 154.033607 68.93818 
+L 137.802522 68.93818 
+z
+" clip-path="url(#p0ba9d812d2)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_17">
+    <!-- 2.40 s -->
+    <g transform="translate(148.67744 63.93818) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 154.033607 357.464 
+L 170.264692 357.464 
+L 170.264692 69.99676 
+L 154.033607 69.99676 
+z
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h38634c2df6); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_18">
+    <!-- 2.39 s -->
+    <g transform="translate(164.908525 64.99676) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="95.410156"/>
      <use xlink:href="#DejaVuSans-39" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1272,14 +1262,96 @@ z
    <g id="patch_7">
     <path d="M 170.264692 357.464 
 L 186.495777 357.464 
-L 186.495777 68.124987 
-L 170.264692 68.124987 
+L 186.495777 72.552929 
+L 170.264692 72.552929 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#h77a67f1944); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#ha69dee44ed); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_19">
-    <!-- 2.36 s -->
-    <g transform="translate(181.13961 63.124987)rotate(-90)scale(0.1 -0.1)">
+    <!-- 2.37 s -->
+    <g transform="translate(181.13961 67.552929) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 202.726862 357.464 
+L 218.957947 357.464 
+L 218.957947 153.560083 
+L 202.726862 153.560083 
+z
+" clip-path="url(#p0ba9d812d2)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 267.651202 357.464 
+L 283.882287 357.464 
+L 283.882287 159.717076 
+L 267.651202 159.717076 
+z
+" clip-path="url(#p0ba9d812d2)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 332.575543 357.464 
+L 348.806628 357.464 
+L 348.806628 251.746343 
+L 332.575543 251.746343 
+z
+" clip-path="url(#p0ba9d812d2)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 397.499883 357.464 
+L 413.730968 357.464 
+L 413.730968 252.046134 
+L 397.499883 252.046134 
+z
+" clip-path="url(#p0ba9d812d2)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 462.424223 357.464 
+L 478.655308 357.464 
+L 478.655308 246.983169 
+L 462.424223 246.983169 
+z
+" clip-path="url(#p0ba9d812d2)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 527.348563 357.464 
+L 543.579648 357.464 
+L 543.579648 247.546557 
+L 527.348563 247.546557 
+z
+" clip-path="url(#p0ba9d812d2)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 1.70 s -->
+    <g transform="translate(213.60178 148.560083) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 1.64 s -->
+    <g transform="translate(278.52612 154.717076) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1312,98 +1384,17 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 202.726862 357.464 
-L 218.957947 357.464 
-L 218.957947 148.653939 
-L 202.726862 148.653939 
-z
-" clip-path="url(#p232ed53a35)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 267.651202 357.464 
-L 283.882287 357.464 
-L 283.882287 154.551418 
-L 267.651202 154.551418 
-z
-" clip-path="url(#p232ed53a35)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 332.575543 357.464 
-L 348.806628 357.464 
-L 348.806628 246.864812 
-L 332.575543 246.864812 
-z
-" clip-path="url(#p232ed53a35)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 397.499883 357.464 
-L 413.730968 357.464 
-L 413.730968 248.327648 
-L 397.499883 248.327648 
-z
-" clip-path="url(#p232ed53a35)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 462.424223 357.464 
-L 478.655308 357.464 
-L 478.655308 242.246501 
-L 462.424223 242.246501 
-z
-" clip-path="url(#p232ed53a35)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 527.348563 357.464 
-L 543.579648 357.464 
-L 543.579648 243.535674 
-L 527.348563 243.535674 
-z
-" clip-path="url(#p232ed53a35)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 1.71 s -->
-    <g transform="translate(213.60178 143.653939)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 1.66 s -->
-    <g transform="translate(278.52612 149.551418)rotate(-90)scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- 903 ms -->
-    <g transform="translate(343.45046 241.864812)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 891 ms -->
-    <g transform="translate(408.3748 243.327648)rotate(-90)scale(0.1 -0.1)">
+    <!-- 879 ms -->
+    <g transform="translate(343.45046 246.746343) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1446,30 +1437,41 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 877 ms -->
+    <g transform="translate(408.3748 247.046134) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 941 ms -->
-    <g transform="translate(473.29914 237.246501)rotate(-90)scale(0.1 -0.1)">
+    <!-- 919 ms -->
+    <g transform="translate(473.29914 241.983169) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 930 ms -->
-    <g transform="translate(538.223481 238.535674)rotate(-90)scale(0.1 -0.1)">
+    <!-- 914 ms -->
+    <g transform="translate(538.223481 242.546557) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1478,54 +1480,54 @@ z
    <g id="patch_14">
     <path d="M 218.957947 357.464 
 L 235.189032 357.464 
-L 235.189032 136.565766 
-L 218.957947 136.565766 
+L 235.189032 141.182428 
+L 218.957947 141.182428 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#h53adb4b918); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h7b649329e8); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 283.882287 357.464 
 L 300.113372 357.464 
-L 300.113372 144.005365 
-L 283.882287 144.005365 
+L 300.113372 149.19329 
+L 283.882287 149.19329 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#h53adb4b918); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h7b649329e8); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 348.806628 357.464 
 L 365.037713 357.464 
-L 365.037713 247.253363 
-L 348.806628 247.253363 
+L 365.037713 252.133553 
+L 348.806628 252.133553 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#h53adb4b918); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h7b649329e8); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 413.730968 357.464 
 L 429.962053 357.464 
-L 429.962053 248.364352 
-L 413.730968 248.364352 
+L 429.962053 252.415255 
+L 413.730968 252.415255 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#h53adb4b918); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h7b649329e8); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 478.655308 357.464 
 L 494.886393 357.464 
-L 494.886393 243.438507 
-L 478.655308 243.438507 
+L 494.886393 248.243061 
+L 478.655308 248.243061 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#h53adb4b918); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h7b649329e8); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 543.579648 357.464 
 L 559.810733 357.464 
-L 559.810733 244.449213 
-L 543.579648 244.449213 
+L 559.810733 248.742302 
+L 543.579648 248.742302 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#h53adb4b918); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h7b649329e8); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_26">
     <!-- 1.80 s -->
-    <g transform="translate(229.832865 131.565766)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(229.832865 136.182428) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="95.410156"/>
@@ -1535,55 +1537,55 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 1.74 s -->
-    <g transform="translate(294.757205 139.005365)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.73 s -->
+    <g transform="translate(294.757205 144.19329) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 900 ms -->
-    <g transform="translate(359.681545 242.253363)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+    <!-- 876 ms -->
+    <g transform="translate(359.681545 247.133553) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 891 ms -->
-    <g transform="translate(424.605885 243.364352)rotate(-90)scale(0.1 -0.1)">
+    <!-- 874 ms -->
+    <g transform="translate(424.605885 247.415255) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 931 ms -->
-    <g transform="translate(489.530225 238.438507)rotate(-90)scale(0.1 -0.1)">
+    <!-- 909 ms -->
+    <g transform="translate(489.530225 243.243061) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 923 ms -->
-    <g transform="translate(554.454566 239.449213)rotate(-90)scale(0.1 -0.1)">
+    <!-- 904 ms -->
+    <g transform="translate(554.454566 243.742302) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1592,112 +1594,112 @@ z
    <g id="patch_20">
     <path d="M 235.189032 357.464 
 L 251.420117 357.464 
-L 251.420117 139.826965 
-L 235.189032 139.826965 
+L 251.420117 145.702885 
+L 235.189032 145.702885 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#hd553b22234); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h1430421cc5); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 300.113372 357.464 
 L 316.344457 357.464 
-L 316.344457 147.017946 
-L 300.113372 147.017946 
+L 316.344457 152.370845 
+L 300.113372 152.370845 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#hd553b22234); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h1430421cc5); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 365.037713 357.464 
 L 381.268798 357.464 
-L 381.268798 240.44377 
-L 365.037713 240.44377 
+L 381.268798 245.008833 
+L 365.037713 245.008833 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#hd553b22234); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h1430421cc5); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 429.962053 357.464 
 L 446.193138 357.464 
-L 446.193138 241.524176 
-L 429.962053 241.524176 
+L 446.193138 245.318191 
+L 429.962053 245.318191 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#hd553b22234); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h1430421cc5); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 494.886393 357.464 
 L 511.117478 357.464 
-L 511.117478 236.473107 
-L 494.886393 236.473107 
+L 511.117478 241.16085 
+L 494.886393 241.16085 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#hd553b22234); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h1430421cc5); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 559.810733 357.464 
 L 576.041818 357.464 
-L 576.041818 237.334261 
-L 559.810733 237.334261 
+L 576.041818 241.525914 
+L 559.810733 241.525914 
 z
-" clip-path="url(#p232ed53a35)" style="fill: url(#hd553b22234); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0ba9d812d2)" style="fill: url(#h1430421cc5); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_32">
-    <!-- 1.78 s -->
-    <g transform="translate(246.06395 134.826965)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.76 s -->
+    <g transform="translate(246.06395 140.702885) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 1.72 s -->
-    <g transform="translate(310.98829 142.017946)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.71 s -->
+    <g transform="translate(310.98829 147.370845) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 956 ms -->
-    <g transform="translate(375.91263 235.44377)rotate(-90)scale(0.1 -0.1)">
+    <!-- 935 ms -->
+    <g transform="translate(375.91263 240.008833) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 947 ms -->
-    <g transform="translate(440.83697 236.524176)rotate(-90)scale(0.1 -0.1)">
+    <!-- 933 ms -->
+    <g transform="translate(440.83697 240.318191) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 988 ms -->
-    <g transform="translate(505.76131 231.473107)rotate(-90)scale(0.1 -0.1)">
+    <!-- 967 ms -->
+    <g transform="translate(505.76131 236.16085) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 981 ms -->
-    <g transform="translate(570.685651 232.334261)rotate(-90)scale(0.1 -0.1)">
+    <!-- 964 ms -->
+    <g transform="translate(570.685651 236.525914) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1705,7 +1707,7 @@ z
    </g>
    <g id="text_38">
     <!-- filled random n=1000  -->
-    <g transform="translate(256.754687 20.88)scale(0.12 -0.12)">
+    <g transform="translate(256.754687 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
@@ -1788,7 +1790,7 @@ z
     </g>
     <g id="text_39">
      <!-- mpl2005 no mask -->
-     <g transform="translate(447.19375 43.478437)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1812,11 +1814,11 @@ L 439.19375 58.156563
 L 439.19375 51.156563 
 L 419.19375 51.156563 
 z
-" style="fill: url(#h865b7f8ea7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h4133adbd33); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_40">
      <!-- mpl2005 corner_mask=False -->
-     <g transform="translate(447.19375 58.156563)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 58.156563) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-5f" d="M 3263 -1063 
 L 3263 -1509 
@@ -1876,7 +1878,7 @@ z
     </g>
     <g id="text_41">
      <!-- mpl2014 no mask -->
-     <g transform="translate(447.19375 73.112812)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 73.112812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1900,11 +1902,11 @@ L 439.19375 87.790937
 L 439.19375 80.790937 
 L 419.19375 80.790937 
 z
-" style="fill: url(#h6d0e70c2ae); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h38634c2df6); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_42">
      <!-- mpl2014 corner_mask=False -->
-     <g transform="translate(447.19375 87.790937)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 87.790937) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1938,11 +1940,11 @@ L 439.19375 102.747187
 L 439.19375 95.747187 
 L 419.19375 95.747187 
 z
-" style="fill: url(#h77a67f1944); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#ha69dee44ed); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_43">
      <!-- mpl2014 corner_mask=True -->
-     <g transform="translate(447.19375 102.747187)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 102.747187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1979,7 +1981,7 @@ z
     </g>
     <g id="text_44">
      <!-- serial no mask -->
-     <g transform="translate(447.19375 117.703437)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 117.703437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2002,11 +2004,11 @@ L 439.19375 132.381562
 L 439.19375 125.381562 
 L 419.19375 125.381562 
 z
-" style="fill: url(#h53adb4b918); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h7b649329e8); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_45">
      <!-- serial corner_mask=False -->
-     <g transform="translate(447.19375 132.381562)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 132.381562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2039,11 +2041,11 @@ L 439.19375 147.337812
 L 439.19375 140.337812 
 L 419.19375 140.337812 
 z
-" style="fill: url(#hd553b22234); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h1430421cc5); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_46">
      <!-- serial corner_mask=True -->
-     <g transform="translate(447.19375 147.337812)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 147.337812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2073,12 +2075,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p232ed53a35">
+  <clipPath id="p0ba9d812d2">
    <rect x="47.72" y="26.88" width="553.48" height="330.584"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h865b7f8ea7" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h4133adbd33" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2118,7 +2120,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h6d0e70c2ae" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h38634c2df6" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2158,7 +2160,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h77a67f1944" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="ha69dee44ed" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2200,7 +2202,7 @@ M 36 108
 L 108 36 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h53adb4b918" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h7b649329e8" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2240,7 +2242,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hd553b22234" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h1430421cc5" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/filled_random_1000_render.svg
+++ b/docs/_static/filled_random_1000_render.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:32.976750</dc:date>
+    <dc:date>2022-10-23T17:46:35.461405</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m09a0a0770e" d="M 0 0 
+       <path id="m3c3b4de11b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m09a0a0770e" x="94.356554" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c3b4de11b" x="94.356554" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- mpl2005 -->
-      <g transform="translate(72.197961 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(72.197961 372.062437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -198,7 +198,7 @@ z
        <use xlink:href="#DejaVuSans-35" x="379.541016"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(80.159679 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(80.159679 383.26025) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -314,7 +314,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(81.554992 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(81.554992 394.458062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -395,12 +395,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m09a0a0770e" x="159.650396" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c3b4de11b" x="159.650396" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- mpl2014 -->
-      <g transform="translate(137.491802 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(137.491802 372.062437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -445,7 +445,7 @@ z
        <use xlink:href="#DejaVuSans-34" x="379.541016"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(145.453521 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(145.453521 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -453,7 +453,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(146.848833 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(146.848833 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -464,12 +464,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m09a0a0770e" x="224.944238" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c3b4de11b" x="224.944238" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- serial -->
-      <g transform="translate(211.365331 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(211.365331 372.062437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
@@ -557,7 +557,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(210.747363 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(210.747363 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -565,7 +565,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(212.142675 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(212.142675 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -576,12 +576,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m09a0a0770e" x="290.238079" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c3b4de11b" x="290.238079" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- serial -->
-      <g transform="translate(276.659173 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(276.659173 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -590,7 +590,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(276.041204 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(276.041204 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -598,7 +598,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(275.140423 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(275.140423 394.458062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -634,12 +634,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m09a0a0770e" x="355.531921" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c3b4de11b" x="355.531921" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- serial -->
-      <g transform="translate(341.953015 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(341.953015 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -648,7 +648,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(339.638952 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(339.638952 383.26025) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -710,7 +710,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(330.128015 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(330.128015 394.458062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -749,7 +749,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(342.730358 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(342.730358 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -760,12 +760,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m09a0a0770e" x="420.825762" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c3b4de11b" x="420.825762" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- serial -->
-      <g transform="translate(407.246856 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(407.246856 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -774,7 +774,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(404.932794 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(404.932794 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -782,7 +782,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(395.421856 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(395.421856 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -793,7 +793,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(405.728106 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(405.728106 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -806,12 +806,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m09a0a0770e" x="486.119604" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c3b4de11b" x="486.119604" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- serial -->
-      <g transform="translate(472.540698 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(472.540698 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -820,7 +820,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(470.226635 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(470.226635 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -828,7 +828,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(460.715698 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(460.715698 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -839,14 +839,14 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(473.318042 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(473.318042 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
        <use xlink:href="#DejaVuSans-65" x="194.482422"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(471.021948 416.853687)scale(0.1 -0.1)">
+      <g transform="translate(471.021948 416.853687) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -859,12 +859,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m09a0a0770e" x="551.413446" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c3b4de11b" x="551.413446" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- serial -->
-      <g transform="translate(537.834539 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(537.834539 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -873,7 +873,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(535.520477 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(535.520477 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -881,7 +881,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(526.009539 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(526.009539 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -892,7 +892,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(536.315789 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(536.315789 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -901,7 +901,7 @@ z
        <use xlink:href="#DejaVuSans-74" x="262.744141"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(536.315789 416.853687)scale(0.1 -0.1)">
+      <g transform="translate(536.315789 416.853687) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -917,57 +917,57 @@ z
      <g id="line2d_9">
       <path d="M 44.57 357.464 
 L 601.2 357.464 
-" clip-path="url(#pb7f36a82a5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p9fbf49b019)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <defs>
-       <path id="mba0e9122b5" d="M 0 0 
+       <path id="m2c85c85990" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mba0e9122b5" x="44.57" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c85c85990" x="44.57" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0 -->
-      <g transform="translate(31.2075 361.263219)scale(0.1 -0.1)">
+      <g transform="translate(31.2075 361.263219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_11">
-      <path d="M 44.57 310.220386 
-L 601.2 310.220386 
-" clip-path="url(#pb7f36a82a5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 311.650612 
+L 601.2 311.650612 
+" clip-path="url(#p9fbf49b019)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mba0e9122b5" x="44.57" y="310.220386" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c85c85990" x="44.57" y="311.650612" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 5 -->
-      <g transform="translate(31.2075 314.019604)scale(0.1 -0.1)">
+      <g transform="translate(31.2075 315.44983) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-35"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_13">
-      <path d="M 44.57 262.976771 
-L 601.2 262.976771 
-" clip-path="url(#pb7f36a82a5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 265.837223 
+L 601.2 265.837223 
+" clip-path="url(#p9fbf49b019)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mba0e9122b5" x="44.57" y="262.976771" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c85c85990" x="44.57" y="265.837223" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10 -->
-      <g transform="translate(24.845 266.77599)scale(0.1 -0.1)">
+      <g transform="translate(24.845 269.636442) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" x="63.623047"/>
       </g>
@@ -975,18 +975,18 @@ L 601.2 262.976771
     </g>
     <g id="ytick_4">
      <g id="line2d_15">
-      <path d="M 44.57 215.733157 
-L 601.2 215.733157 
-" clip-path="url(#pb7f36a82a5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 220.023835 
+L 601.2 220.023835 
+" clip-path="url(#p9fbf49b019)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mba0e9122b5" x="44.57" y="215.733157" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c85c85990" x="44.57" y="220.023835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 15 -->
-      <g transform="translate(24.845 219.532376)scale(0.1 -0.1)">
+      <g transform="translate(24.845 223.823054) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-35" x="63.623047"/>
       </g>
@@ -994,18 +994,18 @@ L 601.2 215.733157
     </g>
     <g id="ytick_5">
      <g id="line2d_17">
-      <path d="M 44.57 168.489543 
-L 601.2 168.489543 
-" clip-path="url(#pb7f36a82a5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 174.210447 
+L 601.2 174.210447 
+" clip-path="url(#p9fbf49b019)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mba0e9122b5" x="44.57" y="168.489543" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c85c85990" x="44.57" y="174.210447" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 20 -->
-      <g transform="translate(24.845 172.288761)scale(0.1 -0.1)">
+      <g transform="translate(24.845 178.009665) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-30" x="63.623047"/>
       </g>
@@ -1013,18 +1013,18 @@ L 601.2 168.489543
     </g>
     <g id="ytick_6">
      <g id="line2d_19">
-      <path d="M 44.57 121.245928 
-L 601.2 121.245928 
-" clip-path="url(#pb7f36a82a5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 128.397058 
+L 601.2 128.397058 
+" clip-path="url(#p9fbf49b019)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mba0e9122b5" x="44.57" y="121.245928" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c85c85990" x="44.57" y="128.397058" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 25 -->
-      <g transform="translate(24.845 125.045147)scale(0.1 -0.1)">
+      <g transform="translate(24.845 132.196277) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-35" x="63.623047"/>
       </g>
@@ -1032,18 +1032,18 @@ L 601.2 121.245928
     </g>
     <g id="ytick_7">
      <g id="line2d_21">
-      <path d="M 44.57 74.002314 
-L 601.2 74.002314 
-" clip-path="url(#pb7f36a82a5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 82.58367 
+L 601.2 82.58367 
+" clip-path="url(#p9fbf49b019)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mba0e9122b5" x="44.57" y="74.002314" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c85c85990" x="44.57" y="82.58367" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 30 -->
-      <g transform="translate(24.845 77.801533)scale(0.1 -0.1)">
+      <g transform="translate(24.845 86.382889) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1083,9 +1083,28 @@ z
       </g>
      </g>
     </g>
-    <g id="text_16">
+    <g id="ytick_8">
+     <g id="line2d_23">
+      <path d="M 44.57 36.770281 
+L 601.2 36.770281 
+" clip-path="url(#p9fbf49b019)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m2c85c85990" x="44.57" y="36.770281" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 35 -->
+      <g transform="translate(24.845 40.5695) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_17">
      <!-- Time (seconds) -->
-     <g transform="translate(18.765313 230.333719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.765313 230.333719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1167,220 +1186,14 @@ z
    <g id="patch_3">
     <path d="M 69.871364 357.464 
 L 86.194824 357.464 
-L 86.194824 176.610674 
-L 69.871364 176.610674 
+L 86.194824 189.946249 
+L 69.871364 189.946249 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_17">
-    <!-- 19.1 s -->
-    <g transform="translate(80.792469 171.610674)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2e" d="M 684 794 
-L 1344 794 
-L 1344 0 
-L 684 0 
-L 684 794 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_4">
-    <path d="M 86.194824 357.464 
-L 102.518284 357.464 
-L 102.518284 266.230303 
-L 86.194824 266.230303 
-z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h089ec38e12); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9fbf49b019)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_18">
-    <!-- 9.66 s -->
-    <g transform="translate(97.115929 261.230303)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 135.165205 357.464 
-L 151.488666 357.464 
-L 151.488666 261.107282 
-L 135.165205 261.107282 
-z
-" clip-path="url(#pb7f36a82a5)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 10.2 s -->
-    <g transform="translate(146.08631 256.107282)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 151.488666 357.464 
-L 167.812126 357.464 
-L 167.812126 258.9797 
-L 151.488666 258.9797 
-z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#hd477cc2839); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 10.4 s -->
-    <g transform="translate(162.409771 253.9797)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 167.812126 357.464 
-L 184.135587 357.464 
-L 184.135587 262.467763 
-L 167.812126 262.467763 
-z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#hec7ac0a1df); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 10.1 s -->
-    <g transform="translate(178.733231 257.467763)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 200.459047 357.464 
-L 216.782507 357.464 
-L 216.782507 272.87158 
-L 200.459047 272.87158 
-z
-" clip-path="url(#pb7f36a82a5)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 265.752889 357.464 
-L 282.076349 357.464 
-L 282.076349 143.172238 
-L 265.752889 143.172238 
-z
-" clip-path="url(#pb7f36a82a5)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 331.04673 357.464 
-L 347.370191 357.464 
-L 347.370191 326.728293 
-L 331.04673 326.728293 
-z
-" clip-path="url(#pb7f36a82a5)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 396.340572 357.464 
-L 412.664032 357.464 
-L 412.664032 326.573081 
-L 396.340572 326.573081 
-z
-" clip-path="url(#pb7f36a82a5)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 461.634413 357.464 
-L 477.957874 357.464 
-L 477.957874 257.079846 
-L 461.634413 257.079846 
-z
-" clip-path="url(#pb7f36a82a5)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 526.928255 357.464 
-L 543.251716 357.464 
-L 543.251716 94.290606 
-L 526.928255 94.290606 
-z
-" clip-path="url(#pb7f36a82a5)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 8.95 s -->
-    <g transform="translate(211.380152 267.87158)rotate(-90)scale(0.1 -0.1)">
+    <!-- 18.3 s -->
+    <g transform="translate(80.792469 184.946249) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1421,19 +1234,64 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_23">
-    <!-- 22.7 s -->
-    <g transform="translate(276.673994 138.172238)rotate(-90)scale(0.1 -0.1)">
+   <g id="patch_4">
+    <path d="M 86.194824 357.464 
+L 102.518284 357.464 
+L 102.518284 268.600387 
+L 86.194824 268.600387 
+z
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h054b80244d); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 9.70 s -->
+    <g transform="translate(97.115929 263.600387) rotate(-90) scale(0.1 -0.1)">
      <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1445,39 +1303,198 @@ L 525 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 135.165205 357.464 
+L 151.488666 357.464 
+L 151.488666 263.937616 
+L 135.165205 263.937616 
+z
+" clip-path="url(#p9fbf49b019)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 10.2 s -->
+    <g transform="translate(146.08631 258.937616) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 151.488666 357.464 
+L 167.812126 357.464 
+L 167.812126 262.545847 
+L 151.488666 262.545847 
+z
+" clip-path="url(#p9fbf49b019)" style="fill: url(#haaa72b8eb4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 10.4 s -->
+    <g transform="translate(162.409771 257.545847) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 167.812126 357.464 
+L 184.135587 357.464 
+L 184.135587 265.700234 
+L 167.812126 265.700234 
+z
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h2fe00aac5d); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 10.0 s -->
+    <g transform="translate(178.733231 260.700234) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 200.459047 357.464 
+L 216.782507 357.464 
+L 216.782507 276.166006 
+L 200.459047 276.166006 
+z
+" clip-path="url(#p9fbf49b019)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 265.752889 357.464 
+L 282.076349 357.464 
+L 282.076349 147.790968 
+L 265.752889 147.790968 
+z
+" clip-path="url(#p9fbf49b019)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 331.04673 357.464 
+L 347.370191 357.464 
+L 347.370191 327.802575 
+L 331.04673 327.802575 
+z
+" clip-path="url(#p9fbf49b019)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 396.340572 357.464 
+L 412.664032 357.464 
+L 412.664032 327.609793 
+L 396.340572 327.609793 
+z
+" clip-path="url(#p9fbf49b019)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 461.634413 357.464 
+L 477.957874 357.464 
+L 477.957874 260.093255 
+L 461.634413 260.093255 
+z
+" clip-path="url(#p9fbf49b019)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 526.928255 357.464 
+L 543.251716 357.464 
+L 543.251716 96.523839 
+L 526.928255 96.523839 
+z
+" clip-path="url(#p9fbf49b019)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_23">
+    <!-- 8.87 s -->
+    <g transform="translate(211.380152 271.166006) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="95.410156"/>
      <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 3.25 s -->
-    <g transform="translate(341.967835 321.728293)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+    <!-- 22.9 s -->
+    <g transform="translate(276.673994 142.790968) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 3.27 s -->
-    <g transform="translate(407.261677 321.573081)rotate(-90)scale(0.1 -0.1)">
+    <!-- 3.24 s -->
+    <g transform="translate(341.967835 322.802575) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_26">
+    <!-- 3.26 s -->
+    <g transform="translate(407.261677 322.609793) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_27">
     <!-- 10.6 s -->
-    <g transform="translate(472.555519 252.079846)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(472.555519 255.093255) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
@@ -1486,13 +1503,13 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- 27.9 s -->
-    <g transform="translate(537.84936 89.290606)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_28">
+    <!-- 28.5 s -->
+    <g transform="translate(537.84936 91.523839) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1500,42 +1517,42 @@ z
    <g id="patch_14">
     <path d="M 216.782507 357.464 
 L 233.105968 357.464 
-L 233.105968 267.509811 
-L 216.782507 267.509811 
+L 233.105968 271.612206 
+L 216.782507 271.612206 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h12326bbec7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h3b85d69cc9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 282.076349 357.464 
 L 298.399809 357.464 
-L 298.399809 123.658622 
-L 282.076349 123.658622 
+L 298.399809 125.929597 
+L 282.076349 125.929597 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h12326bbec7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h3b85d69cc9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 347.370191 357.464 
 L 363.693651 357.464 
-L 363.693651 328.991192 
-L 347.370191 328.991192 
+L 363.693651 329.934312 
+L 347.370191 329.934312 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h12326bbec7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h3b85d69cc9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 412.664032 357.464 
 L 428.987493 357.464 
-L 428.987493 328.835379 
-L 412.664032 328.835379 
+L 428.987493 329.910761 
+L 412.664032 329.910761 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h12326bbec7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h3b85d69cc9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 477.957874 357.464 
 L 494.281334 357.464 
-L 494.281334 248.258109 
-L 477.957874 248.258109 
+L 494.281334 252.956122 
+L 477.957874 252.956122 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h12326bbec7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h3b85d69cc9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 543.251716 357.464 
@@ -1543,33 +1560,44 @@ L 559.575176 357.464
 L 559.575176 71.244087 
 L 543.251716 71.244087 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h12326bbec7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_28">
-    <!-- 9.52 s -->
-    <g transform="translate(227.703613 262.509811)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h3b85d69cc9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_29">
-    <!-- 24.7 s -->
-    <g transform="translate(292.997454 118.658622)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+    <!-- 9.37 s -->
+    <g transform="translate(227.703613 266.612206) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="95.410156"/>
      <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_30">
+    <!-- 25.3 s -->
+    <g transform="translate(292.997454 120.929597) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 3.00 s -->
+    <g transform="translate(358.291296 324.934312) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_32">
     <!-- 3.01 s -->
-    <g transform="translate(358.291296 323.991192)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(423.585137 324.910761) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1578,35 +1606,24 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- 3.03 s -->
-    <g transform="translate(423.585137 323.835379)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 11.6 s -->
-    <g transform="translate(488.878979 243.258109)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_33">
+    <!-- 11.4 s -->
+    <g transform="translate(488.878979 247.956122) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_33">
-    <!-- 30.3 s -->
-    <g transform="translate(554.172821 66.244087)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_34">
+    <!-- 31.2 s -->
+    <g transform="translate(554.172821 66.244087) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1614,87 +1631,76 @@ z
    <g id="patch_20">
     <path d="M 233.105968 357.464 
 L 249.429428 357.464 
-L 249.429428 272.736749 
-L 233.105968 272.736749 
+L 249.429428 275.858238 
+L 233.105968 275.858238 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h82340dd1d7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h29179d1b81); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 298.399809 357.464 
 L 314.72327 357.464 
-L 314.72327 144.030814 
-L 298.399809 144.030814 
+L 314.72327 147.184344 
+L 298.399809 147.184344 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h82340dd1d7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h29179d1b81); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 363.693651 357.464 
 L 380.017111 357.464 
-L 380.017111 326.725279 
-L 363.693651 326.725279 
+L 380.017111 327.703519 
+L 363.693651 327.703519 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h82340dd1d7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h29179d1b81); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 428.987493 357.464 
 L 445.310953 357.464 
-L 445.310953 326.762408 
-L 428.987493 326.762408 
+L 445.310953 327.581941 
+L 428.987493 327.581941 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h82340dd1d7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h29179d1b81); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 494.281334 357.464 
 L 510.604795 357.464 
-L 510.604795 256.675748 
-L 494.281334 256.675748 
+L 510.604795 259.685644 
+L 494.281334 259.685644 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h82340dd1d7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h29179d1b81); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 559.575176 357.464 
 L 575.898636 357.464 
-L 575.898636 98.01046 
-L 559.575176 98.01046 
+L 575.898636 95.732198 
+L 559.575176 95.732198 
 z
-" clip-path="url(#pb7f36a82a5)" style="fill: url(#h82340dd1d7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9fbf49b019)" style="fill: url(#h29179d1b81); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_34">
-    <!-- 8.97 s -->
-    <g transform="translate(244.027073 267.736749)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_35">
+    <!-- 8.91 s -->
+    <g transform="translate(244.027073 270.858238) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 22.6 s -->
-    <g transform="translate(309.320915 139.030814)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 3.25 s -->
-    <g transform="translate(374.614756 321.725279)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+    <!-- 22.9 s -->
+    <g transform="translate(309.320915 142.184344) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_37">
     <!-- 3.25 s -->
-    <g transform="translate(439.908598 321.762408)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(374.614756 322.703519) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1704,8 +1710,19 @@ z
     </g>
    </g>
    <g id="text_38">
+    <!-- 3.26 s -->
+    <g transform="translate(439.908598 322.581941) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_39">
     <!-- 10.7 s -->
-    <g transform="translate(505.20244 251.675748)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(505.20244 254.685644) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
@@ -1714,20 +1731,20 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_39">
-    <!-- 27.5 s -->
-    <g transform="translate(570.496281 93.01046)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_40">
+    <!-- 28.6 s -->
+    <g transform="translate(570.496281 90.732198) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_40">
+   <g id="text_41">
     <!-- filled random n=1000 (calculate and render) -->
-    <g transform="translate(188.47 20.88)scale(0.12 -0.12)">
+    <g transform="translate(188.47 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
@@ -1830,9 +1847,9 @@ L 332.4513 41.896413
 z
 " style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_41">
+    <g id="text_42">
      <!-- mpl2005 no mask -->
-     <g transform="translate(360.4513 48.896413)scale(0.1 -0.1)">
+     <g transform="translate(360.4513 48.896413) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1856,11 +1873,11 @@ L 352.4513 63.574538
 L 352.4513 56.574538 
 L 332.4513 56.574538 
 z
-" style="fill: url(#h089ec38e12); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h054b80244d); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_42">
+    <g id="text_43">
      <!-- mpl2005 corner_mask=False -->
-     <g transform="translate(360.4513 63.574538)scale(0.1 -0.1)">
+     <g transform="translate(360.4513 63.574538) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-5f" d="M 3263 -1063 
 L 3263 -1509 
@@ -1918,9 +1935,9 @@ L 332.4513 71.530788
 z
 " style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_43">
+    <g id="text_44">
      <!-- mpl2014 no mask -->
-     <g transform="translate(360.4513 78.530788)scale(0.1 -0.1)">
+     <g transform="translate(360.4513 78.530788) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1944,11 +1961,11 @@ L 352.4513 93.208913
 L 352.4513 86.208913 
 L 332.4513 86.208913 
 z
-" style="fill: url(#hd477cc2839); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#haaa72b8eb4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_44">
+    <g id="text_45">
      <!-- mpl2014 corner_mask=False -->
-     <g transform="translate(360.4513 93.208913)scale(0.1 -0.1)">
+     <g transform="translate(360.4513 93.208913) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1982,11 +1999,11 @@ L 352.4513 108.165163
 L 352.4513 101.165163 
 L 332.4513 101.165163 
 z
-" style="fill: url(#hec7ac0a1df); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h2fe00aac5d); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_45">
+    <g id="text_46">
      <!-- mpl2014 corner_mask=True -->
-     <g transform="translate(360.4513 108.165163)scale(0.1 -0.1)">
+     <g transform="translate(360.4513 108.165163) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -2021,9 +2038,9 @@ L 332.4513 116.121413
 z
 " style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_46">
+    <g id="text_47">
      <!-- serial no mask -->
-     <g transform="translate(360.4513 123.121413)scale(0.1 -0.1)">
+     <g transform="translate(360.4513 123.121413) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2046,11 +2063,11 @@ L 352.4513 137.799538
 L 352.4513 130.799538 
 L 332.4513 130.799538 
 z
-" style="fill: url(#h12326bbec7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h3b85d69cc9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_47">
+    <g id="text_48">
      <!-- serial corner_mask=False -->
-     <g transform="translate(360.4513 137.799538)scale(0.1 -0.1)">
+     <g transform="translate(360.4513 137.799538) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2083,11 +2100,11 @@ L 352.4513 152.755788
 L 352.4513 145.755788 
 L 332.4513 145.755788 
 z
-" style="fill: url(#h82340dd1d7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h29179d1b81); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_48">
+    <g id="text_49">
      <!-- serial corner_mask=True -->
-     <g transform="translate(360.4513 152.755788)scale(0.1 -0.1)">
+     <g transform="translate(360.4513 152.755788) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2117,12 +2134,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pb7f36a82a5">
+  <clipPath id="p9fbf49b019">
    <rect x="44.57" y="26.88" width="556.63" height="330.584"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h089ec38e12" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h054b80244d" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2162,7 +2179,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hd477cc2839" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="haaa72b8eb4" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2202,7 +2219,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hec7ac0a1df" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h2fe00aac5d" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2244,7 +2261,7 @@ M 36 108
 L 108 36 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h12326bbec7" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h3b85d69cc9" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2284,7 +2301,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h82340dd1d7" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h29179d1b81" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/filled_simple_1000.svg
+++ b/docs/_static/filled_simple_1000.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:33.140270</dc:date>
+    <dc:date>2022-10-23T17:46:35.629797</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mfa23008fb7" d="M 0 0 
+       <path id="mbed9352b63" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfa23008fb7" x="102.96132" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbed9352b63" x="102.96132" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- mpl2005 -->
-      <g transform="translate(80.802726 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(80.802726 372.062437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -198,7 +198,7 @@ z
        <use xlink:href="#DejaVuSans-35" x="379.541016"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(88.764445 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(88.764445 383.26025) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -314,7 +314,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(90.159757 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(90.159757 394.458062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -395,12 +395,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mfa23008fb7" x="167.146657" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbed9352b63" x="167.146657" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- mpl2014 -->
-      <g transform="translate(144.988063 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(144.988063 372.062437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -445,7 +445,7 @@ z
        <use xlink:href="#DejaVuSans-34" x="379.541016"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(152.949782 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(152.949782 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -453,7 +453,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(154.345094 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(154.345094 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -464,12 +464,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mfa23008fb7" x="231.331994" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbed9352b63" x="231.331994" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- serial -->
-      <g transform="translate(217.753088 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(217.753088 372.062437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
@@ -557,7 +557,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(217.135119 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(217.135119 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -565,7 +565,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(218.530432 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(218.530432 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -576,12 +576,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mfa23008fb7" x="295.517331" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbed9352b63" x="295.517331" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- serial -->
-      <g transform="translate(281.938425 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(281.938425 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -590,7 +590,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(281.320456 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(281.320456 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -598,7 +598,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(280.419675 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(280.419675 394.458062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -634,12 +634,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mfa23008fb7" x="359.702669" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbed9352b63" x="359.702669" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- serial -->
-      <g transform="translate(346.123762 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(346.123762 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -648,7 +648,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(343.8097 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(343.8097 383.26025) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -710,7 +710,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(334.298762 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(334.298762 394.458062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -749,7 +749,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(346.901106 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(346.901106 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -760,12 +760,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mfa23008fb7" x="423.888006" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbed9352b63" x="423.888006" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- serial -->
-      <g transform="translate(410.3091 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(410.3091 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -774,7 +774,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(407.995037 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(407.995037 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -782,7 +782,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(398.4841 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(398.4841 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -793,7 +793,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(408.79035 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(408.79035 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -806,12 +806,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mfa23008fb7" x="488.073343" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbed9352b63" x="488.073343" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- serial -->
-      <g transform="translate(474.494437 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(474.494437 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -820,7 +820,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(472.180374 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(472.180374 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -828,7 +828,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(462.669437 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(462.669437 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -839,14 +839,14 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(475.271781 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(475.271781 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
        <use xlink:href="#DejaVuSans-65" x="194.482422"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(472.975687 416.853687)scale(0.1 -0.1)">
+      <g transform="translate(472.975687 416.853687) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -859,12 +859,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mfa23008fb7" x="552.25868" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbed9352b63" x="552.25868" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- serial -->
-      <g transform="translate(538.679774 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(538.679774 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -873,7 +873,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(536.365712 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(536.365712 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -881,7 +881,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(526.854774 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(526.854774 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -892,7 +892,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(537.161024 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(537.161024 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -901,7 +901,7 @@ z
        <use xlink:href="#DejaVuSans-74" x="262.744141"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(537.161024 416.853687)scale(0.1 -0.1)">
+      <g transform="translate(537.161024 416.853687) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -917,21 +917,21 @@ z
      <g id="line2d_9">
       <path d="M 54.02 357.464 
 L 601.2 357.464 
-" clip-path="url(#p9033ea9d10)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pcd24b1b549)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <defs>
-       <path id="m6309fd3ea0" d="M 0 0 
+       <path id="mb59fc166b2" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6309fd3ea0" x="54.02" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59fc166b2" x="54.02" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.00 -->
-      <g transform="translate(24.754375 361.263219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 361.263219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -950,18 +950,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_11">
-      <path d="M 54.02 302.813982 
-L 601.2 302.813982 
-" clip-path="url(#p9033ea9d10)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 305.81025 
+L 601.2 305.81025 
+" clip-path="url(#pcd24b1b549)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6309fd3ea0" x="54.02" y="302.813982" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59fc166b2" x="54.02" y="305.81025" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.05 -->
-      <g transform="translate(24.754375 306.613201)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 309.609469) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -971,18 +971,18 @@ L 601.2 302.813982
     </g>
     <g id="ytick_3">
      <g id="line2d_13">
-      <path d="M 54.02 248.163964 
-L 601.2 248.163964 
-" clip-path="url(#p9033ea9d10)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 254.1565 
+L 601.2 254.1565 
+" clip-path="url(#pcd24b1b549)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6309fd3ea0" x="54.02" y="248.163964" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59fc166b2" x="54.02" y="254.1565" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.10 -->
-      <g transform="translate(24.754375 251.963182)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 257.955719) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -992,18 +992,18 @@ L 601.2 248.163964
     </g>
     <g id="ytick_4">
      <g id="line2d_15">
-      <path d="M 54.02 193.513946 
-L 601.2 193.513946 
-" clip-path="url(#p9033ea9d10)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 202.50275 
+L 601.2 202.50275 
+" clip-path="url(#pcd24b1b549)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m6309fd3ea0" x="54.02" y="193.513946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59fc166b2" x="54.02" y="202.50275" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.15 -->
-      <g transform="translate(24.754375 197.313164)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 206.301969) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1013,18 +1013,18 @@ L 601.2 193.513946
     </g>
     <g id="ytick_5">
      <g id="line2d_17">
-      <path d="M 54.02 138.863927 
-L 601.2 138.863927 
-" clip-path="url(#p9033ea9d10)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 150.849 
+L 601.2 150.849 
+" clip-path="url(#pcd24b1b549)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m6309fd3ea0" x="54.02" y="138.863927" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59fc166b2" x="54.02" y="150.849" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.20 -->
-      <g transform="translate(24.754375 142.663146)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 154.648219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1034,18 +1034,18 @@ L 601.2 138.863927
     </g>
     <g id="ytick_6">
      <g id="line2d_19">
-      <path d="M 54.02 84.213909 
-L 601.2 84.213909 
-" clip-path="url(#p9033ea9d10)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 99.19525 
+L 601.2 99.19525 
+" clip-path="url(#pcd24b1b549)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m6309fd3ea0" x="54.02" y="84.213909" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59fc166b2" x="54.02" y="99.19525" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 88.013128)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 102.994469) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1055,18 +1055,18 @@ L 601.2 84.213909
     </g>
     <g id="ytick_7">
      <g id="line2d_21">
-      <path d="M 54.02 29.563891 
-L 601.2 29.563891 
-" clip-path="url(#p9033ea9d10)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 47.5415 
+L 601.2 47.5415 
+" clip-path="url(#pcd24b1b549)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m6309fd3ea0" x="54.02" y="29.563891" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59fc166b2" x="54.02" y="47.5415" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 0.30 -->
-      <g transform="translate(24.754375 33.36311)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 51.340719) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1110,7 +1110,7 @@ z
     </g>
     <g id="text_16">
      <!-- Time (seconds) -->
-     <g transform="translate(18.674688 230.333719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.674688 230.333719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1192,17 +1192,49 @@ z
    <g id="patch_3">
     <path d="M 78.891818 357.464 
 L 94.938152 357.464 
-L 94.938152 200.950114 
-L 78.891818 200.950114 
+L 94.938152 224.347389 
+L 78.891818 224.347389 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_17">
-    <!-- 143 ms -->
-    <g transform="translate(89.67436 195.950114)rotate(-90)scale(0.1 -0.1)">
+    <!-- 129 ms -->
+    <g transform="translate(89.67436 219.347389) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1211,14 +1243,33 @@ z
    <g id="patch_4">
     <path d="M 94.938152 357.464 
 L 110.984487 357.464 
-L 110.984487 198.300012 
-L 94.938152 198.300012 
+L 110.984487 222.774896 
+L 94.938152 222.774896 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#hd5d918bf45); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#h0fb468958a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_18">
-    <!-- 146 ms -->
-    <g transform="translate(105.720695 193.300012)rotate(-90)scale(0.1 -0.1)">
+    <!-- 130 ms -->
+    <g transform="translate(105.720695 217.774896) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 143.077155 357.464 
+L 159.12349 357.464 
+L 159.12349 87.808112 
+L 143.077155 87.808112 
+z
+" clip-path="url(#pcd24b1b549)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 261 ms -->
+    <g transform="translate(153.859698 82.808112) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1251,28 +1302,9 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 143.077155 357.464 
-L 159.12349 357.464 
-L 159.12349 71.244087 
-L 143.077155 71.244087 
-z
-" clip-path="url(#p9033ea9d10)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 262 ms -->
-    <g transform="translate(153.859698 66.244087)rotate(-90)scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1281,17 +1313,17 @@ z
    <g id="patch_6">
     <path d="M 159.12349 357.464 
 L 175.169824 357.464 
-L 175.169824 113.700769 
-L 159.12349 113.700769 
+L 175.169824 130.224313 
+L 159.12349 130.224313 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h52b5e5b408); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#h021b3b051f); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_20">
-    <!-- 223 ms -->
-    <g transform="translate(169.906032 108.700769)rotate(-90)scale(0.1 -0.1)">
+    <!-- 220 ms -->
+    <g transform="translate(169.906032 125.224313) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1300,14 +1332,14 @@ z
    <g id="patch_7">
     <path d="M 175.169824 357.464 
 L 191.216158 357.464 
-L 191.216158 108.002404 
-L 175.169824 108.002404 
+L 191.216158 122.056928 
+L 175.169824 122.056928 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h7045d592aa); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#h88cae817a9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_21">
     <!-- 228 ms -->
-    <g transform="translate(185.952366 103.002404)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(185.952366 117.056928) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1360,112 +1392,112 @@ z
    <g id="patch_8">
     <path d="M 207.262493 357.464 
 L 223.308827 357.464 
-L 223.308827 206.184069 
-L 207.262493 206.184069 
+L 223.308827 201.931739 
+L 207.262493 201.931739 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 271.44783 357.464 
 L 287.494164 357.464 
-L 287.494164 206.094993 
-L 271.44783 206.094993 
+L 287.494164 202.368109 
+L 271.44783 202.368109 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 335.633167 357.464 
 L 351.679501 357.464 
-L 351.679501 206.472563 
-L 335.633167 206.472563 
+L 351.679501 202.404787 
+L 335.633167 202.404787 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 399.818504 357.464 
 L 415.864839 357.464 
-L 415.864839 206.624077 
-L 399.818504 206.624077 
+L 415.864839 202.240686 
+L 399.818504 202.240686 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 464.003842 357.464 
 L 480.050176 357.464 
-L 480.050176 206.418051 
-L 464.003842 206.418051 
+L 480.050176 202.454522 
+L 464.003842 202.454522 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 528.189179 357.464 
 L 544.235513 357.464 
-L 544.235513 206.530601 
-L 528.189179 206.530601 
+L 544.235513 202.403323 
+L 528.189179 202.403323 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_22">
-    <!-- 138 ms -->
-    <g transform="translate(218.045035 201.184069)rotate(-90)scale(0.1 -0.1)">
+    <!-- 151 ms -->
+    <g transform="translate(218.045035 196.931739) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- 138 ms -->
-    <g transform="translate(282.230372 201.094993)rotate(-90)scale(0.1 -0.1)">
+    <!-- 150 ms -->
+    <g transform="translate(282.230372 197.368109) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 138 ms -->
-    <g transform="translate(346.415709 201.472563)rotate(-90)scale(0.1 -0.1)">
+    <!-- 150 ms -->
+    <g transform="translate(346.415709 197.404787) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 138 ms -->
-    <g transform="translate(410.601047 201.624077)rotate(-90)scale(0.1 -0.1)">
+    <!-- 150 ms -->
+    <g transform="translate(410.601047 197.240686) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 138 ms -->
-    <g transform="translate(474.786384 201.418051)rotate(-90)scale(0.1 -0.1)">
+    <!-- 150 ms -->
+    <g transform="translate(474.786384 197.454522) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- 138 ms -->
-    <g transform="translate(538.971721 201.530601)rotate(-90)scale(0.1 -0.1)">
+    <!-- 150 ms -->
+    <g transform="translate(538.971721 197.403323) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1474,124 +1506,112 @@ z
    <g id="patch_14">
     <path d="M 223.308827 357.464 
 L 239.355161 357.464 
-L 239.355161 218.250851 
-L 223.308827 218.250851 
+L 239.355161 214.456771 
+L 223.308827 214.456771 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h76070ba15f); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#h43e184840a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 287.494164 357.464 
 L 303.540499 357.464 
-L 303.540499 218.753042 
-L 287.494164 218.753042 
+L 303.540499 214.916362 
+L 287.494164 214.916362 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h76070ba15f); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#h43e184840a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 351.679501 357.464 
 L 367.725836 357.464 
-L 367.725836 219.019925 
-L 351.679501 219.019925 
+L 367.725836 214.770938 
+L 351.679501 214.770938 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h76070ba15f); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#h43e184840a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 415.864839 357.464 
 L 431.911173 357.464 
-L 431.911173 218.929849 
-L 415.864839 218.929849 
+L 431.911173 214.756061 
+L 415.864839 214.756061 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h76070ba15f); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#h43e184840a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 480.050176 357.464 
 L 496.09651 357.464 
-L 496.09651 218.809011 
-L 480.050176 218.809011 
+L 496.09651 214.761457 
+L 480.050176 214.761457 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h76070ba15f); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#h43e184840a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 544.235513 357.464 
 L 560.281848 357.464 
-L 560.281848 219.111489 
-L 544.235513 219.111489 
+L 560.281848 214.450261 
+L 544.235513 214.450261 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h76070ba15f); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#h43e184840a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_28">
-    <!-- 127 ms -->
-    <g transform="translate(234.091369 213.250851)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 138 ms -->
+    <g transform="translate(234.091369 209.456771) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 127 ms -->
-    <g transform="translate(298.276706 213.753042)rotate(-90)scale(0.1 -0.1)">
+    <!-- 138 ms -->
+    <g transform="translate(298.276706 209.916362) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 127 ms -->
-    <g transform="translate(362.462044 214.019925)rotate(-90)scale(0.1 -0.1)">
+    <!-- 138 ms -->
+    <g transform="translate(362.462044 209.770938) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 127 ms -->
-    <g transform="translate(426.647381 213.929849)rotate(-90)scale(0.1 -0.1)">
+    <!-- 138 ms -->
+    <g transform="translate(426.647381 209.756061) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 127 ms -->
-    <g transform="translate(490.832718 213.809011)rotate(-90)scale(0.1 -0.1)">
+    <!-- 138 ms -->
+    <g transform="translate(490.832718 209.761457) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 127 ms -->
-    <g transform="translate(555.018055 214.111489)rotate(-90)scale(0.1 -0.1)">
+    <!-- 138 ms -->
+    <g transform="translate(555.018055 209.450261) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1600,112 +1620,112 @@ z
    <g id="patch_20">
     <path d="M 239.355161 357.464 
 L 255.401496 357.464 
-L 255.401496 217.980335 
-L 239.355161 217.980335 
+L 255.401496 213.060825 
+L 239.355161 213.060825 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h56ebeb93f4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#ha66aae6d7e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 303.540499 357.464 
 L 319.586833 357.464 
-L 319.586833 218.106713 
-L 303.540499 218.106713 
+L 319.586833 213.29843 
+L 303.540499 213.29843 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h56ebeb93f4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#ha66aae6d7e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 367.725836 357.464 
 L 383.77217 357.464 
-L 383.77217 218.165286 
-L 367.725836 218.165286 
+L 383.77217 213.251935 
+L 367.725836 213.251935 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h56ebeb93f4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#ha66aae6d7e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 431.911173 357.464 
 L 447.957507 357.464 
-L 447.957507 217.81695 
-L 431.911173 217.81695 
+L 447.957507 213.422342 
+L 431.911173 213.422342 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h56ebeb93f4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#ha66aae6d7e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 496.09651 357.464 
 L 512.142845 357.464 
-L 512.142845 218.24423 
-L 496.09651 218.24423 
+L 512.142845 213.382326 
+L 496.09651 213.382326 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h56ebeb93f4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#ha66aae6d7e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 560.281848 357.464 
 L 576.328182 357.464 
-L 576.328182 218.318331 
-L 560.281848 218.318331 
+L 576.328182 213.089775 
+L 560.281848 213.089775 
 z
-" clip-path="url(#p9033ea9d10)" style="fill: url(#h56ebeb93f4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcd24b1b549)" style="fill: url(#ha66aae6d7e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_34">
-    <!-- 128 ms -->
-    <g transform="translate(250.137703 212.980335)rotate(-90)scale(0.1 -0.1)">
+    <!-- 140 ms -->
+    <g transform="translate(250.137703 208.060825) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 127 ms -->
-    <g transform="translate(314.323041 213.106713)rotate(-90)scale(0.1 -0.1)">
+    <!-- 140 ms -->
+    <g transform="translate(314.323041 208.29843) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 127 ms -->
-    <g transform="translate(378.508378 213.165286)rotate(-90)scale(0.1 -0.1)">
+    <!-- 140 ms -->
+    <g transform="translate(378.508378 208.251935) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 128 ms -->
-    <g transform="translate(442.693715 212.81695)rotate(-90)scale(0.1 -0.1)">
+    <!-- 139 ms -->
+    <g transform="translate(442.693715 208.422342) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 127 ms -->
-    <g transform="translate(506.879052 213.24423)rotate(-90)scale(0.1 -0.1)">
+    <!-- 139 ms -->
+    <g transform="translate(506.879052 208.382326) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 127 ms -->
-    <g transform="translate(571.06439 213.318331)rotate(-90)scale(0.1 -0.1)">
+    <!-- 140 ms -->
+    <g transform="translate(571.06439 208.089775) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1713,7 +1733,7 @@ z
    </g>
    <g id="text_40">
     <!-- filled simple n=1000  -->
-    <g transform="translate(263.370625 20.88)scale(0.12 -0.12)">
+    <g transform="translate(263.370625 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
@@ -1796,7 +1816,7 @@ z
     </g>
     <g id="text_41">
      <!-- mpl2005 no mask -->
-     <g transform="translate(447.19375 43.478437)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1820,11 +1840,11 @@ L 439.19375 58.156563
 L 439.19375 51.156563 
 L 419.19375 51.156563 
 z
-" style="fill: url(#hd5d918bf45); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h0fb468958a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_42">
      <!-- mpl2005 corner_mask=False -->
-     <g transform="translate(447.19375 58.156563)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 58.156563) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-5f" d="M 3263 -1063 
 L 3263 -1509 
@@ -1884,7 +1904,7 @@ z
     </g>
     <g id="text_43">
      <!-- mpl2014 no mask -->
-     <g transform="translate(447.19375 73.112812)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 73.112812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1908,11 +1928,11 @@ L 439.19375 87.790937
 L 439.19375 80.790937 
 L 419.19375 80.790937 
 z
-" style="fill: url(#h52b5e5b408); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h021b3b051f); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_44">
      <!-- mpl2014 corner_mask=False -->
-     <g transform="translate(447.19375 87.790937)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 87.790937) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1946,11 +1966,11 @@ L 439.19375 102.747187
 L 439.19375 95.747187 
 L 419.19375 95.747187 
 z
-" style="fill: url(#h7045d592aa); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h88cae817a9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_45">
      <!-- mpl2014 corner_mask=True -->
-     <g transform="translate(447.19375 102.747187)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 102.747187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1987,7 +2007,7 @@ z
     </g>
     <g id="text_46">
      <!-- serial no mask -->
-     <g transform="translate(447.19375 117.703437)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 117.703437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2010,11 +2030,11 @@ L 439.19375 132.381562
 L 439.19375 125.381562 
 L 419.19375 125.381562 
 z
-" style="fill: url(#h76070ba15f); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h43e184840a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_47">
      <!-- serial corner_mask=False -->
-     <g transform="translate(447.19375 132.381562)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 132.381562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2047,11 +2067,11 @@ L 439.19375 147.337812
 L 439.19375 140.337812 
 L 419.19375 140.337812 
 z
-" style="fill: url(#h56ebeb93f4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#ha66aae6d7e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_48">
      <!-- serial corner_mask=True -->
-     <g transform="translate(447.19375 147.337812)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 147.337812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2081,12 +2101,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p9033ea9d10">
+  <clipPath id="pcd24b1b549">
    <rect x="54.02" y="26.88" width="547.18" height="330.584"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="hd5d918bf45" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h0fb468958a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2126,7 +2146,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h52b5e5b408" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h021b3b051f" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2166,7 +2186,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h7045d592aa" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h88cae817a9" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2208,7 +2228,7 @@ M 36 108
 L 108 36 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h76070ba15f" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h43e184840a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2248,7 +2268,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h56ebeb93f4" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="ha66aae6d7e" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/filled_simple_1000_render.svg
+++ b/docs/_static/filled_simple_1000_render.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:33.314724</dc:date>
+    <dc:date>2022-10-23T17:46:35.784303</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m5af90ac04d" d="M 0 0 
+       <path id="m477d0b6dbb" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5af90ac04d" x="102.96132" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m477d0b6dbb" x="102.96132" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- mpl2005 -->
-      <g transform="translate(80.802726 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(80.802726 372.062437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -198,7 +198,7 @@ z
        <use xlink:href="#DejaVuSans-35" x="379.541016"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(88.764445 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(88.764445 383.26025) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -314,7 +314,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(90.159757 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(90.159757 394.458062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -395,12 +395,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m5af90ac04d" x="167.146657" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m477d0b6dbb" x="167.146657" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- mpl2014 -->
-      <g transform="translate(144.988063 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(144.988063 372.062437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -445,7 +445,7 @@ z
        <use xlink:href="#DejaVuSans-34" x="379.541016"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(152.949782 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(152.949782 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -453,7 +453,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(154.345094 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(154.345094 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -464,12 +464,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m5af90ac04d" x="231.331994" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m477d0b6dbb" x="231.331994" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- serial -->
-      <g transform="translate(217.753088 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(217.753088 372.062437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
@@ -557,7 +557,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(217.135119 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(217.135119 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -565,7 +565,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(218.530432 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(218.530432 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -576,12 +576,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5af90ac04d" x="295.517331" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m477d0b6dbb" x="295.517331" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- serial -->
-      <g transform="translate(281.938425 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(281.938425 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -590,7 +590,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Outer -->
-      <g transform="translate(281.320456 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(281.320456 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -598,7 +598,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(280.419675 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(280.419675 394.458062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -634,12 +634,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m5af90ac04d" x="359.702669" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m477d0b6dbb" x="359.702669" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- serial -->
-      <g transform="translate(346.123762 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(346.123762 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -648,7 +648,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(343.8097 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(343.8097 383.26025) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -710,7 +710,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(334.298762 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(334.298762 394.458062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -749,7 +749,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(346.901106 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(346.901106 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -760,12 +760,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5af90ac04d" x="423.888006" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m477d0b6dbb" x="423.888006" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- serial -->
-      <g transform="translate(410.3091 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(410.3091 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -774,7 +774,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(407.995037 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(407.995037 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -782,7 +782,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(398.4841 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(398.4841 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -793,7 +793,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(408.79035 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(408.79035 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -806,12 +806,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m5af90ac04d" x="488.073343" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m477d0b6dbb" x="488.073343" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- serial -->
-      <g transform="translate(474.494437 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(474.494437 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -820,7 +820,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(472.180374 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(472.180374 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -828,7 +828,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(462.669437 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(462.669437 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -839,14 +839,14 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(475.271781 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(475.271781 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
        <use xlink:href="#DejaVuSans-65" x="194.482422"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(472.975687 416.853687)scale(0.1 -0.1)">
+      <g transform="translate(472.975687 416.853687) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -859,12 +859,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5af90ac04d" x="552.25868" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m477d0b6dbb" x="552.25868" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- serial -->
-      <g transform="translate(538.679774 372.062437)scale(0.1 -0.1)">
+      <g transform="translate(538.679774 372.062437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -873,7 +873,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(536.365712 383.26025)scale(0.1 -0.1)">
+      <g transform="translate(536.365712 383.26025) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -881,7 +881,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(526.854774 394.458062)scale(0.1 -0.1)">
+      <g transform="translate(526.854774 394.458062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -892,7 +892,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(537.161024 405.655875)scale(0.1 -0.1)">
+      <g transform="translate(537.161024 405.655875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -901,7 +901,7 @@ z
        <use xlink:href="#DejaVuSans-74" x="262.744141"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(537.161024 416.853687)scale(0.1 -0.1)">
+      <g transform="translate(537.161024 416.853687) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -917,21 +917,21 @@ z
      <g id="line2d_9">
       <path d="M 54.02 357.464 
 L 601.2 357.464 
-" clip-path="url(#pfbae7b765c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <defs>
-       <path id="m247e600ab2" d="M 0 0 
+       <path id="m0893eba0d6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m247e600ab2" x="54.02" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0893eba0d6" x="54.02" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.00 -->
-      <g transform="translate(24.754375 361.263219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 361.263219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -950,18 +950,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_11">
-      <path d="M 54.02 320.138704 
-L 601.2 320.138704 
-" clip-path="url(#pfbae7b765c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 319.735978 
+L 601.2 319.735978 
+" clip-path="url(#p40b3b87ccf)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m247e600ab2" x="54.02" y="320.138704" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0893eba0d6" x="54.02" y="319.735978" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.05 -->
-      <g transform="translate(24.754375 323.937923)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 323.535197) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -971,18 +971,18 @@ L 601.2 320.138704
     </g>
     <g id="ytick_3">
      <g id="line2d_13">
-      <path d="M 54.02 282.813409 
-L 601.2 282.813409 
-" clip-path="url(#pfbae7b765c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 282.007957 
+L 601.2 282.007957 
+" clip-path="url(#p40b3b87ccf)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m247e600ab2" x="54.02" y="282.813409" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0893eba0d6" x="54.02" y="282.007957" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.10 -->
-      <g transform="translate(24.754375 286.612628)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 285.807176) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -992,18 +992,18 @@ L 601.2 282.813409
     </g>
     <g id="ytick_4">
      <g id="line2d_15">
-      <path d="M 54.02 245.488113 
-L 601.2 245.488113 
-" clip-path="url(#pfbae7b765c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 244.279935 
+L 601.2 244.279935 
+" clip-path="url(#p40b3b87ccf)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m247e600ab2" x="54.02" y="245.488113" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0893eba0d6" x="54.02" y="244.279935" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.15 -->
-      <g transform="translate(24.754375 249.287332)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 248.079154) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1013,18 +1013,18 @@ L 601.2 245.488113
     </g>
     <g id="ytick_5">
      <g id="line2d_17">
-      <path d="M 54.02 208.162818 
-L 601.2 208.162818 
-" clip-path="url(#pfbae7b765c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 206.551914 
+L 601.2 206.551914 
+" clip-path="url(#p40b3b87ccf)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m247e600ab2" x="54.02" y="208.162818" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0893eba0d6" x="54.02" y="206.551914" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.20 -->
-      <g transform="translate(24.754375 211.962037)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 210.351133) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1034,18 +1034,18 @@ L 601.2 208.162818
     </g>
     <g id="ytick_6">
      <g id="line2d_19">
-      <path d="M 54.02 170.837522 
-L 601.2 170.837522 
-" clip-path="url(#pfbae7b765c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 168.823892 
+L 601.2 168.823892 
+" clip-path="url(#p40b3b87ccf)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m247e600ab2" x="54.02" y="170.837522" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0893eba0d6" x="54.02" y="168.823892" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 174.636741)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 172.623111) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1055,18 +1055,18 @@ L 601.2 170.837522
     </g>
     <g id="ytick_7">
      <g id="line2d_21">
-      <path d="M 54.02 133.512227 
-L 601.2 133.512227 
-" clip-path="url(#pfbae7b765c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 131.095871 
+L 601.2 131.095871 
+" clip-path="url(#p40b3b87ccf)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m247e600ab2" x="54.02" y="133.512227" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0893eba0d6" x="54.02" y="131.095871" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 0.30 -->
-      <g transform="translate(24.754375 137.311446)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 134.89509) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1110,18 +1110,18 @@ z
     </g>
     <g id="ytick_8">
      <g id="line2d_23">
-      <path d="M 54.02 96.186931 
-L 601.2 96.186931 
-" clip-path="url(#pfbae7b765c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 93.367849 
+L 601.2 93.367849 
+" clip-path="url(#p40b3b87ccf)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m247e600ab2" x="54.02" y="96.186931" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0893eba0d6" x="54.02" y="93.367849" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 0.35 -->
-      <g transform="translate(24.754375 99.98615)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 97.167068) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-33" x="95.410156"/>
@@ -1131,18 +1131,18 @@ L 601.2 96.186931
     </g>
     <g id="ytick_9">
      <g id="line2d_25">
-      <path d="M 54.02 58.861636 
-L 601.2 58.861636 
-" clip-path="url(#pfbae7b765c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 55.639828 
+L 601.2 55.639828 
+" clip-path="url(#p40b3b87ccf)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m247e600ab2" x="54.02" y="58.861636" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0893eba0d6" x="54.02" y="55.639828" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- 0.40 -->
-      <g transform="translate(24.754375 62.660855)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 59.439047) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -1152,7 +1152,7 @@ L 601.2 58.861636
     </g>
     <g id="text_18">
      <!-- Time (seconds) -->
-     <g transform="translate(18.674688 230.333719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.674688 230.333719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1234,14 +1234,215 @@ z
    <g id="patch_3">
     <path d="M 78.891818 357.464 
 L 94.938152 357.464 
-L 94.938152 159.326361 
-L 78.891818 159.326361 
+L 94.938152 169.830791 
+L 78.891818 169.830791 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_19">
-    <!-- 265 ms -->
-    <g transform="translate(89.67436 154.326361)rotate(-90)scale(0.1 -0.1)">
+    <!-- 249 ms -->
+    <g transform="translate(89.67436 164.830791) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 94.938152 357.464 
+L 110.984487 357.464 
+L 110.984487 172.955394 
+L 94.938152 172.955394 
+z
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#h90cb3beff1); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 245 ms -->
+    <g transform="translate(105.720695 167.955394) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 143.077155 357.464 
+L 159.12349 357.464 
+L 159.12349 71.244087 
+L 143.077155 71.244087 
+z
+" clip-path="url(#p40b3b87ccf)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 379 ms -->
+    <g transform="translate(153.859698 66.244087) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 159.12349 357.464 
+L 175.169824 357.464 
+L 175.169824 104.615551 
+L 159.12349 104.615551 
+z
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#haf57c61a54); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 335 ms -->
+    <g transform="translate(169.906032 99.615551) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 175.169824 357.464 
+L 191.216158 357.464 
+L 191.216158 99.974379 
+L 175.169824 99.974379 
+z
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#hc1aa0fbdc7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_23">
+    <!-- 341 ms -->
+    <g transform="translate(185.952366 94.974379) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 207.262493 357.464 
+L 223.308827 357.464 
+L 223.308827 153.779136 
+L 207.262493 153.779136 
+z
+" clip-path="url(#p40b3b87ccf)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 271.44783 357.464 
+L 287.494164 357.464 
+L 287.494164 153.083888 
+L 271.44783 153.083888 
+z
+" clip-path="url(#p40b3b87ccf)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 335.633167 357.464 
+L 351.679501 357.464 
+L 351.679501 154.505579 
+L 335.633167 154.505579 
+z
+" clip-path="url(#p40b3b87ccf)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 399.818504 357.464 
+L 415.864839 357.464 
+L 415.864839 153.895126 
+L 399.818504 153.895126 
+z
+" clip-path="url(#p40b3b87ccf)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 464.003842 357.464 
+L 480.050176 357.464 
+L 480.050176 153.381843 
+L 464.003842 153.381843 
+z
+" clip-path="url(#p40b3b87ccf)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 528.189179 357.464 
+L 544.235513 357.464 
+L 544.235513 152.729091 
+L 528.189179 152.729091 
+z
+" clip-path="url(#p40b3b87ccf)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_24">
+    <!-- 270 ms -->
+    <g transform="translate(218.045035 148.779136) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 271 ms -->
+    <g transform="translate(282.230372 148.083888) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 269 ms -->
+    <g transform="translate(346.415709 149.505579) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1276,258 +1477,28 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_4">
-    <path d="M 94.938152 357.464 
-L 110.984487 357.464 
-L 110.984487 161.968274 
-L 94.938152 161.968274 
-z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#h66fb9d94a8); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 262 ms -->
-    <g transform="translate(105.720695 156.968274)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 143.077155 357.464 
-L 159.12349 357.464 
-L 159.12349 71.244087 
-L 143.077155 71.244087 
-z
-" clip-path="url(#pfbae7b765c)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 383 ms -->
-    <g transform="translate(153.859698 66.244087)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 159.12349 357.464 
-L 175.169824 357.464 
-L 175.169824 103.853911 
-L 159.12349 103.853911 
-z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#hab78d5dfc3); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 340 ms -->
-    <g transform="translate(169.906032 98.853911)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 175.169824 357.464 
-L 191.216158 357.464 
-L 191.216158 100.248545 
-L 175.169824 100.248545 
-z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#h617822ae69); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_23">
-    <!-- 345 ms -->
-    <g transform="translate(185.952366 95.248545)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 207.262493 357.464 
-L 223.308827 357.464 
-L 223.308827 164.454736 
-L 207.262493 164.454736 
-z
-" clip-path="url(#pfbae7b765c)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 271.44783 357.464 
-L 287.494164 357.464 
-L 287.494164 163.419293 
-L 271.44783 163.419293 
-z
-" clip-path="url(#pfbae7b765c)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 335.633167 357.464 
-L 351.679501 357.464 
-L 351.679501 164.660982 
-L 335.633167 164.660982 
-z
-" clip-path="url(#pfbae7b765c)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 399.818504 357.464 
-L 415.864839 357.464 
-L 415.864839 164.171855 
-L 399.818504 164.171855 
-z
-" clip-path="url(#pfbae7b765c)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 464.003842 357.464 
-L 480.050176 357.464 
-L 480.050176 163.65931 
-L 464.003842 163.65931 
-z
-" clip-path="url(#pfbae7b765c)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 528.189179 357.464 
-L 544.235513 357.464 
-L 544.235513 162.851133 
-L 528.189179 162.851133 
-z
-" clip-path="url(#pfbae7b765c)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_24">
-    <!-- 259 ms -->
-    <g transform="translate(218.045035 159.454736)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 260 ms -->
-    <g transform="translate(282.230372 158.419293)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 258 ms -->
-    <g transform="translate(346.415709 159.660982)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- 259 ms -->
-    <g transform="translate(410.601047 159.171855)rotate(-90)scale(0.1 -0.1)">
+    <!-- 270 ms -->
+    <g transform="translate(410.601047 148.895126) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 260 ms -->
-    <g transform="translate(474.786384 158.65931)rotate(-90)scale(0.1 -0.1)">
+    <!-- 270 ms -->
+    <g transform="translate(474.786384 148.381843) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1535,10 +1506,10 @@ z
     </g>
    </g>
    <g id="text_29">
-    <!-- 261 ms -->
-    <g transform="translate(538.971721 157.851133)rotate(-90)scale(0.1 -0.1)">
+    <!-- 271 ms -->
+    <g transform="translate(538.971721 147.729091) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
      <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1548,56 +1519,56 @@ z
    <g id="patch_14">
     <path d="M 223.308827 357.464 
 L 239.355161 357.464 
-L 239.355161 176.419483 
-L 223.308827 176.419483 
+L 239.355161 166.571125 
+L 223.308827 166.571125 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#ha0e844e074); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#h10c77173e2); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 287.494164 357.464 
 L 303.540499 357.464 
-L 303.540499 174.909396 
-L 287.494164 174.909396 
+L 303.540499 165.194318 
+L 287.494164 165.194318 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#ha0e844e074); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#h10c77173e2); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 351.679501 357.464 
 L 367.725836 357.464 
-L 367.725836 176.5858 
-L 351.679501 176.5858 
+L 367.725836 167.52849 
+L 351.679501 167.52849 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#ha0e844e074); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#h10c77173e2); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 415.864839 357.464 
 L 431.911173 357.464 
-L 431.911173 176.02685 
-L 415.864839 176.02685 
+L 431.911173 166.543778 
+L 415.864839 166.543778 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#ha0e844e074); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#h10c77173e2); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 480.050176 357.464 
 L 496.09651 357.464 
-L 496.09651 175.48761 
-L 480.050176 175.48761 
+L 496.09651 166.186594 
+L 480.050176 166.186594 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#ha0e844e074); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#h10c77173e2); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 544.235513 357.464 
 L 560.281848 357.464 
-L 560.281848 174.310399 
-L 544.235513 174.310399 
+L 560.281848 165.057881 
+L 544.235513 165.057881 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#ha0e844e074); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#h10c77173e2); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_30">
-    <!-- 243 ms -->
-    <g transform="translate(234.091369 171.419483)rotate(-90)scale(0.1 -0.1)">
+    <!-- 253 ms -->
+    <g transform="translate(234.091369 161.571125) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1605,10 +1576,10 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 245 ms -->
-    <g transform="translate(298.276706 169.909396)rotate(-90)scale(0.1 -0.1)">
+    <!-- 255 ms -->
+    <g transform="translate(298.276706 160.194318) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1616,10 +1587,10 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 242 ms -->
-    <g transform="translate(362.462044 171.5858)rotate(-90)scale(0.1 -0.1)">
+    <!-- 252 ms -->
+    <g transform="translate(362.462044 162.52849) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1627,10 +1598,10 @@ z
     </g>
    </g>
    <g id="text_33">
-    <!-- 243 ms -->
-    <g transform="translate(426.647381 171.02685)rotate(-90)scale(0.1 -0.1)">
+    <!-- 253 ms -->
+    <g transform="translate(426.647381 161.543778) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1638,21 +1609,21 @@ z
     </g>
    </g>
    <g id="text_34">
-    <!-- 244 ms -->
-    <g transform="translate(490.832718 170.48761)rotate(-90)scale(0.1 -0.1)">
+    <!-- 253 ms -->
+    <g transform="translate(490.832718 161.186594) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 245 ms -->
-    <g transform="translate(555.018055 169.310399)rotate(-90)scale(0.1 -0.1)">
+    <!-- 255 ms -->
+    <g transform="translate(555.018055 160.057881) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1662,89 +1633,89 @@ z
    <g id="patch_20">
     <path d="M 239.355161 357.464 
 L 255.401496 357.464 
-L 255.401496 175.90017 
-L 239.355161 175.90017 
+L 255.401496 165.706921 
+L 239.355161 165.706921 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#h73eddd402e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#hafcbc31840); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 303.540499 357.464 
 L 319.586833 357.464 
-L 319.586833 174.283445 
-L 303.540499 174.283445 
+L 319.586833 164.669525 
+L 303.540499 164.669525 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#h73eddd402e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#hafcbc31840); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 367.725836 357.464 
 L 383.77217 357.464 
-L 383.77217 176.086928 
-L 367.725836 176.086928 
+L 383.77217 166.060625 
+L 367.725836 166.060625 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#h73eddd402e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#hafcbc31840); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 431.911173 357.464 
 L 447.957507 357.464 
-L 447.957507 175.638087 
-L 431.911173 175.638087 
+L 447.957507 165.737367 
+L 431.911173 165.737367 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#h73eddd402e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#hafcbc31840); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 496.09651 357.464 
 L 512.142845 357.464 
-L 512.142845 174.518055 
-L 496.09651 174.518055 
+L 512.142845 165.344362 
+L 496.09651 165.344362 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#h73eddd402e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#hafcbc31840); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 560.281848 357.464 
 L 576.328182 357.464 
-L 576.328182 173.331992 
-L 560.281848 173.331992 
+L 576.328182 164.264371 
+L 560.281848 164.264371 
 z
-" clip-path="url(#pfbae7b765c)" style="fill: url(#h73eddd402e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p40b3b87ccf)" style="fill: url(#hafcbc31840); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_36">
-    <!-- 243 ms -->
-    <g transform="translate(250.137703 170.90017)rotate(-90)scale(0.1 -0.1)">
+    <!-- 254 ms -->
+    <g transform="translate(250.137703 160.706921) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 245 ms -->
-    <g transform="translate(314.323041 169.283445)rotate(-90)scale(0.1 -0.1)">
+    <!-- 256 ms -->
+    <g transform="translate(314.323041 159.669525) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 243 ms -->
-    <g transform="translate(378.508378 171.086928)rotate(-90)scale(0.1 -0.1)">
+    <!-- 254 ms -->
+    <g transform="translate(378.508378 161.060625) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 244 ms -->
-    <g transform="translate(442.693715 170.638087)rotate(-90)scale(0.1 -0.1)">
+    <!-- 254 ms -->
+    <g transform="translate(442.693715 160.737367) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1752,10 +1723,10 @@ z
     </g>
    </g>
    <g id="text_40">
-    <!-- 245 ms -->
-    <g transform="translate(506.879052 169.518055)rotate(-90)scale(0.1 -0.1)">
+    <!-- 255 ms -->
+    <g transform="translate(506.879052 160.344362) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1763,23 +1734,11 @@ z
     </g>
    </g>
    <g id="text_41">
-    <!-- 247 ms -->
-    <g transform="translate(571.06439 168.331992)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 256 ms -->
+    <g transform="translate(571.06439 159.264371) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1787,7 +1746,7 @@ z
    </g>
    <g id="text_42">
     <!-- filled simple n=1000 (calculate and render) -->
-    <g transform="translate(196.660938 20.88)scale(0.12 -0.12)">
+    <g transform="translate(196.660938 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
@@ -1892,7 +1851,7 @@ z
     </g>
     <g id="text_43">
      <!-- mpl2005 no mask -->
-     <g transform="translate(447.19375 242.246813)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 242.246813) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1916,11 +1875,11 @@ L 439.19375 256.924938
 L 439.19375 249.924938 
 L 419.19375 249.924938 
 z
-" style="fill: url(#h66fb9d94a8); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h90cb3beff1); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_44">
      <!-- mpl2005 corner_mask=False -->
-     <g transform="translate(447.19375 256.924938)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 256.924938) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-5f" d="M 3263 -1063 
 L 3263 -1509 
@@ -1980,7 +1939,7 @@ z
     </g>
     <g id="text_45">
      <!-- mpl2014 no mask -->
-     <g transform="translate(447.19375 271.881188)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 271.881188) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -2004,11 +1963,11 @@ L 439.19375 286.559313
 L 439.19375 279.559313 
 L 419.19375 279.559313 
 z
-" style="fill: url(#hab78d5dfc3); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#haf57c61a54); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_46">
      <!-- mpl2014 corner_mask=False -->
-     <g transform="translate(447.19375 286.559313)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 286.559313) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -2042,11 +2001,11 @@ L 439.19375 301.515563
 L 439.19375 294.515563 
 L 419.19375 294.515563 
 z
-" style="fill: url(#h617822ae69); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hc1aa0fbdc7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_47">
      <!-- mpl2014 corner_mask=True -->
-     <g transform="translate(447.19375 301.515563)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 301.515563) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -2083,7 +2042,7 @@ z
     </g>
     <g id="text_48">
      <!-- serial no mask -->
-     <g transform="translate(447.19375 316.471813)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 316.471813) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2106,11 +2065,11 @@ L 439.19375 331.149938
 L 439.19375 324.149938 
 L 419.19375 324.149938 
 z
-" style="fill: url(#ha0e844e074); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h10c77173e2); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_49">
      <!-- serial corner_mask=False -->
-     <g transform="translate(447.19375 331.149938)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 331.149938) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2143,11 +2102,11 @@ L 439.19375 346.106188
 L 439.19375 339.106188 
 L 419.19375 339.106188 
 z
-" style="fill: url(#h73eddd402e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hafcbc31840); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_50">
      <!-- serial corner_mask=True -->
-     <g transform="translate(447.19375 346.106188)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 346.106188) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2177,12 +2136,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pfbae7b765c">
+  <clipPath id="p40b3b87ccf">
    <rect x="54.02" y="26.88" width="547.18" height="330.584"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h66fb9d94a8" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h90cb3beff1" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2222,7 +2181,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hab78d5dfc3" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="haf57c61a54" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2262,7 +2221,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h617822ae69" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hc1aa0fbdc7" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2304,7 +2263,7 @@ M 36 108
 L 108 36 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="ha0e844e074" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h10c77173e2" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2344,7 +2303,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h73eddd402e" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hafcbc31840" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/lines_random_1000.svg
+++ b/docs/_static/lines_random_1000.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:32.215710</dc:date>
+    <dc:date>2022-10-23T17:46:34.749578</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m637b69b0e1" d="M 0 0 
+       <path id="m2e8eb2362f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m637b69b0e1" x="105.773775" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e8eb2362f" x="105.773775" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- mpl2005 -->
-      <g transform="translate(83.615181 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(83.615181 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -198,7 +198,7 @@ z
        <use xlink:href="#DejaVuSans-35" x="379.541016"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(83.128462 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(83.128462 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
@@ -338,7 +338,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(92.972212 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(92.972212 406.122063) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -419,12 +419,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m637b69b0e1" x="193.266265" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e8eb2362f" x="193.266265" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- mpl2014 -->
-      <g transform="translate(171.107671 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(171.107671 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -469,7 +469,7 @@ z
        <use xlink:href="#DejaVuSans-34" x="379.541016"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(170.620952 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(170.620952 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -480,7 +480,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(180.464702 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(180.464702 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -491,12 +491,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m637b69b0e1" x="280.758755" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e8eb2362f" x="280.758755" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- serial -->
-      <g transform="translate(267.179849 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(267.179849 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
@@ -551,7 +551,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(258.113442 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(258.113442 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -566,12 +566,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m637b69b0e1" x="368.251245" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e8eb2362f" x="368.251245" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- serial -->
-      <g transform="translate(354.672339 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(354.672339 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -580,7 +580,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(345.605933 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(345.605933 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -591,7 +591,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(355.449683 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(355.449683 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -602,12 +602,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m637b69b0e1" x="455.743735" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e8eb2362f" x="455.743735" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- serial -->
-      <g transform="translate(442.164829 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(442.164829 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -616,7 +616,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(439.850766 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(439.850766 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -700,7 +700,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(430.339829 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(430.339829 406.122063) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -739,7 +739,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(442.942173 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(442.942173 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -750,12 +750,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m637b69b0e1" x="543.236225" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e8eb2362f" x="543.236225" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- serial -->
-      <g transform="translate(529.657319 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(529.657319 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -764,7 +764,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(527.343257 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(527.343257 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -772,7 +772,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(517.832319 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(517.832319 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -783,7 +783,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(528.138569 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(528.138569 417.319875) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -843,21 +843,21 @@ z
      <g id="line2d_7">
       <path d="M 47.81 369.128 
 L 601.2 369.128 
-" clip-path="url(#p81b2e485e0)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="md45c4d59d1" d="M 0 0 
+       <path id="m7d6f797faa" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md45c4d59d1" x="47.81" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d6f797faa" x="47.81" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.0 -->
-      <g transform="translate(24.906875 372.927219)scale(0.1 -0.1)">
+      <g transform="translate(24.906875 372.927219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -875,18 +875,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 47.81 330.432227 
-L 601.2 330.432227 
-" clip-path="url(#p81b2e485e0)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.81 330.628608 
+L 601.2 330.628608 
+" clip-path="url(#p2c60bd8a19)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#md45c4d59d1" x="47.81" y="330.432227" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d6f797faa" x="47.81" y="330.628608" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.2 -->
-      <g transform="translate(24.906875 334.231445)scale(0.1 -0.1)">
+      <g transform="translate(24.906875 334.427826) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -895,18 +895,18 @@ L 601.2 330.432227
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 47.81 291.736453 
-L 601.2 291.736453 
-" clip-path="url(#p81b2e485e0)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.81 292.129215 
+L 601.2 292.129215 
+" clip-path="url(#p2c60bd8a19)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#md45c4d59d1" x="47.81" y="291.736453" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d6f797faa" x="47.81" y="292.129215" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.4 -->
-      <g transform="translate(24.906875 295.535672)scale(0.1 -0.1)">
+      <g transform="translate(24.906875 295.928434) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -915,18 +915,18 @@ L 601.2 291.736453
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 47.81 253.04068 
-L 601.2 253.04068 
-" clip-path="url(#p81b2e485e0)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.81 253.629823 
+L 601.2 253.629823 
+" clip-path="url(#p2c60bd8a19)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md45c4d59d1" x="47.81" y="253.04068" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d6f797faa" x="47.81" y="253.629823" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.6 -->
-      <g transform="translate(24.906875 256.839899)scale(0.1 -0.1)">
+      <g transform="translate(24.906875 257.429041) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -967,18 +967,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 47.81 214.344907 
-L 601.2 214.344907 
-" clip-path="url(#p81b2e485e0)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.81 215.13043 
+L 601.2 215.13043 
+" clip-path="url(#p2c60bd8a19)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md45c4d59d1" x="47.81" y="214.344907" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d6f797faa" x="47.81" y="215.13043" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.8 -->
-      <g transform="translate(24.906875 218.144126)scale(0.1 -0.1)">
+      <g transform="translate(24.906875 218.929649) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1028,18 +1028,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 47.81 175.649133 
-L 601.2 175.649133 
-" clip-path="url(#p81b2e485e0)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.81 176.631038 
+L 601.2 176.631038 
+" clip-path="url(#p2c60bd8a19)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md45c4d59d1" x="47.81" y="175.649133" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d6f797faa" x="47.81" y="176.631038" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.0 -->
-      <g transform="translate(24.906875 179.448352)scale(0.1 -0.1)">
+      <g transform="translate(24.906875 180.430257) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1048,18 +1048,18 @@ L 601.2 175.649133
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 47.81 136.95336 
-L 601.2 136.95336 
-" clip-path="url(#p81b2e485e0)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.81 138.131645 
+L 601.2 138.131645 
+" clip-path="url(#p2c60bd8a19)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md45c4d59d1" x="47.81" y="136.95336" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d6f797faa" x="47.81" y="138.131645" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.2 -->
-      <g transform="translate(24.906875 140.752579)scale(0.1 -0.1)">
+      <g transform="translate(24.906875 141.930864) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1068,18 +1068,18 @@ L 601.2 136.95336
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 47.81 98.257587 
-L 601.2 98.257587 
-" clip-path="url(#p81b2e485e0)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.81 99.632253 
+L 601.2 99.632253 
+" clip-path="url(#p2c60bd8a19)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md45c4d59d1" x="47.81" y="98.257587" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d6f797faa" x="47.81" y="99.632253" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 1.4 -->
-      <g transform="translate(24.906875 102.056806)scale(0.1 -0.1)">
+      <g transform="translate(24.906875 103.431472) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -1088,18 +1088,18 @@ L 601.2 98.257587
     </g>
     <g id="ytick_9">
      <g id="line2d_23">
-      <path d="M 47.81 59.561814 
-L 601.2 59.561814 
-" clip-path="url(#p81b2e485e0)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.81 61.13286 
+L 601.2 61.13286 
+" clip-path="url(#p2c60bd8a19)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md45c4d59d1" x="47.81" y="59.561814" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d6f797faa" x="47.81" y="61.13286" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 1.6 -->
-      <g transform="translate(24.906875 63.361032)scale(0.1 -0.1)">
+      <g transform="translate(24.906875 64.932079) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-36" x="95.410156"/>
@@ -1108,7 +1108,7 @@ L 601.2 59.561814
     </g>
     <g id="text_16">
      <!-- Time (seconds) -->
-     <g transform="translate(18.827188 236.165719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.827188 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1190,14 +1190,14 @@ z
    <g id="patch_3">
     <path d="M 72.964091 369.128 
 L 94.837213 369.128 
-L 94.837213 112.322074 
-L 72.964091 112.322074 
+L 94.837213 111.312832 
+L 72.964091 111.312832 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_17">
-    <!-- 1.33 s -->
-    <g transform="translate(86.660027 107.322074)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.34 s -->
+    <g transform="translate(86.660027 106.312832) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1235,7 +1235,7 @@ z
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1246,15 +1246,15 @@ L 116.710336 369.128
 L 116.710336 72.809385 
 L 94.837213 72.809385 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: url(#hc6bc6f1db7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: url(#ha3bd909c72); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_18">
-    <!-- 1.53 s -->
-    <g transform="translate(108.53315 67.809385)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.54 s -->
+    <g transform="translate(108.53315 67.809385) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1262,14 +1262,14 @@ z
    <g id="patch_5">
     <path d="M 160.456581 369.128 
 L 182.329704 369.128 
-L 182.329704 152.721128 
-L 160.456581 152.721128 
+L 182.329704 152.985405 
+L 160.456581 152.985405 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_19">
     <!-- 1.12 s -->
-    <g transform="translate(174.152517 147.721128)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(174.152517 147.985405) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1281,18 +1281,18 @@ z
    <g id="patch_6">
     <path d="M 182.329704 369.128 
 L 204.202826 369.128 
-L 204.202826 111.135245 
-L 182.329704 111.135245 
+L 204.202826 111.488239 
+L 182.329704 111.488239 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: url(#h68a322ff0c); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: url(#hfe2f74c604); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_20">
-    <!-- 1.33 s -->
-    <g transform="translate(196.02564 106.135245)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.34 s -->
+    <g transform="translate(196.02564 106.488239) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1300,80 +1300,14 @@ z
    <g id="patch_7">
     <path d="M 204.202826 369.128 
 L 226.075949 369.128 
-L 226.075949 120.964186 
-L 204.202826 120.964186 
+L 226.075949 120.385775 
+L 204.202826 120.385775 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: url(#h226890a923); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: url(#hf3f1feff2f); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_21">
-    <!-- 1.28 s -->
-    <g transform="translate(217.898762 115.964186)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 247.949071 369.128 
-L 269.822194 369.128 
-L 269.822194 205.19229 
-L 247.949071 205.19229 
-z
-" clip-path="url(#p81b2e485e0)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 335.441561 369.128 
-L 357.314684 369.128 
-L 357.314684 138.806112 
-L 335.441561 138.806112 
-z
-" clip-path="url(#p81b2e485e0)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 422.934051 369.128 
-L 444.807174 369.128 
-L 444.807174 270.221035 
-L 422.934051 270.221035 
-z
-" clip-path="url(#p81b2e485e0)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 510.426542 369.128 
-L 532.299664 369.128 
-L 532.299664 272.525245 
-L 510.426542 272.525245 
-z
-" clip-path="url(#p81b2e485e0)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 847 ms -->
-    <g transform="translate(261.645007 200.19229)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 1.19 s -->
-    <g transform="translate(349.137498 133.806112)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.29 s -->
+    <g transform="translate(217.898762 115.385775) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1408,6 +1342,60 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 247.949071 369.128 
+L 269.822194 369.128 
+L 269.822194 206.511725 
+L 247.949071 206.511725 
+z
+" clip-path="url(#p2c60bd8a19)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 335.441561 369.128 
+L 357.314684 369.128 
+L 357.314684 140.013943 
+L 335.441561 140.013943 
+z
+" clip-path="url(#p2c60bd8a19)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 422.934051 369.128 
+L 444.807174 369.128 
+L 444.807174 272.113309 
+L 422.934051 272.113309 
+z
+" clip-path="url(#p2c60bd8a19)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 510.426542 369.128 
+L 532.299664 369.128 
+L 532.299664 273.691482 
+L 510.426542 273.691482 
+z
+" clip-path="url(#p2c60bd8a19)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 845 ms -->
+    <g transform="translate(261.645007 201.511725) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 1.19 s -->
+    <g transform="translate(349.137498 135.013943) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-31" x="95.410156"/>
      <use xlink:href="#DejaVuSans-39" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1415,22 +1403,22 @@ z
     </g>
    </g>
    <g id="text_24">
-    <!-- 511 ms -->
-    <g transform="translate(436.629988 265.221035)rotate(-90)scale(0.1 -0.1)">
+    <!-- 504 ms -->
+    <g transform="translate(436.629988 267.113309) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 499 ms -->
-    <g transform="translate(524.122478 267.525245)rotate(-90)scale(0.1 -0.1)">
+    <!-- 496 ms -->
+    <g transform="translate(524.122478 268.691482) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1439,41 +1427,53 @@ z
    <g id="patch_12">
     <path d="M 269.822194 369.128 
 L 291.695316 369.128 
-L 291.695316 192.64268 
-L 269.822194 192.64268 
+L 291.695316 192.566921 
+L 269.822194 192.566921 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: url(#h2780e6f214); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: url(#hebc7af5b53); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 357.314684 369.128 
 L 379.187806 369.128 
-L 379.187806 116.459397 
-L 357.314684 116.459397 
+L 379.187806 116.046856 
+L 357.314684 116.046856 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: url(#h2780e6f214); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: url(#hebc7af5b53); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 444.807174 369.128 
 L 466.680296 369.128 
-L 466.680296 268.460866 
-L 444.807174 268.460866 
+L 466.680296 269.689387 
+L 444.807174 269.689387 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: url(#h2780e6f214); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: url(#hebc7af5b53); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 532.299664 369.128 
 L 554.172787 369.128 
-L 554.172787 271.354476 
-L 532.299664 271.354476 
+L 554.172787 271.920365 
+L 532.299664 271.920365 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: url(#h2780e6f214); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: url(#hebc7af5b53); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_26">
-    <!-- 912 ms -->
-    <g transform="translate(283.51813 187.64268)rotate(-90)scale(0.1 -0.1)">
+    <!-- 917 ms -->
+    <g transform="translate(283.51813 187.566921) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1481,7 +1481,7 @@ z
    </g>
    <g id="text_27">
     <!-- 1.31 s -->
-    <g transform="translate(371.01062 111.459397)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(371.01062 111.046856) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="95.410156"/>
@@ -1491,11 +1491,11 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 520 ms -->
-    <g transform="translate(458.50311 263.460866)rotate(-90)scale(0.1 -0.1)">
+    <!-- 517 ms -->
+    <g transform="translate(458.50311 264.689387) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1503,7 +1503,7 @@ z
    </g>
    <g id="text_29">
     <!-- 505 ms -->
-    <g transform="translate(545.9956 266.354476)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(545.9956 266.920365) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
@@ -1515,41 +1515,41 @@ z
    <g id="patch_16">
     <path d="M 291.695316 369.128 
 L 313.568439 369.128 
-L 313.568439 194.741847 
-L 291.695316 194.741847 
+L 313.568439 195.169716 
+L 291.695316 195.169716 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: url(#h6da96af3f9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: url(#h6938ab5d80); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 379.187806 369.128 
 L 401.060929 369.128 
-L 401.060929 125.286115 
-L 379.187806 125.286115 
+L 401.060929 126.529361 
+L 379.187806 126.529361 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: url(#h6da96af3f9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: url(#h6938ab5d80); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 466.680296 369.128 
 L 488.553419 369.128 
-L 488.553419 262.061321 
-L 466.680296 262.061321 
+L 488.553419 263.652215 
+L 466.680296 263.652215 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: url(#h6da96af3f9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: url(#h6938ab5d80); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 554.172787 369.128 
 L 576.045909 369.128 
-L 576.045909 264.590286 
-L 554.172787 264.590286 
+L 576.045909 265.752696 
+L 554.172787 265.752696 
 z
-" clip-path="url(#p81b2e485e0)" style="fill: url(#h6da96af3f9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2c60bd8a19)" style="fill: url(#h6938ab5d80); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_30">
-    <!-- 901 ms -->
-    <g transform="translate(305.391252 189.741847)rotate(-90)scale(0.1 -0.1)">
+    <!-- 904 ms -->
+    <g transform="translate(305.391252 190.169716) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1557,7 +1557,7 @@ z
    </g>
    <g id="text_31">
     <!-- 1.26 s -->
-    <g transform="translate(392.883743 120.286115)rotate(-90)scale(0.1 -0.1)">
+    <g transform="translate(392.883743 121.529361) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1567,22 +1567,22 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 553 ms -->
-    <g transform="translate(480.376233 257.061321)rotate(-90)scale(0.1 -0.1)">
+    <!-- 548 ms -->
+    <g transform="translate(480.376233 258.652215) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 540 ms -->
-    <g transform="translate(567.868723 259.590286)rotate(-90)scale(0.1 -0.1)">
+    <!-- 537 ms -->
+    <g transform="translate(567.868723 260.752696) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1590,7 +1590,7 @@ z
    </g>
    <g id="text_34">
     <!-- lines random n=1000  -->
-    <g transform="translate(257.459687 20.88)scale(0.12 -0.12)">
+    <g transform="translate(257.459687 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
@@ -1672,7 +1672,7 @@ z
     </g>
     <g id="text_35">
      <!-- mpl2005 no mask -->
-     <g transform="translate(447.19375 43.478437)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1696,11 +1696,11 @@ L 439.19375 58.156563
 L 439.19375 51.156563 
 L 419.19375 51.156563 
 z
-" style="fill: url(#hc6bc6f1db7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#ha3bd909c72); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_36">
      <!-- mpl2005 corner_mask=False -->
-     <g transform="translate(447.19375 58.156563)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 58.156563) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-5f" d="M 3263 -1063 
 L 3263 -1509 
@@ -1760,7 +1760,7 @@ z
     </g>
     <g id="text_37">
      <!-- mpl2014 no mask -->
-     <g transform="translate(447.19375 73.112812)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 73.112812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1784,11 +1784,11 @@ L 439.19375 87.790937
 L 439.19375 80.790937 
 L 419.19375 80.790937 
 z
-" style="fill: url(#h68a322ff0c); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hfe2f74c604); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_38">
      <!-- mpl2014 corner_mask=False -->
-     <g transform="translate(447.19375 87.790937)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 87.790937) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1822,11 +1822,11 @@ L 439.19375 102.747187
 L 439.19375 95.747187 
 L 419.19375 95.747187 
 z
-" style="fill: url(#h226890a923); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hf3f1feff2f); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_39">
      <!-- mpl2014 corner_mask=True -->
-     <g transform="translate(447.19375 102.747187)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 102.747187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1863,7 +1863,7 @@ z
     </g>
     <g id="text_40">
      <!-- serial no mask -->
-     <g transform="translate(447.19375 117.703437)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 117.703437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1886,11 +1886,11 @@ L 439.19375 132.381562
 L 439.19375 125.381562 
 L 419.19375 125.381562 
 z
-" style="fill: url(#h2780e6f214); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hebc7af5b53); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_41">
      <!-- serial corner_mask=False -->
-     <g transform="translate(447.19375 132.381562)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 132.381562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1923,11 +1923,11 @@ L 439.19375 147.337812
 L 439.19375 140.337812 
 L 419.19375 140.337812 
 z
-" style="fill: url(#h6da96af3f9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h6938ab5d80); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_42">
      <!-- serial corner_mask=True -->
-     <g transform="translate(447.19375 147.337812)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 147.337812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1957,12 +1957,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p81b2e485e0">
+  <clipPath id="p2c60bd8a19">
    <rect x="47.81" y="26.88" width="553.39" height="342.248"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="hc6bc6f1db7" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="ha3bd909c72" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2002,7 +2002,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h68a322ff0c" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hfe2f74c604" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2042,7 +2042,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h226890a923" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hf3f1feff2f" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2084,7 +2084,7 @@ M 36 108
 L 108 36 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h2780e6f214" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hebc7af5b53" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2124,7 +2124,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h6da96af3f9" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h6938ab5d80" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/lines_random_1000_render.svg
+++ b/docs/_static/lines_random_1000_render.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:32.364195</dc:date>
+    <dc:date>2022-10-23T17:46:34.890016</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m86db86ca79" d="M 0 0 
+       <path id="m6fcc26323c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m86db86ca79" x="102.873142" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6fcc26323c" x="102.873142" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- mpl2005 -->
-      <g transform="translate(80.714549 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(80.714549 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -198,7 +198,7 @@ z
        <use xlink:href="#DejaVuSans-35" x="379.541016"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(80.22783 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(80.22783 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
@@ -338,7 +338,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(90.07158 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(90.07158 406.122063) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -419,12 +419,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m86db86ca79" x="190.877885" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6fcc26323c" x="190.877885" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- mpl2014 -->
-      <g transform="translate(168.719292 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(168.719292 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -469,7 +469,7 @@ z
        <use xlink:href="#DejaVuSans-34" x="379.541016"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(168.232573 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(168.232573 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -480,7 +480,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(178.076323 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(178.076323 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -491,12 +491,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m86db86ca79" x="278.882628" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6fcc26323c" x="278.882628" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- serial -->
-      <g transform="translate(265.303722 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(265.303722 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
@@ -551,7 +551,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(256.237316 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(256.237316 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -566,12 +566,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m86db86ca79" x="366.887372" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6fcc26323c" x="366.887372" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- serial -->
-      <g transform="translate(353.308465 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(353.308465 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -580,7 +580,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(344.242059 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(344.242059 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -591,7 +591,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(354.085809 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(354.085809 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -602,12 +602,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m86db86ca79" x="454.892115" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6fcc26323c" x="454.892115" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- serial -->
-      <g transform="translate(441.313208 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(441.313208 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -616,7 +616,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(438.999146 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(438.999146 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -700,7 +700,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(429.488208 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(429.488208 406.122063) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -739,7 +739,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(442.090552 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(442.090552 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -750,12 +750,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m86db86ca79" x="542.896858" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6fcc26323c" x="542.896858" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- serial -->
-      <g transform="translate(529.317951 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(529.317951 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -764,7 +764,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(527.003889 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(527.003889 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -772,7 +772,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(517.492951 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(517.492951 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -783,7 +783,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(527.799201 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(527.799201 417.319875) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -843,75 +843,75 @@ z
      <g id="line2d_7">
       <path d="M 44.57 369.128 
 L 601.2 369.128 
-" clip-path="url(#pca066992d5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#ped1a52e267)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="m294a32628e" d="M 0 0 
+       <path id="maaeab84cde" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m294a32628e" x="44.57" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maaeab84cde" x="44.57" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0 -->
-      <g transform="translate(31.2075 372.927219)scale(0.1 -0.1)">
+      <g transform="translate(31.2075 372.927219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 44.57 324.220719 
-L 601.2 324.220719 
-" clip-path="url(#pca066992d5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 324.226784 
+L 601.2 324.226784 
+" clip-path="url(#ped1a52e267)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m294a32628e" x="44.57" y="324.220719" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maaeab84cde" x="44.57" y="324.226784" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 2 -->
-      <g transform="translate(31.2075 328.019938)scale(0.1 -0.1)">
+      <g transform="translate(31.2075 328.026003) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 44.57 279.313438 
-L 601.2 279.313438 
-" clip-path="url(#pca066992d5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 279.325568 
+L 601.2 279.325568 
+" clip-path="url(#ped1a52e267)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m294a32628e" x="44.57" y="279.313438" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maaeab84cde" x="44.57" y="279.325568" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 4 -->
-      <g transform="translate(31.2075 283.112657)scale(0.1 -0.1)">
+      <g transform="translate(31.2075 283.124787) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-34"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 44.57 234.406157 
-L 601.2 234.406157 
-" clip-path="url(#pca066992d5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 234.424352 
+L 601.2 234.424352 
+" clip-path="url(#ped1a52e267)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m294a32628e" x="44.57" y="234.406157" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maaeab84cde" x="44.57" y="234.424352" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 6 -->
-      <g transform="translate(31.2075 238.205375)scale(0.1 -0.1)">
+      <g transform="translate(31.2075 238.223571) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -950,18 +950,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 44.57 189.498876 
-L 601.2 189.498876 
-" clip-path="url(#pca066992d5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 189.523136 
+L 601.2 189.523136 
+" clip-path="url(#ped1a52e267)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m294a32628e" x="44.57" y="189.498876" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maaeab84cde" x="44.57" y="189.523136" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 8 -->
-      <g transform="translate(31.2075 193.298094)scale(0.1 -0.1)">
+      <g transform="translate(31.2075 193.322355) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1009,18 +1009,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 44.57 144.591594 
-L 601.2 144.591594 
-" clip-path="url(#pca066992d5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 144.62192 
+L 601.2 144.62192 
+" clip-path="url(#ped1a52e267)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m294a32628e" x="44.57" y="144.591594" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maaeab84cde" x="44.57" y="144.62192" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 10 -->
-      <g transform="translate(24.845 148.390813)scale(0.1 -0.1)">
+      <g transform="translate(24.845 148.421139) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" x="63.623047"/>
       </g>
@@ -1028,18 +1028,18 @@ L 601.2 144.591594
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 44.57 99.684313 
-L 601.2 99.684313 
-" clip-path="url(#pca066992d5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 99.720704 
+L 601.2 99.720704 
+" clip-path="url(#ped1a52e267)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m294a32628e" x="44.57" y="99.684313" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maaeab84cde" x="44.57" y="99.720704" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 12 -->
-      <g transform="translate(24.845 103.483532)scale(0.1 -0.1)">
+      <g transform="translate(24.845 103.519923) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-32" x="63.623047"/>
       </g>
@@ -1047,18 +1047,18 @@ L 601.2 99.684313
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 44.57 54.777032 
-L 601.2 54.777032 
-" clip-path="url(#pca066992d5)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 54.819488 
+L 601.2 54.819488 
+" clip-path="url(#ped1a52e267)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m294a32628e" x="44.57" y="54.777032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maaeab84cde" x="44.57" y="54.819488" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 14 -->
-      <g transform="translate(24.845 58.576251)scale(0.1 -0.1)">
+      <g transform="translate(24.845 58.618707) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-34" x="63.623047"/>
       </g>
@@ -1066,7 +1066,7 @@ L 601.2 54.777032
     </g>
     <g id="text_15">
      <!-- Time (seconds) -->
-     <g transform="translate(18.765313 236.165719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.765313 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1148,14 +1148,14 @@ z
    <g id="patch_3">
     <path d="M 69.871364 369.128 
 L 91.872549 369.128 
-L 91.872549 105.336835 
-L 69.871364 105.336835 
+L 91.872549 112.011906 
+L 69.871364 112.011906 
 z
-" clip-path="url(#pca066992d5)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#ped1a52e267)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_16">
-    <!-- 11.7 s -->
-    <g transform="translate(83.631332 100.336835)rotate(-90)scale(0.1 -0.1)">
+    <!-- 11.5 s -->
+    <g transform="translate(83.631332 107.011906) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -1164,6 +1164,27 @@ L 684 0
 L 684 794 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 91.872549 369.128 
+L 113.873735 369.128 
+L 113.873735 105.418073 
+L 91.872549 105.418073 
+z
+" clip-path="url(#ped1a52e267)" style="fill: url(#hb046b0f13d); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_17">
+    <!-- 11.7 s -->
+    <g transform="translate(105.632517 100.418073) rotate(-90) scale(0.1 -0.1)">
+     <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1183,182 +1204,17 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="patch_4">
-    <path d="M 91.872549 369.128 
-L 113.873735 369.128 
-L 113.873735 97.964091 
-L 91.872549 97.964091 
-z
-" clip-path="url(#pca066992d5)" style="fill: url(#he25b69bb89); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_17">
-    <!-- 12.1 s -->
-    <g transform="translate(105.632517 92.964091)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
    <g id="patch_5">
     <path d="M 157.876107 369.128 
 L 179.877292 369.128 
-L 179.877292 111.295996 
-L 157.876107 111.295996 
+L 179.877292 115.904926 
+L 157.876107 115.904926 
 z
-" clip-path="url(#pca066992d5)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#ped1a52e267)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_18">
-    <!-- 11.5 s -->
-    <g transform="translate(171.636075 106.295996)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 179.877292 369.128 
-L 201.878478 369.128 
-L 201.878478 103.188756 
-L 179.877292 103.188756 
-z
-" clip-path="url(#pca066992d5)" style="fill: url(#h6e1360fa14); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 11.8 s -->
-    <g transform="translate(193.63726 98.188756)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 201.878478 369.128 
-L 223.879664 369.128 
-L 223.879664 106.583662 
-L 201.878478 106.583662 
-z
-" clip-path="url(#pca066992d5)" style="fill: url(#h82fc677f1a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 11.7 s -->
-    <g transform="translate(215.638446 101.583662)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 245.88085 369.128 
-L 267.882036 369.128 
-L 267.882036 78.508991 
-L 245.88085 78.508991 
-z
-" clip-path="url(#pca066992d5)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 333.885593 369.128 
-L 355.886779 369.128 
-L 355.886779 110.189704 
-L 333.885593 110.189704 
-z
-" clip-path="url(#pca066992d5)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 421.890336 369.128 
-L 443.891522 369.128 
-L 443.891522 236.230971 
-L 421.890336 236.230971 
-z
-" clip-path="url(#pca066992d5)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 509.895079 369.128 
-L 531.896265 369.128 
-L 531.896265 72.809385 
-L 509.895079 72.809385 
-z
-" clip-path="url(#pca066992d5)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 12.9 s -->
-    <g transform="translate(259.640818 73.508991)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 11.5 s -->
-    <g transform="translate(347.645561 105.189704)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 5.92 s -->
-    <g transform="translate(435.650304 231.230971)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 13.2 s -->
-    <g transform="translate(523.655047 67.809385)rotate(-90)scale(0.1 -0.1)">
+    <!-- 11.3 s -->
+    <g transform="translate(171.636075 110.904926) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1394,6 +1250,120 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 179.877292 369.128 
+L 201.878478 369.128 
+L 201.878478 109.378835 
+L 179.877292 109.378835 
+z
+" clip-path="url(#ped1a52e267)" style="fill: url(#h0d6d16c51e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 11.6 s -->
+    <g transform="translate(193.63726 104.378835) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 201.878478 369.128 
+L 223.879664 369.128 
+L 223.879664 112.412415 
+L 201.878478 112.412415 
+z
+" clip-path="url(#ped1a52e267)" style="fill: url(#h114bf2322b); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 11.4 s -->
+    <g transform="translate(215.638446 107.412415) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 245.88085 369.128 
+L 267.882036 369.128 
+L 267.882036 82.044492 
+L 245.88085 82.044492 
+z
+" clip-path="url(#ped1a52e267)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 333.885593 369.128 
+L 355.886779 369.128 
+L 355.886779 113.590613 
+L 333.885593 113.590613 
+z
+" clip-path="url(#ped1a52e267)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 421.890336 369.128 
+L 443.891522 369.128 
+L 443.891522 240.227332 
+L 421.890336 240.227332 
+z
+" clip-path="url(#ped1a52e267)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 509.895079 369.128 
+L 531.896265 369.128 
+L 531.896265 72.809385 
+L 509.895079 72.809385 
+z
+" clip-path="url(#ped1a52e267)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 12.8 s -->
+    <g transform="translate(259.640818 77.044492) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 11.4 s -->
+    <g transform="translate(347.645561 108.590613) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 5.74 s -->
+    <g transform="translate(435.650304 235.227332) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 13.2 s -->
+    <g transform="translate(523.655047 67.809385) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-32" x="159.033203"/>
@@ -1404,75 +1374,107 @@ z
    <g id="patch_12">
     <path d="M 267.882036 369.128 
 L 289.883221 369.128 
-L 289.883221 90.180367 
-L 267.882036 90.180367 
+L 289.883221 97.362796 
+L 267.882036 97.362796 
 z
-" clip-path="url(#pca066992d5)" style="fill: url(#hfe5b8f6744); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#ped1a52e267)" style="fill: url(#h993de57762); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 355.886779 369.128 
 L 377.887964 369.128 
-L 377.887964 103.905891 
-L 355.886779 103.905891 
+L 377.887964 108.709738 
+L 355.886779 108.709738 
 z
-" clip-path="url(#pca066992d5)" style="fill: url(#hfe5b8f6744); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#ped1a52e267)" style="fill: url(#h993de57762); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 443.891522 369.128 
 L 465.892708 369.128 
-L 465.892708 253.825402 
-L 443.891522 253.825402 
+L 465.892708 257.766293 
+L 443.891522 257.766293 
 z
-" clip-path="url(#pca066992d5)" style="fill: url(#hfe5b8f6744); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#ped1a52e267)" style="fill: url(#h993de57762); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 531.896265 369.128 
 L 553.897451 369.128 
-L 553.897451 80.858524 
-L 531.896265 80.858524 
+L 553.897451 85.473903 
+L 531.896265 85.473903 
 z
-" clip-path="url(#pca066992d5)" style="fill: url(#hfe5b8f6744); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#ped1a52e267)" style="fill: url(#h993de57762); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_25">
-    <!-- 12.4 s -->
-    <g transform="translate(281.642003 85.180367)rotate(-90)scale(0.1 -0.1)">
+    <!-- 12.1 s -->
+    <g transform="translate(281.642003 92.362796) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 11.8 s -->
-    <g transform="translate(369.646747 98.905891)rotate(-90)scale(0.1 -0.1)">
+    <!-- 11.6 s -->
+    <g transform="translate(369.646747 103.709738) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- 5.14 s -->
-    <g transform="translate(457.65149 248.825402)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
+    <!-- 4.96 s -->
+    <g transform="translate(457.65149 252.766293) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-39" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 12.8 s -->
-    <g transform="translate(545.656233 75.858524)rotate(-90)scale(0.1 -0.1)">
+    <!-- 12.6 s -->
+    <g transform="translate(545.656233 80.473903) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1480,82 +1482,82 @@ z
    <g id="patch_16">
     <path d="M 289.883221 369.128 
 L 311.884407 369.128 
-L 311.884407 88.736981 
-L 289.883221 88.736981 
+L 311.884407 90.527099 
+L 289.883221 90.527099 
 z
-" clip-path="url(#pca066992d5)" style="fill: url(#ha4afd003d5); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#ped1a52e267)" style="fill: url(#hd3b2ab19ff); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 377.887964 369.128 
 L 399.88915 369.128 
-L 399.88915 103.495988 
-L 377.887964 103.495988 
+L 399.88915 111.928672 
+L 377.887964 111.928672 
 z
-" clip-path="url(#pca066992d5)" style="fill: url(#ha4afd003d5); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#ped1a52e267)" style="fill: url(#hd3b2ab19ff); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 465.892708 369.128 
 L 487.893893 369.128 
-L 487.893893 240.526101 
-L 465.892708 240.526101 
+L 487.893893 244.992311 
+L 465.892708 244.992311 
 z
-" clip-path="url(#pca066992d5)" style="fill: url(#ha4afd003d5); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#ped1a52e267)" style="fill: url(#hd3b2ab19ff); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 553.897451 369.128 
 L 575.898636 369.128 
-L 575.898636 78.470993 
-L 553.897451 78.470993 
+L 575.898636 83.409693 
+L 553.897451 83.409693 
 z
-" clip-path="url(#pca066992d5)" style="fill: url(#ha4afd003d5); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#ped1a52e267)" style="fill: url(#hd3b2ab19ff); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_29">
-    <!-- 12.5 s -->
-    <g transform="translate(303.643189 83.736981)rotate(-90)scale(0.1 -0.1)">
+    <!-- 12.4 s -->
+    <g transform="translate(303.643189 85.527099) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 11.5 s -->
+    <g transform="translate(391.647932 106.928672) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_30">
-    <!-- 11.8 s -->
-    <g transform="translate(391.647932 98.495988)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
    <g id="text_31">
-    <!-- 5.73 s -->
-    <g transform="translate(479.652675 235.526101)rotate(-90)scale(0.1 -0.1)">
+    <!-- 5.53 s -->
+    <g transform="translate(479.652675 239.992311) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-35" x="95.410156"/>
      <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 12.9 s -->
-    <g transform="translate(567.657418 73.470993)rotate(-90)scale(0.1 -0.1)">
+    <!-- 12.7 s -->
+    <g transform="translate(567.657418 78.409693) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lines random n=1000 (calculate and render) -->
-    <g transform="translate(189.13 20.88)scale(0.12 -0.12)">
+    <g transform="translate(189.13 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
@@ -1659,7 +1661,7 @@ z
     </g>
     <g id="text_34">
      <!-- mpl2005 no mask -->
-     <g transform="translate(81.57 253.910813)scale(0.1 -0.1)">
+     <g transform="translate(81.57 253.910813) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1683,11 +1685,11 @@ L 73.57 268.588938
 L 73.57 261.588938 
 L 53.57 261.588938 
 z
-" style="fill: url(#he25b69bb89); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hb046b0f13d); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_35">
      <!-- mpl2005 corner_mask=False -->
-     <g transform="translate(81.57 268.588938)scale(0.1 -0.1)">
+     <g transform="translate(81.57 268.588938) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-5f" d="M 3263 -1063 
 L 3263 -1509 
@@ -1747,7 +1749,7 @@ z
     </g>
     <g id="text_36">
      <!-- mpl2014 no mask -->
-     <g transform="translate(81.57 283.545187)scale(0.1 -0.1)">
+     <g transform="translate(81.57 283.545187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1771,11 +1773,11 @@ L 73.57 298.223313
 L 73.57 291.223313 
 L 53.57 291.223313 
 z
-" style="fill: url(#h6e1360fa14); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h0d6d16c51e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_37">
      <!-- mpl2014 corner_mask=False -->
-     <g transform="translate(81.57 298.223313)scale(0.1 -0.1)">
+     <g transform="translate(81.57 298.223313) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1809,11 +1811,11 @@ L 73.57 313.179563
 L 73.57 306.179563 
 L 53.57 306.179563 
 z
-" style="fill: url(#h82fc677f1a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h114bf2322b); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_38">
      <!-- mpl2014 corner_mask=True -->
-     <g transform="translate(81.57 313.179563)scale(0.1 -0.1)">
+     <g transform="translate(81.57 313.179563) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1850,7 +1852,7 @@ z
     </g>
     <g id="text_39">
      <!-- serial no mask -->
-     <g transform="translate(81.57 328.135813)scale(0.1 -0.1)">
+     <g transform="translate(81.57 328.135813) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1873,11 +1875,11 @@ L 73.57 342.813938
 L 73.57 335.813938 
 L 53.57 335.813938 
 z
-" style="fill: url(#hfe5b8f6744); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h993de57762); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_40">
      <!-- serial corner_mask=False -->
-     <g transform="translate(81.57 342.813938)scale(0.1 -0.1)">
+     <g transform="translate(81.57 342.813938) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1910,11 +1912,11 @@ L 73.57 357.770188
 L 73.57 350.770188 
 L 53.57 350.770188 
 z
-" style="fill: url(#ha4afd003d5); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hd3b2ab19ff); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_41">
      <!-- serial corner_mask=True -->
-     <g transform="translate(81.57 357.770188)scale(0.1 -0.1)">
+     <g transform="translate(81.57 357.770188) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1944,12 +1946,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pca066992d5">
+  <clipPath id="ped1a52e267">
    <rect x="44.57" y="26.88" width="556.63" height="342.248"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="he25b69bb89" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hb046b0f13d" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -1989,7 +1991,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h6e1360fa14" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h0d6d16c51e" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2029,7 +2031,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h82fc677f1a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h114bf2322b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2071,7 +2073,7 @@ M 36 108
 L 108 36 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hfe5b8f6744" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h993de57762" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2111,7 +2113,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="ha4afd003d5" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hd3b2ab19ff" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/lines_simple_1000.svg
+++ b/docs/_static/lines_simple_1000.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:32.504476</dc:date>
+    <dc:date>2022-10-23T17:46:35.024629</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m44d9f54046" d="M 0 0 
+       <path id="m3196c58928" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m44d9f54046" x="111.33332" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3196c58928" x="111.33332" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- mpl2005 -->
-      <g transform="translate(89.174726 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(89.174726 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -198,7 +198,7 @@ z
        <use xlink:href="#DejaVuSans-35" x="379.541016"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(88.688008 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(88.688008 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
@@ -338,7 +338,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(98.531758 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(98.531758 406.122063) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -419,12 +419,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m44d9f54046" x="197.843992" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3196c58928" x="197.843992" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- mpl2014 -->
-      <g transform="translate(175.685398 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(175.685398 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -469,7 +469,7 @@ z
        <use xlink:href="#DejaVuSans-34" x="379.541016"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(175.19868 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(175.19868 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -480,7 +480,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(185.04243 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(185.04243 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -491,12 +491,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m44d9f54046" x="284.354664" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3196c58928" x="284.354664" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- serial -->
-      <g transform="translate(270.775758 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(270.775758 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
@@ -551,7 +551,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(261.709352 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(261.709352 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -566,12 +566,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m44d9f54046" x="370.865336" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3196c58928" x="370.865336" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- serial -->
-      <g transform="translate(357.28643 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(357.28643 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -580,7 +580,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(348.220023 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(348.220023 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -591,7 +591,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(358.063773 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(358.063773 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -602,12 +602,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m44d9f54046" x="457.376008" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3196c58928" x="457.376008" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- serial -->
-      <g transform="translate(443.797102 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(443.797102 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -616,7 +616,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(441.483039 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(441.483039 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -700,7 +700,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(431.972102 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(431.972102 406.122063) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -739,7 +739,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(444.574445 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(444.574445 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -750,12 +750,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m44d9f54046" x="543.88668" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3196c58928" x="543.88668" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- serial -->
-      <g transform="translate(530.307774 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(530.307774 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -764,7 +764,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(527.993711 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(527.993711 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -772,7 +772,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(518.482774 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(518.482774 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -783,7 +783,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(528.789024 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(528.789024 417.319875) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -843,21 +843,21 @@ z
      <g id="line2d_7">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#p3112f316db)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf13694680e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="m1f4f4dc147" d="M 0 0 
+       <path id="m54713d7e15" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1f4f4dc147" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m54713d7e15" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.00 -->
-      <g transform="translate(24.754375 372.927219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 372.927219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -876,18 +876,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 54.02 306.020644 
-L 601.2 306.020644 
-" clip-path="url(#p3112f316db)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 310.995932 
+L 601.2 310.995932 
+" clip-path="url(#pf13694680e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m1f4f4dc147" x="54.02" y="306.020644" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m54713d7e15" x="54.02" y="310.995932" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.05 -->
-      <g transform="translate(24.754375 309.819863)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 314.795151) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -897,18 +897,18 @@ L 601.2 306.020644
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 54.02 242.913289 
-L 601.2 242.913289 
-" clip-path="url(#p3112f316db)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 252.863864 
+L 601.2 252.863864 
+" clip-path="url(#pf13694680e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m1f4f4dc147" x="54.02" y="242.913289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m54713d7e15" x="54.02" y="252.863864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.10 -->
-      <g transform="translate(24.754375 246.712508)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 256.663083) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -918,18 +918,18 @@ L 601.2 242.913289
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 54.02 179.805933 
-L 601.2 179.805933 
-" clip-path="url(#p3112f316db)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 194.731796 
+L 601.2 194.731796 
+" clip-path="url(#pf13694680e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1f4f4dc147" x="54.02" y="179.805933" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m54713d7e15" x="54.02" y="194.731796" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.15 -->
-      <g transform="translate(24.754375 183.605152)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 198.531015) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -939,18 +939,18 @@ L 601.2 179.805933
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 54.02 116.698578 
-L 601.2 116.698578 
-" clip-path="url(#p3112f316db)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 136.599728 
+L 601.2 136.599728 
+" clip-path="url(#pf13694680e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m1f4f4dc147" x="54.02" y="116.698578" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m54713d7e15" x="54.02" y="136.599728" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.20 -->
-      <g transform="translate(24.754375 120.497796)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 140.398946) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -960,18 +960,18 @@ L 601.2 116.698578
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 54.02 53.591222 
-L 601.2 53.591222 
-" clip-path="url(#p3112f316db)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 78.46766 
+L 601.2 78.46766 
+" clip-path="url(#pf13694680e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1f4f4dc147" x="54.02" y="53.591222" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m54713d7e15" x="54.02" y="78.46766" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 57.390441)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 82.266878) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -981,7 +981,7 @@ L 601.2 53.591222
     </g>
     <g id="text_13">
      <!-- Time (seconds) -->
-     <g transform="translate(18.674688 236.165719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.674688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1063,17 +1063,49 @@ z
    <g id="patch_3">
     <path d="M 78.891818 369.128 
 L 100.519486 369.128 
-L 100.519486 189.66844 
-L 78.891818 189.66844 
+L 100.519486 222.075534 
+L 78.891818 222.075534 
 z
-" clip-path="url(#p3112f316db)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf13694680e)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_14">
-    <!-- 142 ms -->
-    <g transform="translate(92.465027 184.66844)rotate(-90)scale(0.1 -0.1)">
+    <!-- 126 ms -->
+    <g transform="translate(92.465027 217.075534) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1082,17 +1114,17 @@ z
    <g id="patch_4">
     <path d="M 100.519486 369.128 
 L 122.147154 369.128 
-L 122.147154 187.576157 
-L 100.519486 187.576157 
+L 122.147154 222.376348 
+L 100.519486 222.376348 
 z
-" clip-path="url(#p3112f316db)" style="fill: url(#h8714169901); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf13694680e)" style="fill: url(#h92630a03d3); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_15">
-    <!-- 144 ms -->
-    <g transform="translate(114.092695 182.576157)rotate(-90)scale(0.1 -0.1)">
+    <!-- 126 ms -->
+    <g transform="translate(114.092695 217.376348) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1104,11 +1136,30 @@ L 187.030158 369.128
 L 187.030158 72.809385 
 L 165.40249 72.809385 
 z
-" clip-path="url(#p3112f316db)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf13694680e)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_16">
-    <!-- 235 ms -->
-    <g transform="translate(178.975699 67.809385)rotate(-90)scale(0.1 -0.1)">
+    <!-- 255 ms -->
+    <g transform="translate(178.975699 67.809385) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 187.030158 369.128 
+L 208.657826 369.128 
+L 208.657826 109.424904 
+L 187.030158 109.424904 
+z
+" clip-path="url(#pf13694680e)" style="fill: url(#h04df0af7d4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_17">
+    <!-- 223 ms -->
+    <g transform="translate(200.603367 104.424904) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1144,26 +1195,7 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 187.030158 369.128 
-L 208.657826 369.128 
-L 208.657826 112.431158 
-L 187.030158 112.431158 
-z
-" clip-path="url(#p3112f316db)" style="fill: url(#h3143098a11); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_17">
-    <!-- 203 ms -->
-    <g transform="translate(200.603367 107.431158)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1173,57 +1205,14 @@ z
    <g id="patch_7">
     <path d="M 208.657826 369.128 
 L 230.285494 369.128 
-L 230.285494 79.255214 
-L 208.657826 79.255214 
+L 230.285494 81.526272 
+L 208.657826 81.526272 
 z
-" clip-path="url(#p3112f316db)" style="fill: url(#h0e8db1405c); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf13694680e)" style="fill: url(#h9df59ed2a7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_18">
-    <!-- 230 ms -->
-    <g transform="translate(222.231035 74.255214)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 251.913162 369.128 
-L 273.54083 369.128 
-L 273.54083 209.260271 
-L 251.913162 209.260271 
-z
-" clip-path="url(#p3112f316db)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 338.423834 369.128 
-L 360.051502 369.128 
-L 360.051502 209.044934 
-L 338.423834 209.044934 
-z
-" clip-path="url(#p3112f316db)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 424.934506 369.128 
-L 446.562174 369.128 
-L 446.562174 209.381214 
-L 424.934506 209.381214 
-z
-" clip-path="url(#p3112f316db)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 511.445178 369.128 
-L 533.072846 369.128 
-L 533.072846 209.342821 
-L 511.445178 209.342821 
-z
-" clip-path="url(#p3112f316db)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 127 ms -->
-    <g transform="translate(265.486371 204.260271)rotate(-90)scale(0.1 -0.1)">
+    <!-- 247 ms -->
+    <g transform="translate(222.231035 76.526272) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1236,42 +1225,85 @@ L 525 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 251.913162 369.128 
+L 273.54083 369.128 
+L 273.54083 212.263051 
+L 251.913162 212.263051 
+z
+" clip-path="url(#pf13694680e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 338.423834 369.128 
+L 360.051502 369.128 
+L 360.051502 212.602673 
+L 338.423834 212.602673 
+z
+" clip-path="url(#pf13694680e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 424.934506 369.128 
+L 446.562174 369.128 
+L 446.562174 212.658118 
+L 424.934506 212.658118 
+z
+" clip-path="url(#pf13694680e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 511.445178 369.128 
+L 533.072846 369.128 
+L 533.072846 212.036305 
+L 511.445178 212.036305 
+z
+" clip-path="url(#pf13694680e)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 135 ms -->
+    <g transform="translate(265.486371 207.263051) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 127 ms -->
-    <g transform="translate(351.997043 204.044934)rotate(-90)scale(0.1 -0.1)">
+    <!-- 135 ms -->
+    <g transform="translate(351.997043 207.602673) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- 127 ms -->
-    <g transform="translate(438.507715 204.381214)rotate(-90)scale(0.1 -0.1)">
+    <!-- 135 ms -->
+    <g transform="translate(438.507715 207.658118) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- 127 ms -->
-    <g transform="translate(525.018387 204.342821)rotate(-90)scale(0.1 -0.1)">
+    <!-- 135 ms -->
+    <g transform="translate(525.018387 207.036305) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1280,40 +1312,40 @@ z
    <g id="patch_12">
     <path d="M 273.54083 369.128 
 L 295.168498 369.128 
-L 295.168498 220.94596 
-L 273.54083 220.94596 
+L 295.168498 221.762778 
+L 273.54083 221.762778 
 z
-" clip-path="url(#p3112f316db)" style="fill: url(#hb916e285b4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf13694680e)" style="fill: url(#h42d241dad9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 360.051502 369.128 
 L 381.67917 369.128 
-L 381.67917 220.58134 
-L 360.051502 220.58134 
+L 381.67917 220.305964 
+L 360.051502 220.305964 
 z
-" clip-path="url(#p3112f316db)" style="fill: url(#hb916e285b4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf13694680e)" style="fill: url(#h42d241dad9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 446.562174 369.128 
 L 468.189842 369.128 
-L 468.189842 220.264301 
-L 446.562174 220.264301 
+L 468.189842 222.27946 
+L 446.562174 222.27946 
 z
-" clip-path="url(#p3112f316db)" style="fill: url(#hb916e285b4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf13694680e)" style="fill: url(#h42d241dad9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 533.072846 369.128 
 L 554.700514 369.128 
-L 554.700514 220.656794 
-L 533.072846 220.656794 
+L 554.700514 222.026414 
+L 533.072846 222.026414 
 z
-" clip-path="url(#p3112f316db)" style="fill: url(#hb916e285b4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf13694680e)" style="fill: url(#h42d241dad9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_23">
-    <!-- 117 ms -->
-    <g transform="translate(287.114039 215.94596)rotate(-90)scale(0.1 -0.1)">
+    <!-- 127 ms -->
+    <g transform="translate(287.114039 216.762778) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1321,8 +1353,8 @@ z
     </g>
    </g>
    <g id="text_24">
-    <!-- 118 ms -->
-    <g transform="translate(373.624711 215.58134)rotate(-90)scale(0.1 -0.1)">
+    <!-- 128 ms -->
+    <g transform="translate(373.624711 215.305964) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1365,7 +1397,7 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1373,22 +1405,22 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- 118 ms -->
-    <g transform="translate(460.135383 215.264301)rotate(-90)scale(0.1 -0.1)">
+    <!-- 126 ms -->
+    <g transform="translate(460.135383 217.27946) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 118 ms -->
-    <g transform="translate(546.646055 215.656794)rotate(-90)scale(0.1 -0.1)">
+    <!-- 127 ms -->
+    <g transform="translate(546.646055 217.026414) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1397,40 +1429,40 @@ z
    <g id="patch_16">
     <path d="M 295.168498 369.128 
 L 316.796166 369.128 
-L 316.796166 219.80085 
-L 295.168498 219.80085 
+L 316.796166 220.70718 
+L 295.168498 220.70718 
 z
-" clip-path="url(#p3112f316db)" style="fill: url(#h7d0a89dc84); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf13694680e)" style="fill: url(#h82f4822d4e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 381.67917 369.128 
 L 403.306838 369.128 
-L 403.306838 219.800906 
-L 381.67917 219.800906 
+L 403.306838 219.917957 
+L 381.67917 219.917957 
 z
-" clip-path="url(#p3112f316db)" style="fill: url(#h7d0a89dc84); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf13694680e)" style="fill: url(#h82f4822d4e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 468.189842 369.128 
 L 489.81751 369.128 
-L 489.81751 219.87813 
-L 468.189842 219.87813 
+L 489.81751 220.904632 
+L 468.189842 220.904632 
 z
-" clip-path="url(#p3112f316db)" style="fill: url(#h7d0a89dc84); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf13694680e)" style="fill: url(#h82f4822d4e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 554.700514 369.128 
 L 576.328182 369.128 
-L 576.328182 218.838605 
-L 554.700514 218.838605 
+L 576.328182 220.411667 
+L 554.700514 220.411667 
 z
-" clip-path="url(#p3112f316db)" style="fill: url(#h7d0a89dc84); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pf13694680e)" style="fill: url(#h82f4822d4e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_27">
-    <!-- 118 ms -->
-    <g transform="translate(308.741707 214.80085)rotate(-90)scale(0.1 -0.1)">
+    <!-- 128 ms -->
+    <g transform="translate(308.741707 215.70718) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1438,10 +1470,10 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 118 ms -->
-    <g transform="translate(395.252379 214.800906)rotate(-90)scale(0.1 -0.1)">
+    <!-- 128 ms -->
+    <g transform="translate(395.252379 214.917957) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1449,54 +1481,22 @@ z
     </g>
    </g>
    <g id="text_29">
-    <!-- 118 ms -->
-    <g transform="translate(481.763051 214.87813)rotate(-90)scale(0.1 -0.1)">
+    <!-- 127 ms -->
+    <g transform="translate(481.763051 215.904632) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 119 ms -->
-    <g transform="translate(568.273723 213.838605)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 128 ms -->
+    <g transform="translate(568.273723 215.411667) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1504,7 +1504,7 @@ z
    </g>
    <g id="text_31">
     <!-- lines simple n=1000  -->
-    <g transform="translate(264.030625 20.88)scale(0.12 -0.12)">
+    <g transform="translate(264.030625 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
@@ -1586,7 +1586,7 @@ z
     </g>
     <g id="text_32">
      <!-- mpl2005 no mask -->
-     <g transform="translate(447.19375 43.478437)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1610,11 +1610,11 @@ L 439.19375 58.156563
 L 439.19375 51.156563 
 L 419.19375 51.156563 
 z
-" style="fill: url(#h8714169901); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h92630a03d3); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_33">
      <!-- mpl2005 corner_mask=False -->
-     <g transform="translate(447.19375 58.156563)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 58.156563) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-5f" d="M 3263 -1063 
 L 3263 -1509 
@@ -1674,7 +1674,7 @@ z
     </g>
     <g id="text_34">
      <!-- mpl2014 no mask -->
-     <g transform="translate(447.19375 73.112812)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 73.112812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1698,11 +1698,11 @@ L 439.19375 87.790937
 L 439.19375 80.790937 
 L 419.19375 80.790937 
 z
-" style="fill: url(#h3143098a11); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h04df0af7d4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_35">
      <!-- mpl2014 corner_mask=False -->
-     <g transform="translate(447.19375 87.790937)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 87.790937) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1736,11 +1736,11 @@ L 439.19375 102.747187
 L 439.19375 95.747187 
 L 419.19375 95.747187 
 z
-" style="fill: url(#h0e8db1405c); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h9df59ed2a7); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_36">
      <!-- mpl2014 corner_mask=True -->
-     <g transform="translate(447.19375 102.747187)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 102.747187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1777,7 +1777,7 @@ z
     </g>
     <g id="text_37">
      <!-- serial no mask -->
-     <g transform="translate(447.19375 117.703437)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 117.703437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1800,11 +1800,11 @@ L 439.19375 132.381562
 L 439.19375 125.381562 
 L 419.19375 125.381562 
 z
-" style="fill: url(#hb916e285b4); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h42d241dad9); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_38">
      <!-- serial corner_mask=False -->
-     <g transform="translate(447.19375 132.381562)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 132.381562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1837,11 +1837,11 @@ L 439.19375 147.337812
 L 439.19375 140.337812 
 L 419.19375 140.337812 
 z
-" style="fill: url(#h7d0a89dc84); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h82f4822d4e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_39">
      <!-- serial corner_mask=True -->
-     <g transform="translate(447.19375 147.337812)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 147.337812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1871,12 +1871,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p3112f316db">
+  <clipPath id="pf13694680e">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h8714169901" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h92630a03d3" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -1916,7 +1916,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h3143098a11" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h04df0af7d4" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -1956,7 +1956,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h0e8db1405c" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9df59ed2a7" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -1998,7 +1998,7 @@ M 36 108
 L 108 36 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hb916e285b4" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h42d241dad9" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2038,7 +2038,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h7d0a89dc84" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h82f4822d4e" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/lines_simple_1000_render.svg
+++ b/docs/_static/lines_simple_1000_render.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:32.658530</dc:date>
+    <dc:date>2022-10-23T17:46:35.161075</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m9db86e5a8e" d="M 0 0 
+       <path id="m7f724015cf" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9db86e5a8e" x="111.33332" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f724015cf" x="111.33332" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- mpl2005 -->
-      <g transform="translate(89.174726 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(89.174726 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -198,7 +198,7 @@ z
        <use xlink:href="#DejaVuSans-35" x="379.541016"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(88.688008 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(88.688008 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
@@ -338,7 +338,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(98.531758 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(98.531758 406.122063) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -419,12 +419,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m9db86e5a8e" x="197.843992" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f724015cf" x="197.843992" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- mpl2014 -->
-      <g transform="translate(175.685398 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(175.685398 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -469,7 +469,7 @@ z
        <use xlink:href="#DejaVuSans-34" x="379.541016"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(175.19868 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(175.19868 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -480,7 +480,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(185.04243 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(185.04243 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -491,12 +491,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m9db86e5a8e" x="284.354664" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f724015cf" x="284.354664" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- serial -->
-      <g transform="translate(270.775758 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(270.775758 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
@@ -551,7 +551,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(261.709352 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(261.709352 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -566,12 +566,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9db86e5a8e" x="370.865336" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f724015cf" x="370.865336" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- serial -->
-      <g transform="translate(357.28643 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(357.28643 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -580,7 +580,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Separate -->
-      <g transform="translate(348.220023 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(348.220023 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -591,7 +591,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(358.063773 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(358.063773 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -602,12 +602,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m9db86e5a8e" x="457.376008" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f724015cf" x="457.376008" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- serial -->
-      <g transform="translate(443.797102 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(443.797102 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -616,7 +616,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(441.483039 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(441.483039 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -700,7 +700,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(431.972102 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(431.972102 406.122063) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -739,7 +739,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(444.574445 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(444.574445 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -750,12 +750,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9db86e5a8e" x="543.88668" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f724015cf" x="543.88668" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- serial -->
-      <g transform="translate(530.307774 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(530.307774 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-65" x="52.099609"/>
        <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -764,7 +764,7 @@ z
        <use xlink:href="#DejaVuSans-6c" x="243.798828"/>
       </g>
       <!-- Chunk -->
-      <g transform="translate(527.993711 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(527.993711 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -772,7 +772,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(518.482774 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(518.482774 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -783,7 +783,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(528.789024 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(528.789024 417.319875) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -843,21 +843,21 @@ z
      <g id="line2d_7">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#pec9f965abd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="mfd792f6048" d="M 0 0 
+       <path id="ma58c8296d8" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfd792f6048" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma58c8296d8" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.00 -->
-      <g transform="translate(24.754375 372.927219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 372.927219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -876,18 +876,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 54.02 327.844341 
-L 601.2 327.844341 
-" clip-path="url(#pec9f965abd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 330.031409 
+L 601.2 330.031409 
+" clip-path="url(#p8cee1dfc6a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mfd792f6048" x="54.02" y="327.844341" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma58c8296d8" x="54.02" y="330.031409" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.05 -->
-      <g transform="translate(24.754375 331.64356)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 333.830628) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -897,18 +897,18 @@ L 601.2 327.844341
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 54.02 286.560682 
-L 601.2 286.560682 
-" clip-path="url(#pec9f965abd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 290.934818 
+L 601.2 290.934818 
+" clip-path="url(#p8cee1dfc6a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mfd792f6048" x="54.02" y="286.560682" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma58c8296d8" x="54.02" y="290.934818" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.10 -->
-      <g transform="translate(24.754375 290.359901)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 294.734037) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -918,18 +918,18 @@ L 601.2 286.560682
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 54.02 245.277023 
-L 601.2 245.277023 
-" clip-path="url(#pec9f965abd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 251.838227 
+L 601.2 251.838227 
+" clip-path="url(#p8cee1dfc6a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mfd792f6048" x="54.02" y="245.277023" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma58c8296d8" x="54.02" y="251.838227" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.15 -->
-      <g transform="translate(24.754375 249.076242)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 255.637446) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -939,18 +939,18 @@ L 601.2 245.277023
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 54.02 203.993364 
-L 601.2 203.993364 
-" clip-path="url(#pec9f965abd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 212.741636 
+L 601.2 212.741636 
+" clip-path="url(#p8cee1dfc6a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mfd792f6048" x="54.02" y="203.993364" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma58c8296d8" x="54.02" y="212.741636" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.20 -->
-      <g transform="translate(24.754375 207.792582)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 216.540855) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -960,18 +960,18 @@ L 601.2 203.993364
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 54.02 162.709705 
-L 601.2 162.709705 
-" clip-path="url(#pec9f965abd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 173.645045 
+L 601.2 173.645045 
+" clip-path="url(#p8cee1dfc6a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mfd792f6048" x="54.02" y="162.709705" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma58c8296d8" x="54.02" y="173.645045" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 166.508923)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 177.444264) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -981,18 +981,18 @@ L 601.2 162.709705
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 54.02 121.426046 
-L 601.2 121.426046 
-" clip-path="url(#pec9f965abd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 134.548454 
+L 601.2 134.548454 
+" clip-path="url(#p8cee1dfc6a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mfd792f6048" x="54.02" y="121.426046" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma58c8296d8" x="54.02" y="134.548454" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.30 -->
-      <g transform="translate(24.754375 125.225264)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 138.347673) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1036,18 +1036,18 @@ z
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 54.02 80.142387 
-L 601.2 80.142387 
-" clip-path="url(#pec9f965abd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 95.451864 
+L 601.2 95.451864 
+" clip-path="url(#p8cee1dfc6a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mfd792f6048" x="54.02" y="80.142387" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma58c8296d8" x="54.02" y="95.451864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.35 -->
-      <g transform="translate(24.754375 83.941605)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 99.251082) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-33" x="95.410156"/>
@@ -1057,18 +1057,18 @@ L 601.2 80.142387
     </g>
     <g id="ytick_9">
      <g id="line2d_23">
-      <path d="M 54.02 38.858727 
-L 601.2 38.858727 
-" clip-path="url(#pec9f965abd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 56.355273 
+L 601.2 56.355273 
+" clip-path="url(#p8cee1dfc6a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mfd792f6048" x="54.02" y="38.858727" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma58c8296d8" x="54.02" y="56.355273" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 0.40 -->
-      <g transform="translate(24.754375 42.657946)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 60.154491) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -1078,7 +1078,7 @@ L 601.2 38.858727
     </g>
     <g id="text_16">
      <!-- Time (seconds) -->
-     <g transform="translate(18.674688 236.165719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.674688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1160,45 +1160,114 @@ z
    <g id="patch_3">
     <path d="M 78.891818 369.128 
 L 100.519486 369.128 
-L 100.519486 147.477291 
-L 78.891818 147.477291 
+L 100.519486 172.363397 
+L 78.891818 172.363397 
 z
-" clip-path="url(#pec9f965abd)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: #eedd88; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_17">
-    <!-- 268 ms -->
-    <g transform="translate(92.465027 142.477291)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
+    <!-- 252 ms -->
+    <g transform="translate(92.465027 167.363397) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 100.519486 369.128 
+L 122.147154 369.128 
+L 122.147154 178.642439 
+L 100.519486 178.642439 
 z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+" clip-path="url(#p8cee1dfc6a)" style="fill: url(#h93921850e0); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_18">
+    <!-- 244 ms -->
+    <g transform="translate(114.092695 173.642439) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 165.40249 369.128 
+L 187.030158 369.128 
+L 187.030158 72.809385 
+L 165.40249 72.809385 
+z
+" clip-path="url(#p8cee1dfc6a)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 379 ms -->
+    <g transform="translate(178.975699 67.809385) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 187.030158 369.128 
+L 208.657826 369.128 
+L 208.657826 105.10275 
+L 187.030158 105.10275 
+z
+" clip-path="url(#p8cee1dfc6a)" style="fill: url(#h661afd0d00); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 338 ms -->
+    <g transform="translate(200.603367 100.10275) rotate(-90) scale(0.1 -0.1)">
+     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1239,98 +1308,9 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_4">
-    <path d="M 100.519486 369.128 
-L 122.147154 369.128 
-L 122.147154 152.31419 
-L 100.519486 152.31419 
-z
-" clip-path="url(#pec9f965abd)" style="fill: url(#hfdcb7ae88d); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_18">
-    <!-- 263 ms -->
-    <g transform="translate(114.092695 147.31419)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 165.40249 369.128 
-L 187.030158 369.128 
-L 187.030158 72.809385 
-L 165.40249 72.809385 
-z
-" clip-path="url(#pec9f965abd)" style="fill: #ee8866; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 359 ms -->
-    <g transform="translate(178.975699 67.809385)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 187.030158 369.128 
-L 208.657826 369.128 
-L 208.657826 104.138289 
-L 187.030158 104.138289 
-z
-" clip-path="url(#pec9f965abd)" style="fill: url(#hfca6eb430e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 321 ms -->
-    <g transform="translate(200.603367 99.138289)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1339,29 +1319,49 @@ z
    <g id="patch_7">
     <path d="M 208.657826 369.128 
 L 230.285494 369.128 
-L 230.285494 82.650844 
-L 208.657826 82.650844 
+L 230.285494 87.008421 
+L 208.657826 87.008421 
 z
-" clip-path="url(#pec9f965abd)" style="fill: url(#hc9814e6670); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: url(#hf493309d9a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_21">
-    <!-- 347 ms -->
-    <g transform="translate(222.231035 77.650844)rotate(-90)scale(0.1 -0.1)">
+    <!-- 361 ms -->
+    <g transform="translate(222.231035 82.008421) rotate(-90) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1370,74 +1370,74 @@ z
    <g id="patch_8">
     <path d="M 251.913162 369.128 
 L 273.54083 369.128 
-L 273.54083 160.795644 
-L 251.913162 160.795644 
+L 273.54083 166.968685 
+L 251.913162 166.968685 
 z
-" clip-path="url(#pec9f965abd)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 338.423834 369.128 
 L 360.051502 369.128 
-L 360.051502 160.449702 
-L 338.423834 160.449702 
+L 360.051502 166.139222 
+L 338.423834 166.139222 
 z
-" clip-path="url(#pec9f965abd)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 424.934506 369.128 
 L 446.562174 369.128 
-L 446.562174 160.911105 
-L 424.934506 160.911105 
+L 446.562174 167.100701 
+L 424.934506 167.100701 
 z
-" clip-path="url(#pec9f965abd)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 511.445178 369.128 
 L 533.072846 369.128 
-L 533.072846 160.572569 
-L 511.445178 160.572569 
+L 533.072846 166.946667 
+L 511.445178 166.946667 
 z
-" clip-path="url(#pec9f965abd)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_22">
-    <!-- 252 ms -->
-    <g transform="translate(265.486371 155.795644)rotate(-90)scale(0.1 -0.1)">
+    <!-- 259 ms -->
+    <g transform="translate(265.486371 161.968685) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- 253 ms -->
-    <g transform="translate(351.997043 155.449702)rotate(-90)scale(0.1 -0.1)">
+    <!-- 260 ms -->
+    <g transform="translate(351.997043 161.139222) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 252 ms -->
-    <g transform="translate(438.507715 155.911105)rotate(-90)scale(0.1 -0.1)">
+    <!-- 258 ms -->
+    <g transform="translate(438.507715 162.100701) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 253 ms -->
-    <g transform="translate(525.018387 155.572569)rotate(-90)scale(0.1 -0.1)">
+    <!-- 259 ms -->
+    <g transform="translate(525.018387 161.946667) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1446,74 +1446,74 @@ z
    <g id="patch_12">
     <path d="M 273.54083 369.128 
 L 295.168498 369.128 
-L 295.168498 174.692643 
-L 273.54083 174.692643 
+L 295.168498 179.103315 
+L 273.54083 179.103315 
 z
-" clip-path="url(#pec9f965abd)" style="fill: url(#h17bec6da61); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: url(#hd842b8bae1); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 360.051502 369.128 
 L 381.67917 369.128 
-L 381.67917 173.915323 
-L 360.051502 173.915323 
+L 381.67917 178.809367 
+L 360.051502 178.809367 
 z
-" clip-path="url(#pec9f965abd)" style="fill: url(#h17bec6da61); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: url(#hd842b8bae1); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 446.562174 369.128 
 L 468.189842 369.128 
-L 468.189842 174.412896 
-L 446.562174 174.412896 
+L 468.189842 179.687369 
+L 446.562174 179.687369 
 z
-" clip-path="url(#pec9f965abd)" style="fill: url(#h17bec6da61); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: url(#hd842b8bae1); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 533.072846 369.128 
 L 554.700514 369.128 
-L 554.700514 174.131677 
-L 533.072846 174.131677 
+L 554.700514 179.244877 
+L 533.072846 179.244877 
 z
-" clip-path="url(#pec9f965abd)" style="fill: url(#h17bec6da61); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: url(#hd842b8bae1); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_26">
-    <!-- 235 ms -->
-    <g transform="translate(287.114039 169.692643)rotate(-90)scale(0.1 -0.1)">
+    <!-- 243 ms -->
+    <g transform="translate(287.114039 174.103315) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- 236 ms -->
-    <g transform="translate(373.624711 168.915323)rotate(-90)scale(0.1 -0.1)">
+    <!-- 243 ms -->
+    <g transform="translate(373.624711 173.809367) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 236 ms -->
-    <g transform="translate(460.135383 169.412896)rotate(-90)scale(0.1 -0.1)">
+    <!-- 242 ms -->
+    <g transform="translate(460.135383 174.687369) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 236 ms -->
-    <g transform="translate(546.646055 169.131677)rotate(-90)scale(0.1 -0.1)">
+    <!-- 243 ms -->
+    <g transform="translate(546.646055 174.244877) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1522,74 +1522,74 @@ z
    <g id="patch_16">
     <path d="M 295.168498 369.128 
 L 316.796166 369.128 
-L 316.796166 173.534154 
-L 295.168498 173.534154 
+L 316.796166 177.995305 
+L 295.168498 177.995305 
 z
-" clip-path="url(#pec9f965abd)" style="fill: url(#h9e002b0367); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: url(#h5dfebf41bf); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 381.67917 369.128 
 L 403.306838 369.128 
-L 403.306838 173.094353 
-L 381.67917 173.094353 
+L 403.306838 177.929498 
+L 381.67917 177.929498 
 z
-" clip-path="url(#pec9f965abd)" style="fill: url(#h9e002b0367); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: url(#h5dfebf41bf); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 468.189842 369.128 
 L 489.81751 369.128 
-L 489.81751 173.652793 
-L 468.189842 173.652793 
+L 489.81751 178.607075 
+L 468.189842 178.607075 
 z
-" clip-path="url(#pec9f965abd)" style="fill: url(#h9e002b0367); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: url(#h5dfebf41bf); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 554.700514 369.128 
 L 576.328182 369.128 
-L 576.328182 173.43395 
-L 554.700514 173.43395 
+L 576.328182 178.454604 
+L 554.700514 178.454604 
 z
-" clip-path="url(#pec9f965abd)" style="fill: url(#h9e002b0367); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8cee1dfc6a)" style="fill: url(#h5dfebf41bf); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_30">
-    <!-- 237 ms -->
-    <g transform="translate(308.741707 168.534154)rotate(-90)scale(0.1 -0.1)">
+    <!-- 244 ms -->
+    <g transform="translate(308.741707 172.995305) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 237 ms -->
-    <g transform="translate(395.252379 168.094353)rotate(-90)scale(0.1 -0.1)">
+    <!-- 245 ms -->
+    <g transform="translate(395.252379 172.929498) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 237 ms -->
-    <g transform="translate(481.763051 168.652793)rotate(-90)scale(0.1 -0.1)">
+    <!-- 244 ms -->
+    <g transform="translate(481.763051 173.607075) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 237 ms -->
-    <g transform="translate(568.273723 168.43395)rotate(-90)scale(0.1 -0.1)">
+    <!-- 244 ms -->
+    <g transform="translate(568.273723 173.454604) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1597,7 +1597,7 @@ z
    </g>
    <g id="text_34">
     <!-- lines simple n=1000 (calculate and render) -->
-    <g transform="translate(197.320938 20.88)scale(0.12 -0.12)">
+    <g transform="translate(197.320938 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
@@ -1701,7 +1701,7 @@ z
     </g>
     <g id="text_35">
      <!-- mpl2005 no mask -->
-     <g transform="translate(447.19375 253.910813)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 253.910813) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1725,11 +1725,11 @@ L 439.19375 268.588938
 L 439.19375 261.588938 
 L 419.19375 261.588938 
 z
-" style="fill: url(#hfdcb7ae88d); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h93921850e0); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_36">
      <!-- mpl2005 corner_mask=False -->
-     <g transform="translate(447.19375 268.588938)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 268.588938) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-5f" d="M 3263 -1063 
 L 3263 -1509 
@@ -1789,7 +1789,7 @@ z
     </g>
     <g id="text_37">
      <!-- mpl2014 no mask -->
-     <g transform="translate(447.19375 283.545187)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 283.545187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1813,11 +1813,11 @@ L 439.19375 298.223313
 L 439.19375 291.223313 
 L 419.19375 291.223313 
 z
-" style="fill: url(#hfca6eb430e); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h661afd0d00); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_38">
      <!-- mpl2014 corner_mask=False -->
-     <g transform="translate(447.19375 298.223313)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 298.223313) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1851,11 +1851,11 @@ L 439.19375 313.179563
 L 439.19375 306.179563 
 L 419.19375 306.179563 
 z
-" style="fill: url(#hc9814e6670); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hf493309d9a); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_39">
      <!-- mpl2014 corner_mask=True -->
-     <g transform="translate(447.19375 313.179563)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 313.179563) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
       <use xlink:href="#DejaVuSans-70" x="97.412109"/>
       <use xlink:href="#DejaVuSans-6c" x="160.888672"/>
@@ -1892,7 +1892,7 @@ z
     </g>
     <g id="text_40">
      <!-- serial no mask -->
-     <g transform="translate(447.19375 328.135813)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 328.135813) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1915,11 +1915,11 @@ L 439.19375 342.813938
 L 439.19375 335.813938 
 L 419.19375 335.813938 
 z
-" style="fill: url(#h17bec6da61); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hd842b8bae1); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_41">
      <!-- serial corner_mask=False -->
-     <g transform="translate(447.19375 342.813938)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 342.813938) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1952,11 +1952,11 @@ L 439.19375 357.770188
 L 439.19375 350.770188 
 L 419.19375 350.770188 
 z
-" style="fill: url(#h9e002b0367); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h5dfebf41bf); stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_42">
      <!-- serial corner_mask=True -->
-     <g transform="translate(447.19375 357.770188)scale(0.1 -0.1)">
+     <g transform="translate(447.19375 357.770188) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1986,12 +1986,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pec9f965abd">
+  <clipPath id="p8cee1dfc6a">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="hfdcb7ae88d" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h93921850e0" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2031,7 +2031,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hfca6eb430e" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h661afd0d00" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2071,7 +2071,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hc9814e6670" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hf493309d9a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2113,7 +2113,7 @@ M 36 108
 L 108 36 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h17bec6da61" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hd842b8bae1" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2153,7 +2153,7 @@ M 0 2
 L 72 2 
 " style="fill: #444444; stroke: #444444; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h9e002b0367" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h5dfebf41bf" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/threaded_filled_random.svg
+++ b/docs/_static/threaded_filled_random.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:34.467281</dc:date>
+    <dc:date>2022-10-23T17:46:36.824229</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mb1bad052a6" d="M 0 0 
+       <path id="m6c3e8c8900" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb1bad052a6" x="114.422987" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c3e8c8900" x="114.422987" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Outer -->
-      <g transform="translate(100.226112 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(100.226112 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -169,7 +169,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(101.621425 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(101.621425 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -250,12 +250,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mb1bad052a6" x="199.697792" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c3e8c8900" x="199.697792" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Outer -->
-      <g transform="translate(185.500917 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(185.500917 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -263,7 +263,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(184.600136 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(184.600136 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -330,12 +330,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mb1bad052a6" x="284.972597" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c3e8c8900" x="284.972597" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g transform="translate(269.079629 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(269.079629 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -397,7 +397,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(259.568691 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(259.568691 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -479,7 +479,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(272.171035 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(272.171035 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -490,12 +490,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb1bad052a6" x="370.247403" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c3e8c8900" x="370.247403" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g transform="translate(354.354434 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(354.354434 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -503,7 +503,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(344.843496 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(344.843496 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -514,7 +514,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(355.149746 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(355.149746 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -527,12 +527,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mb1bad052a6" x="455.522208" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c3e8c8900" x="455.522208" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Chunk -->
-      <g transform="translate(439.629239 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(439.629239 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -540,7 +540,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(430.118302 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(430.118302 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -551,14 +551,14 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(442.720645 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(442.720645 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
        <use xlink:href="#DejaVuSans-65" x="194.482422"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(440.424552 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(440.424552 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -571,12 +571,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb1bad052a6" x="540.797013" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c3e8c8900" x="540.797013" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Chunk -->
-      <g transform="translate(524.904044 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(524.904044 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -584,7 +584,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(515.393107 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(515.393107 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -595,7 +595,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(525.699357 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(525.699357 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -604,7 +604,7 @@ z
        <use xlink:href="#DejaVuSans-74" x="262.744141"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(525.699357 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(525.699357 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -620,21 +620,21 @@ z
      <g id="line2d_7">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#pc6db637756)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="m25c369f2b6" d="M 0 0 
+       <path id="m1a53a90deb" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m25c369f2b6" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a53a90deb" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.00 -->
-      <g transform="translate(24.754375 372.927219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 372.927219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -676,16 +676,16 @@ z
      <g id="line2d_9">
       <path d="M 54.02 326.347 
 L 601.2 326.347 
-" clip-path="url(#pc6db637756)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m25c369f2b6" x="54.02" y="326.347" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a53a90deb" x="54.02" y="326.347" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 330.146219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 330.146219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -748,16 +748,16 @@ z
      <g id="line2d_11">
       <path d="M 54.02 283.566 
 L 601.2 283.566 
-" clip-path="url(#pc6db637756)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m25c369f2b6" x="54.02" y="283.566" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a53a90deb" x="54.02" y="283.566" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.50 -->
-      <g transform="translate(24.754375 287.365219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 287.365219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -769,16 +769,16 @@ L 601.2 283.566
      <g id="line2d_13">
       <path d="M 54.02 240.785 
 L 601.2 240.785 
-" clip-path="url(#pc6db637756)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m25c369f2b6" x="54.02" y="240.785" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a53a90deb" x="54.02" y="240.785" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.75 -->
-      <g transform="translate(24.754375 244.584219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 244.584219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -802,16 +802,16 @@ z
      <g id="line2d_15">
       <path d="M 54.02 198.004 
 L 601.2 198.004 
-" clip-path="url(#pc6db637756)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m25c369f2b6" x="54.02" y="198.004" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a53a90deb" x="54.02" y="198.004" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.00 -->
-      <g transform="translate(24.754375 201.803219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 201.803219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -839,16 +839,16 @@ z
      <g id="line2d_17">
       <path d="M 54.02 155.223 
 L 601.2 155.223 
-" clip-path="url(#pc6db637756)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m25c369f2b6" x="54.02" y="155.223" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a53a90deb" x="54.02" y="155.223" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.25 -->
-      <g transform="translate(24.754375 159.022219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 159.022219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -860,16 +860,16 @@ L 601.2 155.223
      <g id="line2d_19">
       <path d="M 54.02 112.442 
 L 601.2 112.442 
-" clip-path="url(#pc6db637756)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m25c369f2b6" x="54.02" y="112.442" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a53a90deb" x="54.02" y="112.442" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.50 -->
-      <g transform="translate(24.754375 116.241219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 116.241219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -881,16 +881,16 @@ L 601.2 112.442
      <g id="line2d_21">
       <path d="M 54.02 69.661 
 L 601.2 69.661 
-" clip-path="url(#pc6db637756)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m25c369f2b6" x="54.02" y="69.661" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a53a90deb" x="54.02" y="69.661" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 1.75 -->
-      <g transform="translate(24.754375 73.460219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 73.460219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-37" x="95.410156"/>
@@ -902,16 +902,16 @@ L 601.2 69.661
      <g id="line2d_23">
       <path d="M 54.02 26.88 
 L 601.2 26.88 
-" clip-path="url(#pc6db637756)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m25c369f2b6" x="54.02" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a53a90deb" x="54.02" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 2.00 -->
-      <g transform="translate(24.754375 30.679219)scale(0.1 -0.1)">
+      <g transform="translate(24.754375 30.679219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -921,7 +921,7 @@ L 601.2 26.88
     </g>
     <g id="text_16">
      <!-- Time (seconds) -->
-     <g transform="translate(18.674688 236.165719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.674688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1023,99 +1023,65 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 78.891818 369.128 
 L 93.104286 369.128 
-L 93.104286 73.661629 
-L 78.891818 73.661629 
+L 93.104286 74.559861 
+L 78.891818 74.559861 
 z
-" clip-path="url(#pc6db637756)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 164.166623 369.128 
 L 178.379091 369.128 
-L 178.379091 82.025437 
-L 164.166623 82.025437 
+L 178.379091 83.73853 
+L 164.166623 83.73853 
 z
-" clip-path="url(#pc6db637756)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 249.441429 369.128 
 L 263.653896 369.128 
-L 263.653896 197.823947 
-L 249.441429 197.823947 
+L 263.653896 201.762078 
+L 249.441429 201.762078 
 z
-" clip-path="url(#pc6db637756)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 334.716234 369.128 
 L 348.928701 369.128 
-L 348.928701 199.262611 
-L 334.716234 199.262611 
+L 348.928701 202.189832 
+L 334.716234 202.189832 
 z
-" clip-path="url(#pc6db637756)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 419.991039 369.128 
 L 434.203506 369.128 
-L 434.203506 191.273034 
-L 419.991039 191.273034 
+L 434.203506 195.239415 
+L 419.991039 195.239415 
 z
-" clip-path="url(#pc6db637756)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 505.265844 369.128 
 L 519.478312 369.128 
-L 519.478312 192.660951 
-L 505.265844 192.660951 
+L 519.478312 195.767212 
+L 505.265844 195.767212 
 z
-" clip-path="url(#pc6db637756)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd26f1c9e80)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_17">
-    <!-- 1.73 s -->
-    <g transform="translate(88.757427 68.661629)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 1.72 s -->
+    <g transform="translate(88.757427 69.559861) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_18">
-    <!-- 1.68 s -->
-    <g transform="translate(174.032232 77.025437)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.67 s -->
+    <g transform="translate(174.032232 78.73853) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1145,6 +1111,49 @@ Q 447 3434 972 4092
 Q 1497 4750 2381 4750 
 Q 2619 4750 2861 4703 
 Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 978 ms -->
+    <g transform="translate(259.307037 196.762078) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1187,71 +1196,253 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 1.00 s -->
-    <g transform="translate(259.307037 192.823947)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 993 ms -->
-    <g transform="translate(344.581843 194.262611)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 976 ms -->
+    <g transform="translate(344.581843 197.189832) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- 1.04 s -->
-    <g transform="translate(429.856648 186.273034)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.02 s -->
+    <g transform="translate(429.856648 190.239415) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 1.01 s -->
+    <g transform="translate(515.131453 190.767212) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_13">
+    <path d="M 93.104286 369.128 
+L 107.316753 369.128 
+L 107.316753 76.638107 
+L 93.104286 76.638107 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 107.316753 369.128 
+L 121.529221 369.128 
+L 121.529221 191.550191 
+L 107.316753 191.550191 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 121.529221 369.128 
+L 135.741688 369.128 
+L 135.741688 227.198475 
+L 121.529221 227.198475 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 135.741688 369.128 
+L 149.954156 369.128 
+L 149.954156 233.275357 
+L 135.741688 233.275357 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 178.379091 369.128 
+L 192.591558 369.128 
+L 192.591558 83.422764 
+L 178.379091 83.422764 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 192.591558 369.128 
+L 206.804026 369.128 
+L 206.804026 195.512766 
+L 192.591558 195.512766 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 206.804026 369.128 
+L 221.016494 369.128 
+L 221.016494 230.297453 
+L 206.804026 230.297453 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 221.016494 369.128 
+L 235.228961 369.128 
+L 235.228961 234.976958 
+L 221.016494 234.976958 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 263.653896 369.128 
+L 277.866364 369.128 
+L 277.866364 200.888615 
+L 263.653896 200.888615 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 277.866364 369.128 
+L 292.078831 369.128 
+L 292.078831 282.219949 
+L 277.866364 282.219949 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 292.078831 369.128 
+L 306.291299 369.128 
+L 306.291299 325.346845 
+L 292.078831 325.346845 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 306.291299 369.128 
+L 320.503766 369.128 
+L 320.503766 336.451946 
+L 306.291299 336.451946 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 348.928701 369.128 
+L 363.141169 369.128 
+L 363.141169 201.445001 
+L 348.928701 201.445001 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 363.141169 369.128 
+L 377.353636 369.128 
+L 377.353636 285.748206 
+L 363.141169 285.748206 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 377.353636 369.128 
+L 391.566104 369.128 
+L 391.566104 325.450406 
+L 377.353636 325.450406 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 391.566104 369.128 
+L 405.778571 369.128 
+L 405.778571 336.582551 
+L 391.566104 336.582551 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 434.203506 369.128 
+L 448.415974 369.128 
+L 448.415974 193.95633 
+L 434.203506 193.95633 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 448.415974 369.128 
+L 462.628442 369.128 
+L 462.628442 281.660614 
+L 448.415974 281.660614 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 462.628442 369.128 
+L 476.840909 369.128 
+L 476.840909 323.768642 
+L 462.628442 323.768642 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 476.840909 369.128 
+L 491.053377 369.128 
+L 491.053377 335.394477 
+L 476.840909 335.394477 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 519.478312 369.128 
+L 533.690779 369.128 
+L 533.690779 194.835489 
+L 519.478312 194.835489 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 533.690779 369.128 
+L 547.903247 369.128 
+L 547.903247 282.579817 
+L 533.690779 282.579817 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 547.903247 369.128 
+L 562.115714 369.128 
+L 562.115714 323.698927 
+L 547.903247 323.698927 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 562.115714 369.128 
+L 576.328182 369.128 
+L 576.328182 335.508939 
+L 562.115714 335.508939 
+z
+" clip-path="url(#pd26f1c9e80)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_23">
+    <!-- 1.71 s -->
+    <g transform="translate(102.969894 71.638107) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 1.04 s (x 1.66) -->
+    <g transform="translate(117.182362 186.550191) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1272,233 +1463,6 @@ L 313 1709
 L 2253 4666 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 1.03 s -->
-    <g transform="translate(515.131453 187.660951)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_13">
-    <path d="M 93.104286 369.128 
-L 107.316753 369.128 
-L 107.316753 71.977748 
-L 93.104286 71.977748 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 107.316753 369.128 
-L 121.529221 369.128 
-L 121.529221 190.373861 
-L 107.316753 190.373861 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 121.529221 369.128 
-L 135.741688 369.128 
-L 135.741688 227.959421 
-L 121.529221 227.959421 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 135.741688 369.128 
-L 149.954156 369.128 
-L 149.954156 233.166705 
-L 135.741688 233.166705 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 178.379091 369.128 
-L 192.591558 369.128 
-L 192.591558 78.512196 
-L 178.379091 78.512196 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 192.591558 369.128 
-L 206.804026 369.128 
-L 206.804026 195.132906 
-L 192.591558 195.132906 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 206.804026 369.128 
-L 221.016494 369.128 
-L 221.016494 228.988839 
-L 206.804026 228.988839 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 221.016494 369.128 
-L 235.228961 369.128 
-L 235.228961 234.965311 
-L 221.016494 234.965311 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 263.653896 369.128 
-L 277.866364 369.128 
-L 277.866364 197.881697 
-L 263.653896 197.881697 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_22">
-    <path d="M 277.866364 369.128 
-L 292.078831 369.128 
-L 292.078831 280.679371 
-L 277.866364 280.679371 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_23">
-    <path d="M 292.078831 369.128 
-L 306.291299 369.128 
-L 306.291299 324.707395 
-L 292.078831 324.707395 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 306.291299 369.128 
-L 320.503766 369.128 
-L 320.503766 336.052144 
-L 306.291299 336.052144 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 348.928701 369.128 
-L 363.141169 369.128 
-L 363.141169 199.055034 
-L 348.928701 199.055034 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 363.141169 369.128 
-L 377.353636 369.128 
-L 377.353636 284.779346 
-L 363.141169 284.779346 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 377.353636 369.128 
-L 391.566104 369.128 
-L 391.566104 325.097077 
-L 377.353636 325.097077 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 391.566104 369.128 
-L 405.778571 369.128 
-L 405.778571 336.338272 
-L 391.566104 336.338272 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_29">
-    <path d="M 434.203506 369.128 
-L 448.415974 369.128 
-L 448.415974 190.481291 
-L 434.203506 190.481291 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_30">
-    <path d="M 448.415974 369.128 
-L 462.628442 369.128 
-L 462.628442 280.153267 
-L 448.415974 280.153267 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_31">
-    <path d="M 462.628442 369.128 
-L 476.840909 369.128 
-L 476.840909 322.88337 
-L 462.628442 322.88337 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_32">
-    <path d="M 476.840909 369.128 
-L 491.053377 369.128 
-L 491.053377 334.88757 
-L 476.840909 334.88757 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_33">
-    <path d="M 519.478312 369.128 
-L 533.690779 369.128 
-L 533.690779 192.562482 
-L 519.478312 192.562482 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_34">
-    <path d="M 533.690779 369.128 
-L 547.903247 369.128 
-L 547.903247 281.351026 
-L 533.690779 281.351026 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_35">
-    <path d="M 547.903247 369.128 
-L 562.115714 369.128 
-L 562.115714 323.369302 
-L 547.903247 323.369302 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_36">
-    <path d="M 562.115714 369.128 
-L 576.328182 369.128 
-L 576.328182 335.14019 
-L 562.115714 335.14019 
-z
-" clip-path="url(#pc6db637756)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_23">
-    <!-- 1.74 s -->
-    <g transform="translate(102.969894 66.977748)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 1.04 s (x 1.65) -->
-    <g transform="translate(117.182362 185.373861)rotate(-90)scale(0.1 -0.1)">
-     <defs>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
 L 3578 0 
@@ -1528,16 +1492,16 @@ z
      <use xlink:href="#DejaVuSans-31" x="468.310547"/>
      <use xlink:href="#DejaVuSans-2e" x="531.933594"/>
      <use xlink:href="#DejaVuSans-36" x="563.720703"/>
-     <use xlink:href="#DejaVuSans-35" x="627.34375"/>
+     <use xlink:href="#DejaVuSans-36" x="627.34375"/>
      <use xlink:href="#DejaVuSans-29" x="690.966797"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 825 ms (x 2.09) -->
-    <g transform="translate(131.39483 222.959421)rotate(-90)scale(0.1 -0.1)">
+    <!-- 829 ms (x 2.08) -->
+    <g transform="translate(131.39483 222.198475) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1548,16 +1512,16 @@ z
      <use xlink:href="#DejaVuSans-32" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-38" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 795 ms (x 2.17) -->
-    <g transform="translate(145.607297 228.166705)rotate(-90)scale(0.1 -0.1)">
+    <!-- 794 ms (x 2.17) -->
+    <g transform="translate(145.607297 228.275357) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1573,23 +1537,23 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 1.70 s -->
-    <g transform="translate(188.2447 73.512196)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.67 s -->
+    <g transform="translate(188.2447 78.422764) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 1.02 s (x 1.65) -->
-    <g transform="translate(202.457167 190.132906)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.01 s (x 1.64) -->
+    <g transform="translate(202.457167 190.512766) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
      <use xlink:href="#DejaVuSans-20" x="306.542969"/>
@@ -1599,16 +1563,16 @@ z
      <use xlink:href="#DejaVuSans-31" x="468.310547"/>
      <use xlink:href="#DejaVuSans-2e" x="531.933594"/>
      <use xlink:href="#DejaVuSans-36" x="563.720703"/>
-     <use xlink:href="#DejaVuSans-35" x="627.34375"/>
+     <use xlink:href="#DejaVuSans-34" x="627.34375"/>
      <use xlink:href="#DejaVuSans-29" x="690.966797"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 819 ms (x 2.05) -->
-    <g transform="translate(216.669635 223.988839)rotate(-90)scale(0.1 -0.1)">
+    <!-- 811 ms (x 2.06) -->
+    <g transform="translate(216.669635 225.297453) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1619,13 +1583,47 @@ z
      <use xlink:href="#DejaVuSans-32" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 784 ms (x 2.14) -->
-    <g transform="translate(230.882102 229.965311)rotate(-90)scale(0.1 -0.1)">
+    <!-- 784 ms (x 2.13) -->
+    <g transform="translate(230.882102 229.976958) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-34" x="127.246094"/>
@@ -1639,27 +1637,27 @@ z
      <use xlink:href="#DejaVuSans-32" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-31" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 1.00 s -->
-    <g transform="translate(273.519505 192.881697)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    <!-- 983 ms -->
+    <g transform="translate(273.519505 195.888615) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 517 ms (x 1.94) -->
-    <g transform="translate(287.731972 275.679371)rotate(-90)scale(0.1 -0.1)">
+    <!-- 508 ms (x 1.93) -->
+    <g transform="translate(287.731972 277.219949) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1670,16 +1668,16 @@ z
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 260 ms (x 3.86) -->
-    <g transform="translate(301.94444 319.707395)rotate(-90)scale(0.1 -0.1)">
+    <!-- 256 ms (x 3.82) -->
+    <g transform="translate(301.94444 320.346845) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1690,16 +1688,16 @@ z
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-38" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 193 ms (x 5.18) -->
-    <g transform="translate(316.156907 331.052144)rotate(-90)scale(0.1 -0.1)">
+    <!-- 191 ms (x 5.12) -->
+    <g transform="translate(316.156907 331.451946) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1710,98 +1708,27 @@ z
      <use xlink:href="#DejaVuSans-35" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-31" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-38" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 994 ms -->
-    <g transform="translate(358.79431 194.055034)rotate(-90)scale(0.1 -0.1)">
+    <!-- 980 ms -->
+    <g transform="translate(358.79431 196.445001) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 493 ms (x 2.01) -->
-    <g transform="translate(373.006778 279.779346)rotate(-90)scale(0.1 -0.1)">
+    <!-- 487 ms (x 2.00) -->
+    <g transform="translate(373.006778 280.748206) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-32" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- 257 ms (x 3.86) -->
-    <g transform="translate(387.219245 320.097077)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-33" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- 192 ms (x 5.18) -->
-    <g transform="translate(401.431713 331.338272)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-35" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-31" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-38" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- 1.04 s -->
-    <g transform="translate(444.069115 185.481291)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- 520 ms (x 2.00) -->
-    <g transform="translate(458.281583 275.153267)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1816,12 +1743,12 @@ z
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_41">
-    <!-- 270 ms (x 3.85) -->
-    <g transform="translate(472.49405 317.88337)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_37">
+    <!-- 255 ms (x 3.82) -->
+    <g transform="translate(387.219245 320.450406) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1832,15 +1759,15 @@ z
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-38" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_42">
-    <!-- 200 ms (x 5.19) -->
-    <g transform="translate(486.706518 329.88757)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+   <g id="text_38">
+    <!-- 190 ms (x 5.13) -->
+    <g transform="translate(401.431713 331.582551) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1852,27 +1779,98 @@ z
      <use xlink:href="#DejaVuSans-35" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-31" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- 1.02 s -->
+    <g transform="translate(444.069115 188.95633) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- 511 ms (x 1.99) -->
+    <g transform="translate(458.281583 276.660614) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
      <use xlink:href="#DejaVuSans-39" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
+   <g id="text_41">
+    <!-- 265 ms (x 3.83) -->
+    <g transform="translate(472.49405 318.768642) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-33" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_42">
+    <!-- 197 ms (x 5.15) -->
+    <g transform="translate(486.706518 330.394477) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-35" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-31" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
    <g id="text_43">
-    <!-- 1.03 s -->
-    <g transform="translate(529.34392 187.562482)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.02 s -->
+    <g transform="translate(529.34392 189.835489) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- 513 ms (x 2.01) -->
-    <g transform="translate(543.556388 276.351026)rotate(-90)scale(0.1 -0.1)">
+    <!-- 506 ms (x 2.00) -->
+    <g transform="translate(543.556388 277.579817) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1883,16 +1881,16 @@ z
      <use xlink:href="#DejaVuSans-32" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-30" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- 267 ms (x 3.86) -->
-    <g transform="translate(557.768856 318.369302)rotate(-90)scale(0.1 -0.1)">
+    <!-- 265 ms (x 3.82) -->
+    <g transform="translate(557.768856 318.698927) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1903,16 +1901,16 @@ z
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-38" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_46">
-    <!-- 199 ms (x 5.19) -->
-    <g transform="translate(571.981323 330.14019)rotate(-90)scale(0.1 -0.1)">
+    <!-- 196 ms (x 5.16) -->
+    <g transform="translate(571.981323 330.508939) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1923,181 +1921,181 @@ z
      <use xlink:href="#DejaVuSans-35" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-31" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_47">
     <!--  1 -->
-    <g transform="translate(95.440207 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(95.440207 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_48">
     <!--  2 -->
-    <g transform="translate(109.652675 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(109.652675 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_49">
     <!--  4 -->
-    <g transform="translate(123.865142 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(123.865142 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_50">
     <!--  6 -->
-    <g transform="translate(138.07761 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(138.07761 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_51">
     <!--  1 -->
-    <g transform="translate(180.715012 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(180.715012 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_52">
     <!--  2 -->
-    <g transform="translate(194.92748 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(194.92748 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_53">
     <!--  4 -->
-    <g transform="translate(209.139947 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(209.139947 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_54">
     <!--  6 -->
-    <g transform="translate(223.352415 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(223.352415 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_55">
     <!--  1 -->
-    <g transform="translate(265.989817 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(265.989817 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_56">
     <!--  2 -->
-    <g transform="translate(280.202285 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(280.202285 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_57">
     <!--  4 -->
-    <g transform="translate(294.414752 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(294.414752 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_58">
     <!--  6 -->
-    <g transform="translate(308.62722 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(308.62722 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_59">
     <!--  1 -->
-    <g transform="translate(351.264623 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(351.264623 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_60">
     <!--  2 -->
-    <g transform="translate(365.47709 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(365.47709 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_61">
     <!--  4 -->
-    <g transform="translate(379.689558 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(379.689558 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_62">
     <!--  6 -->
-    <g transform="translate(393.902025 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(393.902025 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_63">
     <!--  1 -->
-    <g transform="translate(436.539428 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(436.539428 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_64">
     <!--  2 -->
-    <g transform="translate(450.751895 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(450.751895 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_65">
     <!--  4 -->
-    <g transform="translate(464.964363 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(464.964363 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_66">
     <!--  6 -->
-    <g transform="translate(479.17683 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(479.17683 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_67">
     <!--  1 -->
-    <g transform="translate(521.814233 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(521.814233 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_68">
     <!--  2 -->
-    <g transform="translate(536.0267 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(536.0267 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_69">
     <!--  4 -->
-    <g transform="translate(550.239168 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(550.239168 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_70">
     <!--  6 -->
-    <g transform="translate(564.451636 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(564.451636 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_71">
     <!-- filled random n=1000 -->
-    <g transform="translate(261.811563 20.88)scale(0.12 -0.12)">
+    <g transform="translate(261.811563 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -2199,7 +2197,7 @@ z
     </g>
     <g id="text_72">
      <!-- serial no mask -->
-     <g transform="translate(399.71875 43.478437)scale(0.1 -0.1)">
+     <g transform="translate(399.71875 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -2226,7 +2224,7 @@ z
     </g>
     <g id="text_73">
      <!-- threaded no mask -->
-     <g transform="translate(399.71875 58.156562)scale(0.1 -0.1)">
+     <g transform="translate(399.71875 58.156562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-74"/>
       <use xlink:href="#DejaVuSans-68" x="39.208984"/>
       <use xlink:href="#DejaVuSans-72" x="102.587891"/>
@@ -2245,7 +2243,7 @@ z
       <use xlink:href="#DejaVuSans-6b" x="851.65625"/>
      </g>
      <!-- (thread count shown at bottom of bar) -->
-     <g transform="translate(399.71875 69.354375)scale(0.1 -0.1)">
+     <g transform="translate(399.71875 69.354375) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-77" d="M 269 3500 
 L 844 3500 
@@ -2307,7 +2305,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pc6db637756">
+  <clipPath id="pd26f1c9e80">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>

--- a/docs/_static/threaded_filled_simple.svg
+++ b/docs/_static/threaded_filled_simple.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:34.663086</dc:date>
+    <dc:date>2022-10-23T17:46:36.992314</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m5807708760" d="M 0 0 
+       <path id="ma69f76b4be" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5807708760" x="120.027532" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma69f76b4be" x="120.027532" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Outer -->
-      <g transform="translate(105.830657 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(105.830657 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -169,7 +169,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(107.22597 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(107.22597 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -250,12 +250,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m5807708760" x="204.320519" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma69f76b4be" x="204.320519" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Outer -->
-      <g transform="translate(190.123644 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(190.123644 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -263,7 +263,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(189.222863 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(189.222863 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -330,12 +330,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m5807708760" x="288.613506" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma69f76b4be" x="288.613506" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g transform="translate(272.720538 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(272.720538 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -397,7 +397,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(263.2096 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(263.2096 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -479,7 +479,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(275.811944 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(275.811944 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -490,12 +490,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5807708760" x="372.906494" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma69f76b4be" x="372.906494" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g transform="translate(357.013525 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(357.013525 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -503,7 +503,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(347.502587 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(347.502587 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -514,7 +514,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(357.808837 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(357.808837 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -527,12 +527,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m5807708760" x="457.199481" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma69f76b4be" x="457.199481" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Chunk -->
-      <g transform="translate(441.306512 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(441.306512 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -540,7 +540,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(431.795574 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(431.795574 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -551,14 +551,14 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(444.397918 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(444.397918 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
        <use xlink:href="#DejaVuSans-65" x="194.482422"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(442.101824 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(442.101824 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -571,12 +571,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5807708760" x="541.492468" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma69f76b4be" x="541.492468" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Chunk -->
-      <g transform="translate(525.599499 383.726438)scale(0.1 -0.1)">
+      <g transform="translate(525.599499 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -584,7 +584,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(516.088561 394.92425)scale(0.1 -0.1)">
+      <g transform="translate(516.088561 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -595,7 +595,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(526.394811 406.122063)scale(0.1 -0.1)">
+      <g transform="translate(526.394811 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -604,7 +604,7 @@ z
        <use xlink:href="#DejaVuSans-74" x="262.744141"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(526.394811 417.319875)scale(0.1 -0.1)">
+      <g transform="translate(526.394811 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -620,21 +620,21 @@ z
      <g id="line2d_7">
       <path d="M 60.32 369.128 
 L 601.2 369.128 
-" clip-path="url(#pd4a3229f21)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p557f613206)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="m145bc5f53e" d="M 0 0 
+       <path id="m2547204a9c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m145bc5f53e" x="60.32" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2547204a9c" x="60.32" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.000 -->
-      <g transform="translate(24.691875 372.927219)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 372.927219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -675,18 +675,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 60.32 324.231267 
-L 601.2 324.231267 
-" clip-path="url(#pd4a3229f21)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 328.15431 
+L 601.2 328.15431 
+" clip-path="url(#p557f613206)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m145bc5f53e" x="60.32" y="324.231267" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2547204a9c" x="60.32" y="328.15431" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.025 -->
-      <g transform="translate(24.691875 328.030486)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 331.953529) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -748,18 +748,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 60.32 279.334534 
-L 601.2 279.334534 
-" clip-path="url(#pd4a3229f21)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 287.180621 
+L 601.2 287.180621 
+" clip-path="url(#p557f613206)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m145bc5f53e" x="60.32" y="279.334534" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2547204a9c" x="60.32" y="287.180621" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.050 -->
-      <g transform="translate(24.691875 283.133752)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 290.97984) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -770,18 +770,18 @@ L 601.2 279.334534
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 60.32 234.4378 
-L 601.2 234.4378 
-" clip-path="url(#pd4a3229f21)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 246.206931 
+L 601.2 246.206931 
+" clip-path="url(#p557f613206)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m145bc5f53e" x="60.32" y="234.4378" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2547204a9c" x="60.32" y="246.206931" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.075 -->
-      <g transform="translate(24.691875 238.237019)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 250.00615) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -804,18 +804,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 60.32 189.541067 
-L 601.2 189.541067 
-" clip-path="url(#pd4a3229f21)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 205.233242 
+L 601.2 205.233242 
+" clip-path="url(#p557f613206)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m145bc5f53e" x="60.32" y="189.541067" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2547204a9c" x="60.32" y="205.233242" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.100 -->
-      <g transform="translate(24.691875 193.340286)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 209.032461) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -842,18 +842,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 60.32 144.644334 
-L 601.2 144.644334 
-" clip-path="url(#pd4a3229f21)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 164.259552 
+L 601.2 164.259552 
+" clip-path="url(#p557f613206)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m145bc5f53e" x="60.32" y="144.644334" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2547204a9c" x="60.32" y="164.259552" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.125 -->
-      <g transform="translate(24.691875 148.443553)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 168.058771) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -864,18 +864,18 @@ L 601.2 144.644334
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 60.32 99.747601 
-L 601.2 99.747601 
-" clip-path="url(#pd4a3229f21)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 123.285863 
+L 601.2 123.285863 
+" clip-path="url(#p557f613206)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m145bc5f53e" x="60.32" y="99.747601" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2547204a9c" x="60.32" y="123.285863" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.150 -->
-      <g transform="translate(24.691875 103.54682)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 127.085082) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -886,18 +886,18 @@ L 601.2 99.747601
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 60.32 54.850868 
-L 601.2 54.850868 
-" clip-path="url(#pd4a3229f21)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 82.312173 
+L 601.2 82.312173 
+" clip-path="url(#p557f613206)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m145bc5f53e" x="60.32" y="54.850868" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2547204a9c" x="60.32" y="82.312173" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.175 -->
-      <g transform="translate(24.691875 58.650086)scale(0.1 -0.1)">
+      <g transform="translate(24.691875 86.111392) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -906,9 +906,31 @@ L 601.2 54.850868
       </g>
      </g>
     </g>
-    <g id="text_15">
+    <g id="ytick_9">
+     <g id="line2d_23">
+      <path d="M 60.32 41.338484 
+L 601.2 41.338484 
+" clip-path="url(#p557f613206)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m2547204a9c" x="60.32" y="41.338484" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0.200 -->
+      <g transform="translate(24.691875 45.137703) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
      <!-- Time (seconds) -->
-     <g transform="translate(18.612188 236.165719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.612188 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1010,54 +1032,374 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 84.905455 369.128 
 L 98.954286 369.128 
-L 98.954286 124.249429 
-L 84.905455 124.249429 
+L 98.954286 123.567116 
+L 84.905455 123.567116 
 z
-" clip-path="url(#pd4a3229f21)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p557f613206)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 169.198442 369.128 
 L 183.247273 369.128 
-L 183.247273 123.981467 
-L 169.198442 123.981467 
+L 183.247273 123.484687 
+L 169.198442 123.484687 
 z
-" clip-path="url(#pd4a3229f21)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p557f613206)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 253.491429 369.128 
 L 267.54026 369.128 
-L 267.54026 123.858851 
-L 253.491429 123.858851 
+L 267.54026 125.373012 
+L 253.491429 125.373012 
 z
-" clip-path="url(#pd4a3229f21)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p557f613206)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 337.784416 369.128 
 L 351.833247 369.128 
-L 351.833247 122.995477 
-L 337.784416 122.995477 
+L 351.833247 123.620666 
+L 337.784416 123.620666 
 z
-" clip-path="url(#pd4a3229f21)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p557f613206)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 422.077403 369.128 
 L 436.126234 369.128 
-L 436.126234 122.195821 
-L 422.077403 122.195821 
+L 436.126234 125.01675 
+L 422.077403 125.01675 
 z
-" clip-path="url(#pd4a3229f21)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p557f613206)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 506.37039 369.128 
 L 520.419221 369.128 
-L 520.419221 122.441887 
-L 506.37039 122.441887 
+L 520.419221 124.317698 
+L 506.37039 124.317698 
 z
-" clip-path="url(#pd4a3229f21)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p557f613206)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_16">
-    <!-- 136 ms -->
-    <g transform="translate(94.689245 119.249429)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_17">
+    <!-- 150 ms -->
+    <g transform="translate(94.689245 118.567116) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 150 ms -->
+    <g transform="translate(178.982232 118.484687) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 149 ms -->
+    <g transform="translate(263.275219 120.373012) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 150 ms -->
+    <g transform="translate(347.568206 118.620666) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 149 ms -->
+    <g transform="translate(431.861193 120.01675) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 149 ms -->
+    <g transform="translate(516.15418 119.317698) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_13">
+    <path d="M 98.954286 369.128 
+L 113.003117 369.128 
+L 113.003117 124.243818 
+L 98.954286 124.243818 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 113.003117 369.128 
+L 127.051948 369.128 
+L 127.051948 212.919527 
+L 113.003117 212.919527 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 127.051948 369.128 
+L 141.100779 369.128 
+L 141.100779 265.256046 
+L 127.051948 265.256046 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 141.100779 369.128 
+L 155.14961 369.128 
+L 155.14961 281.340181 
+L 141.100779 281.340181 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 183.247273 369.128 
+L 197.296104 369.128 
+L 197.296104 122.504011 
+L 183.247273 122.504011 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 197.296104 369.128 
+L 211.344935 369.128 
+L 211.344935 211.493737 
+L 197.296104 211.493737 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 211.344935 369.128 
+L 225.393766 369.128 
+L 225.393766 265.566767 
+L 211.344935 265.566767 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 225.393766 369.128 
+L 239.442597 369.128 
+L 239.442597 281.288104 
+L 225.393766 281.288104 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 267.54026 369.128 
+L 281.589091 369.128 
+L 281.589091 124.201276 
+L 267.54026 124.201276 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 281.589091 369.128 
+L 295.637922 369.128 
+L 295.637922 212.646346 
+L 281.589091 212.646346 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 295.637922 369.128 
+L 309.686753 369.128 
+L 309.686753 264.933809 
+L 295.637922 264.933809 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 309.686753 369.128 
+L 323.735584 369.128 
+L 323.735584 280.841771 
+L 309.686753 280.841771 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 351.833247 369.128 
+L 365.882078 369.128 
+L 365.882078 122.195821 
+L 351.833247 122.195821 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 365.882078 369.128 
+L 379.930909 369.128 
+L 379.930909 212.633146 
+L 365.882078 212.633146 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 379.930909 369.128 
+L 393.97974 369.128 
+L 393.97974 265.077114 
+L 379.930909 265.077114 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 393.97974 369.128 
+L 408.028571 369.128 
+L 408.028571 281.483167 
+L 393.97974 281.483167 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 436.126234 369.128 
+L 450.175065 369.128 
+L 450.175065 123.494025 
+L 436.126234 123.494025 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 450.175065 369.128 
+L 464.223896 369.128 
+L 464.223896 210.976335 
+L 450.175065 210.976335 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 464.223896 369.128 
+L 478.272727 369.128 
+L 478.272727 264.992289 
+L 464.223896 264.992289 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 478.272727 369.128 
+L 492.321558 369.128 
+L 492.321558 280.951241 
+L 478.272727 280.951241 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 520.419221 369.128 
+L 534.468052 369.128 
+L 534.468052 123.112406 
+L 520.419221 123.112406 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 534.468052 369.128 
+L 548.516883 369.128 
+L 548.516883 212.852356 
+L 534.468052 212.852356 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 548.516883 369.128 
+L 562.565714 369.128 
+L 562.565714 264.395276 
+L 548.516883 264.395276 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 562.565714 369.128 
+L 576.614545 369.128 
+L 576.614545 281.094969 
+L 562.565714 281.094969 
+z
+" clip-path="url(#p557f613206)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_23">
+    <!-- 149 ms -->
+    <g transform="translate(108.738076 119.243818) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 95.3 ms (x 1.57) -->
+    <g transform="translate(122.786907 207.919527) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1091,6 +1433,44 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 63.4 ms (x 2.36) -->
+    <g transform="translate(136.835739 260.256046) rotate(-90) scale(0.1 -0.1)">
+     <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
 Q 1191 2003 1191 1497 
@@ -1122,50 +1502,27 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_17">
-    <!-- 137 ms -->
-    <g transform="translate(178.982232 118.981467)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 137 ms -->
-    <g transform="translate(263.275219 118.858851)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 137 ms -->
-    <g transform="translate(347.568206 117.995477)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 138 ms -->
-    <g transform="translate(431.861193 117.195821)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_26">
+    <!-- 53.6 ms (x 2.80) -->
+    <g transform="translate(150.88457 276.340181) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1207,282 +1564,42 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 137 ms -->
-    <g transform="translate(516.15418 117.441887)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_13">
-    <path d="M 98.954286 369.128 
-L 113.003117 369.128 
-L 113.003117 123.997438 
-L 98.954286 123.997438 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 113.003117 369.128 
-L 127.051948 369.128 
-L 127.051948 209.158837 
-L 113.003117 209.158837 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 127.051948 369.128 
-L 141.100779 369.128 
-L 141.100779 262.559061 
-L 127.051948 262.559061 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 141.100779 369.128 
-L 155.14961 369.128 
-L 155.14961 278.880985 
-L 141.100779 278.880985 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 183.247273 369.128 
-L 197.296104 369.128 
-L 197.296104 125.075769 
-L 183.247273 125.075769 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 197.296104 369.128 
-L 211.344935 369.128 
-L 211.344935 207.116618 
-L 197.296104 207.116618 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 211.344935 369.128 
-L 225.393766 369.128 
-L 225.393766 260.579906 
-L 211.344935 260.579906 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 225.393766 369.128 
-L 239.442597 369.128 
-L 239.442597 278.992023 
-L 225.393766 278.992023 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 267.54026 369.128 
-L 281.589091 369.128 
-L 281.589091 123.756903 
-L 267.54026 123.756903 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_22">
-    <path d="M 281.589091 369.128 
-L 295.637922 369.128 
-L 295.637922 210.19287 
-L 281.589091 210.19287 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_23">
-    <path d="M 295.637922 369.128 
-L 309.686753 369.128 
-L 309.686753 262.757412 
-L 295.637922 262.757412 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 309.686753 369.128 
-L 323.735584 369.128 
-L 323.735584 278.770042 
-L 309.686753 278.770042 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 351.833247 369.128 
-L 365.882078 369.128 
-L 365.882078 125.795704 
-L 351.833247 125.795704 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 365.882078 369.128 
-L 379.930909 369.128 
-L 379.930909 209.437393 
-L 365.882078 209.437393 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 379.930909 369.128 
-L 393.97974 369.128 
-L 393.97974 262.390496 
-L 379.930909 262.390496 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 393.97974 369.128 
-L 408.028571 369.128 
-L 408.028571 277.040771 
-L 393.97974 277.040771 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_29">
-    <path d="M 436.126234 369.128 
-L 450.175065 369.128 
-L 450.175065 123.900722 
-L 436.126234 123.900722 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_30">
-    <path d="M 450.175065 369.128 
-L 464.223896 369.128 
-L 464.223896 210.498829 
-L 450.175065 210.498829 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_31">
-    <path d="M 464.223896 369.128 
-L 478.272727 369.128 
-L 478.272727 262.576755 
-L 464.223896 262.576755 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_32">
-    <path d="M 478.272727 369.128 
-L 492.321558 369.128 
-L 492.321558 278.608133 
-L 478.272727 278.608133 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_33">
-    <path d="M 520.419221 369.128 
-L 534.468052 369.128 
-L 534.468052 125.330692 
-L 520.419221 125.330692 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_34">
-    <path d="M 534.468052 369.128 
-L 548.516883 369.128 
-L 548.516883 210.100845 
-L 534.468052 210.100845 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_35">
-    <path d="M 548.516883 369.128 
-L 562.565714 369.128 
-L 562.565714 259.954377 
-L 548.516883 259.954377 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_36">
-    <path d="M 562.565714 369.128 
-L 576.614545 369.128 
-L 576.614545 278.609467 
-L 562.565714 278.609467 
-z
-" clip-path="url(#pd4a3229f21)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 136 ms -->
-    <g transform="translate(108.738076 118.997438)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 89.1 ms (x 1.53) -->
-    <g transform="translate(122.786907 204.158837)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-38" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- 150 ms -->
+    <g transform="translate(193.031063 117.504011) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 96.2 ms (x 1.56) -->
+    <g transform="translate(207.079894 206.493737) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1493,17 +1610,17 @@ z
      <use xlink:href="#DejaVuSans-31" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- 59.3 ms (x 2.30) -->
-    <g transform="translate(136.835739 257.559061)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+   <g id="text_29">
+    <!-- 63.2 ms (x 2.37) -->
+    <g transform="translate(221.128726 260.566767) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1514,17 +1631,17 @@ z
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-33" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_25">
-    <!-- 50.3 ms (x 2.71) -->
-    <g transform="translate(150.88457 273.880985)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_30">
+    <!-- 53.6 ms (x 2.80) -->
+    <g transform="translate(235.177557 276.288104) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1534,29 +1651,29 @@ z
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-37" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-38" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- 136 ms -->
-    <g transform="translate(193.031063 120.075769)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_31">
+    <!-- 149 ms -->
+    <g transform="translate(277.32405 119.201276) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- 90.2 ms (x 1.51) -->
-    <g transform="translate(207.079894 202.116618)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_32">
+    <!-- 95.5 ms (x 1.56) -->
+    <g transform="translate(291.372881 207.646346) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1567,38 +1684,17 @@ z
      <use xlink:href="#DejaVuSans-31" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- 60.4 ms (x 2.26) -->
-    <g transform="translate(221.128726 255.579906)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+   <g id="text_33">
+    <!-- 63.6 ms (x 2.34) -->
+    <g transform="translate(305.421713 259.933809) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1608,18 +1704,18 @@ z
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-32" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_29">
-    <!-- 50.2 ms (x 2.72) -->
-    <g transform="translate(235.177557 273.992023)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_34">
+    <!-- 53.9 ms (x 2.76) -->
+    <g transform="translate(319.470544 275.841771) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1630,26 +1726,100 @@ z
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-37" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_30">
-    <!-- 137 ms -->
-    <g transform="translate(277.32405 118.756903)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_35">
+    <!-- 151 ms -->
+    <g transform="translate(361.617037 117.195821) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- 88.5 ms (x 1.54) -->
-    <g transform="translate(291.372881 205.19287)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+   <g id="text_36">
+    <!-- 95.5 ms (x 1.57) -->
+    <g transform="translate(375.665869 207.633146) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- 63.5 ms (x 2.36) -->
+    <g transform="translate(389.7147 260.077114) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- 53.5 ms (x 2.80) -->
+    <g transform="translate(403.763531 276.483167) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-38" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- 150 ms -->
+    <g transform="translate(445.910024 118.494025) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- 96.5 ms (x 1.54) -->
+    <g transform="translate(459.958856 205.976335) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1666,13 +1836,13 @@ z
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_32">
-    <!-- 59.2 ms (x 2.31) -->
-    <g transform="translate(305.421713 257.757412)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+   <g id="text_41">
+    <!-- 63.5 ms (x 2.34) -->
+    <g transform="translate(474.007687 259.992289) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1683,216 +1853,15 @@ z
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-33" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- 50.3 ms (x 2.71) -->
-    <g transform="translate(319.470544 273.770042)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-37" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- 135 ms -->
-    <g transform="translate(361.617037 120.795704)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 88.9 ms (x 1.54) -->
-    <g transform="translate(375.665869 204.437393)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
      <use xlink:href="#DejaVuSans-34" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_36">
-    <!-- 59.4 ms (x 2.31) -->
-    <g transform="translate(389.7147 257.390496)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- 51.3 ms (x 2.67) -->
-    <g transform="translate(403.763531 272.040771)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- 137 ms -->
-    <g transform="translate(445.910024 118.900722)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- 88.3 ms (x 1.56) -->
-    <g transform="translate(459.958856 205.498829)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- 59.3 ms (x 2.32) -->
-    <g transform="translate(474.007687 257.576755)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_41">
-    <!-- 50.4 ms (x 2.73) -->
-    <g transform="translate(488.056518 273.608133)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-37" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
    <g id="text_42">
-    <!-- 136 ms -->
-    <g transform="translate(530.203011 120.330692)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
+    <!-- 53.8 ms (x 2.77) -->
+    <g transform="translate(488.056518 275.951241) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- 88.6 ms (x 1.55) -->
-    <g transform="translate(544.251843 205.100845)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_44">
-    <!-- 60.8 ms (x 2.26) -->
-    <g transform="translate(558.300674 254.954377)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-38" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1904,18 +1873,71 @@ z
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-32" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-37" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- 150 ms -->
+    <g transform="translate(530.203011 118.112406) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_44">
+    <!-- 95.4 ms (x 1.57) -->
+    <g transform="translate(544.251843 207.852356) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- 50.4 ms (x 2.73) -->
-    <g transform="translate(572.349505 273.609467)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+    <!-- 63.9 ms (x 2.34) -->
+    <g transform="translate(558.300674 259.395276) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_46">
+    <!-- 53.7 ms (x 2.78) -->
+    <g transform="translate(572.349505 276.094969) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1926,181 +1948,181 @@ z
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-37" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_46">
+   <g id="text_47">
     <!--  1 -->
-    <g transform="translate(101.208389 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(101.208389 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_47">
-    <!--  2 -->
-    <g transform="translate(115.25722 367.048313)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_48">
-    <!--  4 -->
-    <g transform="translate(129.306051 367.048313)scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(115.25722 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_49">
-    <!--  6 -->
-    <g transform="translate(143.354882 367.048313)scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(129.306051 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_50">
-    <!--  1 -->
-    <g transform="translate(185.501376 367.048313)scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(143.354882 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_51">
-    <!--  2 -->
-    <g transform="translate(199.550207 367.048313)scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(185.501376 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_52">
-    <!--  4 -->
-    <g transform="translate(213.599038 367.048313)scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(199.550207 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_53">
-    <!--  6 -->
-    <g transform="translate(227.647869 367.048313)scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(213.599038 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_54">
-    <!--  1 -->
-    <g transform="translate(269.794363 367.048313)scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(227.647869 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_55">
-    <!--  2 -->
-    <g transform="translate(283.843194 367.048313)scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(269.794363 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_56">
-    <!--  4 -->
-    <g transform="translate(297.892025 367.048313)scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(283.843194 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_57">
-    <!--  6 -->
-    <g transform="translate(311.940856 367.048313)scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(297.892025 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_58">
-    <!--  1 -->
-    <g transform="translate(354.08735 367.048313)scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(311.940856 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_59">
-    <!--  2 -->
-    <g transform="translate(368.136181 367.048313)scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(354.08735 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_60">
-    <!--  4 -->
-    <g transform="translate(382.185012 367.048313)scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(368.136181 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_61">
-    <!--  6 -->
-    <g transform="translate(396.233843 367.048313)scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(382.185012 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_62">
-    <!--  1 -->
-    <g transform="translate(438.380337 367.048313)scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(396.233843 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_63">
-    <!--  2 -->
-    <g transform="translate(452.429168 367.048313)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_64">
-    <!--  4 -->
-    <g transform="translate(466.477999 367.048313)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_65">
-    <!--  6 -->
-    <g transform="translate(480.52683 367.048313)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_66">
     <!--  1 -->
-    <g transform="translate(522.673324 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(438.380337 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_67">
+   <g id="text_64">
     <!--  2 -->
-    <g transform="translate(536.722155 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(452.429168 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_68">
+   <g id="text_65">
     <!--  4 -->
-    <g transform="translate(550.770986 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(466.477999 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_69">
+   <g id="text_66">
     <!--  6 -->
-    <g transform="translate(564.819817 367.048313)scale(0.1 -0.1)">
+    <g transform="translate(480.52683 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
+   <g id="text_67">
+    <!--  1 -->
+    <g transform="translate(522.673324 367.048313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_68">
+    <!--  2 -->
+    <g transform="translate(536.722155 367.048313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_69">
+    <!--  4 -->
+    <g transform="translate(550.770986 367.048313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+    </g>
+   </g>
    <g id="text_70">
+    <!--  6 -->
+    <g transform="translate(564.819817 367.048313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_71">
     <!-- filled simple n=1000 -->
-    <g transform="translate(268.4275 20.88)scale(0.12 -0.12)">
+    <g transform="translate(268.4275 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -2193,9 +2215,9 @@ L 371.71875 36.478437
 z
 " style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_71">
+    <g id="text_72">
      <!-- serial no mask -->
-     <g transform="translate(399.71875 43.478437)scale(0.1 -0.1)">
+     <g transform="translate(399.71875 43.478437) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-61" d="M 2194 1759 
 Q 1497 1759 1228 1600 
@@ -2255,9 +2277,9 @@ L 371.71875 57.795312
 z
 " style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_72">
+    <g id="text_73">
      <!-- threaded no mask -->
-     <g transform="translate(399.71875 58.156562)scale(0.1 -0.1)">
+     <g transform="translate(399.71875 58.156562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-74"/>
       <use xlink:href="#DejaVuSans-68" x="39.208984"/>
       <use xlink:href="#DejaVuSans-72" x="102.587891"/>
@@ -2276,7 +2298,7 @@ z
       <use xlink:href="#DejaVuSans-6b" x="851.65625"/>
      </g>
      <!-- (thread count shown at bottom of bar) -->
-     <g transform="translate(399.71875 69.354375)scale(0.1 -0.1)">
+     <g transform="translate(399.71875 69.354375) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-77" d="M 269 3500 
 L 844 3500 
@@ -2338,7 +2360,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pd4a3229f21">
+  <clipPath id="p557f613206">
    <rect x="60.32" y="26.88" width="540.88" height="342.248"/>
   </clipPath>
  </defs>

--- a/docs/_static/threaded_lines_random.svg
+++ b/docs/_static/threaded_lines_random.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:34.151631</dc:date>
+    <dc:date>2022-10-23T17:46:36.534255</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc4063984ef" d="M 0 0 
+       <path id="md638a6951f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc4063984ef" x="127.569881" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md638a6951f" x="127.569881" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Separate -->
-      <g transform="translate(104.924569 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(104.924569 395.390437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
@@ -223,12 +223,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc4063984ef" x="258.82996" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md638a6951f" x="258.82996" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Separate -->
-      <g transform="translate(236.184648 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(236.184648 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -239,7 +239,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(246.028398 406.58825)scale(0.1 -0.1)">
+      <g transform="translate(246.028398 406.58825) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -320,12 +320,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc4063984ef" x="390.09004" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md638a6951f" x="390.09004" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g transform="translate(374.197071 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(374.197071 395.390437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -409,7 +409,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(364.686133 406.58825)scale(0.1 -0.1)">
+      <g transform="translate(364.686133 406.58825) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -491,7 +491,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(377.288477 417.786062)scale(0.1 -0.1)">
+      <g transform="translate(377.288477 417.786062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -502,12 +502,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc4063984ef" x="521.350119" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md638a6951f" x="521.350119" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g transform="translate(505.45715 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(505.45715 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -515,7 +515,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(495.946212 406.58825)scale(0.1 -0.1)">
+      <g transform="translate(495.946212 406.58825) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -526,7 +526,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(506.252462 417.786062)scale(0.1 -0.1)">
+      <g transform="translate(506.252462 417.786062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -617,21 +617,21 @@ z
      <g id="line2d_5">
       <path d="M 47.72 380.792 
 L 601.2 380.792 
-" clip-path="url(#p9b495342ae)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p6edf6ef829)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m5fa55fb4a1" d="M 0 0 
+       <path id="m0d8c69ddb6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5fa55fb4a1" x="47.72" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d8c69ddb6" x="47.72" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 0.0 -->
-      <g transform="translate(24.816875 384.591219)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 384.591219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -672,16 +672,16 @@ z
      <g id="line2d_7">
       <path d="M 47.72 330.233143 
 L 601.2 330.233143 
-" clip-path="url(#p9b495342ae)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p6edf6ef829)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5fa55fb4a1" x="47.72" y="330.233143" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d8c69ddb6" x="47.72" y="330.233143" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 0.2 -->
-      <g transform="translate(24.816875 334.032362)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 334.032362) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -718,16 +718,16 @@ z
      <g id="line2d_9">
       <path d="M 47.72 279.674286 
 L 601.2 279.674286 
-" clip-path="url(#p9b495342ae)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p6edf6ef829)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m5fa55fb4a1" x="47.72" y="279.674286" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d8c69ddb6" x="47.72" y="279.674286" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.4 -->
-      <g transform="translate(24.816875 283.473504)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 283.473504) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -759,16 +759,16 @@ z
      <g id="line2d_11">
       <path d="M 47.72 229.115429 
 L 601.2 229.115429 
-" clip-path="url(#p9b495342ae)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p6edf6ef829)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m5fa55fb4a1" x="47.72" y="229.115429" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d8c69ddb6" x="47.72" y="229.115429" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.6 -->
-      <g transform="translate(24.816875 232.914647)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 232.914647) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -811,16 +811,16 @@ z
      <g id="line2d_13">
       <path d="M 47.72 178.556571 
 L 601.2 178.556571 
-" clip-path="url(#p9b495342ae)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p6edf6ef829)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m5fa55fb4a1" x="47.72" y="178.556571" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d8c69ddb6" x="47.72" y="178.556571" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.8 -->
-      <g transform="translate(24.816875 182.35579)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 182.35579) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -872,16 +872,16 @@ z
      <g id="line2d_15">
       <path d="M 47.72 127.997714 
 L 601.2 127.997714 
-" clip-path="url(#p9b495342ae)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p6edf6ef829)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m5fa55fb4a1" x="47.72" y="127.997714" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d8c69ddb6" x="47.72" y="127.997714" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 1.0 -->
-      <g transform="translate(24.816875 131.796933)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 131.796933) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -908,16 +908,16 @@ z
      <g id="line2d_17">
       <path d="M 47.72 77.438857 
 L 601.2 77.438857 
-" clip-path="url(#p9b495342ae)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p6edf6ef829)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m5fa55fb4a1" x="47.72" y="77.438857" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d8c69ddb6" x="47.72" y="77.438857" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.2 -->
-      <g transform="translate(24.816875 81.238076)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 81.238076) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -928,16 +928,16 @@ L 601.2 77.438857
      <g id="line2d_19">
       <path d="M 47.72 26.88 
 L 601.2 26.88 
-" clip-path="url(#p9b495342ae)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p6edf6ef829)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m5fa55fb4a1" x="47.72" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d8c69ddb6" x="47.72" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.4 -->
-      <g transform="translate(24.816875 30.679219)scale(0.1 -0.1)">
+      <g transform="translate(24.816875 30.679219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -946,7 +946,7 @@ L 601.2 26.88
     </g>
     <g id="text_13">
      <!-- Time (seconds) -->
-     <g transform="translate(18.737188 241.997719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.737188 241.997719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1048,60 +1048,38 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 72.878182 380.792 
 L 94.754862 380.792 
-L 94.754862 162.952498 
-L 72.878182 162.952498 
+L 94.754862 164.322635 
+L 72.878182 164.322635 
 z
-" clip-path="url(#p9b495342ae)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p6edf6ef829)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 204.138261 380.792 
 L 226.014941 380.792 
-L 226.014941 72.233121 
-L 204.138261 72.233121 
+L 226.014941 74.299056 
+L 204.138261 74.299056 
 z
-" clip-path="url(#p9b495342ae)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p6edf6ef829)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 335.39834 380.792 
 L 357.27502 380.792 
-L 357.27502 240.718717 
-L 335.39834 240.718717 
+L 357.27502 242.94633 
+L 335.39834 242.94633 
 z
-" clip-path="url(#p9b495342ae)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p6edf6ef829)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 466.658419 380.792 
 L 488.535099 380.792 
-L 488.535099 245.501482 
-L 466.658419 245.501482 
+L 488.535099 247.026871 
+L 466.658419 247.026871 
 z
-" clip-path="url(#p9b495342ae)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p6edf6ef829)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_14">
-    <!-- 862 ms -->
-    <g transform="translate(86.575897 157.952498)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_15">
-    <!-- 1.22 s -->
-    <g transform="translate(217.835976 67.233121)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_16">
-    <!-- 554 ms -->
-    <g transform="translate(349.096055 235.718717)rotate(-90)scale(0.1 -0.1)">
+    <!-- 856 ms -->
+    <g transform="translate(86.575897 159.322635) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1129,17 +1107,210 @@ L 691 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- 1.21 s -->
+    <g transform="translate(217.835976 69.299056) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 545 ms -->
+    <g transform="translate(349.096055 237.94633) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_17">
-    <!-- 535 ms -->
-    <g transform="translate(480.356134 240.501482)rotate(-90)scale(0.1 -0.1)">
+    <!-- 529 ms -->
+    <g transform="translate(480.356134 242.026871) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_11">
+    <path d="M 94.754862 380.792 
+L 116.631542 380.792 
+L 116.631542 162.58409 
+L 94.754862 162.58409 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 116.631542 380.792 
+L 138.508221 380.792 
+L 138.508221 250.517393 
+L 116.631542 250.517393 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 138.508221 380.792 
+L 160.384901 380.792 
+L 160.384901 276.215719 
+L 138.508221 276.215719 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 160.384901 380.792 
+L 182.261581 380.792 
+L 182.261581 279.771917 
+L 160.384901 279.771917 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 226.014941 380.792 
+L 247.891621 380.792 
+L 247.891621 73.982326 
+L 226.014941 73.982326 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 247.891621 380.792 
+L 269.7683 380.792 
+L 269.7683 174.207636 
+L 247.891621 174.207636 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 269.7683 380.792 
+L 291.64498 380.792 
+L 291.64498 193.426359 
+L 269.7683 193.426359 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 291.64498 380.792 
+L 313.52166 380.792 
+L 313.52166 196.243108 
+L 291.64498 196.243108 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 357.27502 380.792 
+L 379.1517 380.792 
+L 379.1517 241.828166 
+L 357.27502 241.828166 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 379.1517 380.792 
+L 401.028379 380.792 
+L 401.028379 309.763994 
+L 379.1517 309.763994 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 401.028379 380.792 
+L 422.905059 380.792 
+L 422.905059 340.925659 
+L 401.028379 340.925659 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 422.905059 380.792 
+L 444.781739 380.792 
+L 444.781739 349.603187 
+L 422.905059 349.603187 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 488.535099 380.792 
+L 510.411779 380.792 
+L 510.411779 246.011887 
+L 488.535099 246.011887 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 510.411779 380.792 
+L 532.288458 380.792 
+L 532.288458 310.763001 
+L 510.411779 310.763001 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 532.288458 380.792 
+L 554.165138 380.792 
+L 554.165138 341.755173 
+L 532.288458 341.755173 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 554.165138 380.792 
+L 576.041818 380.792 
+L 576.041818 350.387709 
+L 554.165138 350.387709 
+z
+" clip-path="url(#p6edf6ef829)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_18">
+    <!-- 863 ms -->
+    <g transform="translate(108.452577 157.58409) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1174,167 +1345,18 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_11">
-    <path d="M 94.754862 380.792 
-L 116.631542 380.792 
-L 116.631542 161.430491 
-L 94.754862 161.430491 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 116.631542 380.792 
-L 138.508221 380.792 
-L 138.508221 250.200334 
-L 116.631542 250.200334 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 138.508221 380.792 
-L 160.384901 380.792 
-L 160.384901 276.129369 
-L 138.508221 276.129369 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 160.384901 380.792 
-L 182.261581 380.792 
-L 182.261581 280.130618 
-L 160.384901 280.130618 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 226.014941 380.792 
-L 247.891621 380.792 
-L 247.891621 71.661679 
-L 226.014941 71.661679 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 247.891621 380.792 
-L 269.7683 380.792 
-L 269.7683 176.152018 
-L 247.891621 176.152018 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 269.7683 380.792 
-L 291.64498 380.792 
-L 291.64498 193.268543 
-L 269.7683 193.268543 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 291.64498 380.792 
-L 313.52166 380.792 
-L 313.52166 197.06608 
-L 291.64498 197.06608 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 357.27502 380.792 
-L 379.1517 380.792 
-L 379.1517 240.304301 
-L 357.27502 240.304301 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 379.1517 380.792 
-L 401.028379 380.792 
-L 401.028379 309.171047 
-L 379.1517 309.171047 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 401.028379 380.792 
-L 422.905059 380.792 
-L 422.905059 340.630736 
-L 401.028379 340.630736 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_22">
-    <path d="M 422.905059 380.792 
-L 444.781739 380.792 
-L 444.781739 349.254068 
-L 422.905059 349.254068 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_23">
-    <path d="M 488.535099 380.792 
-L 510.411779 380.792 
-L 510.411779 244.398815 
-L 488.535099 244.398815 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 510.411779 380.792 
-L 532.288458 380.792 
-L 532.288458 310.629347 
-L 510.411779 310.629347 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 532.288458 380.792 
-L 554.165138 380.792 
-L 554.165138 341.575874 
-L 532.288458 341.575874 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 554.165138 380.792 
-L 576.041818 380.792 
-L 576.041818 350.199313 
-L 554.165138 350.199313 
-z
-" clip-path="url(#p9b495342ae)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_18">
-    <!-- 868 ms -->
-    <g transform="translate(108.452577 156.430491)rotate(-90)scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_19">
-    <!-- 517 ms (x 1.67) -->
-    <g transform="translate(130.329256 245.200334)rotate(-90)scale(0.1 -0.1)">
+    <!-- 515 ms (x 1.66) -->
+    <g transform="translate(130.329256 245.517393) rotate(-90) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
 L 3578 0 
@@ -1353,7 +1375,7 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1364,13 +1386,25 @@ z
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-36" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 414 ms (x 2.08) -->
-    <g transform="translate(152.205936 271.129369)rotate(-90)scale(0.1 -0.1)">
+    <!-- 414 ms (x 2.07) -->
+    <g transform="translate(152.205936 271.215719) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-34" x="127.246094"/>
@@ -1384,48 +1418,16 @@ z
      <use xlink:href="#DejaVuSans-32" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-38" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- 398 ms (x 2.16) -->
-    <g transform="translate(174.082616 275.130618)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+    <!-- 400 ms (x 2.14) -->
+    <g transform="translate(174.082616 274.771917) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1436,66 +1438,26 @@ z
      <use xlink:href="#DejaVuSans-32" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-31" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-34" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- 1.22 s -->
-    <g transform="translate(239.712656 66.661679)rotate(-90)scale(0.1 -0.1)">
+    <!-- 1.21 s -->
+    <g transform="translate(239.712656 68.982326) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- 810 ms (x 1.51) -->
-    <g transform="translate(261.589335 171.152018)rotate(-90)scale(0.1 -0.1)">
+    <!-- 817 ms (x 1.48) -->
+    <g transform="translate(261.589335 169.207636) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-35" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 742 ms (x 1.65) -->
-    <g transform="translate(283.466015 188.268543)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-36" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 727 ms (x 1.68) -->
-    <g transform="translate(305.342695 192.06608)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1506,28 +1468,68 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-36" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
      <use xlink:href="#DejaVuSans-38" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
+   <g id="text_24">
+    <!-- 741 ms (x 1.64) -->
+    <g transform="translate(283.466015 188.426359) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-37"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-36" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 730 ms (x 1.66) -->
+    <g transform="translate(305.342695 191.243108) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-37"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-36" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
    <g id="text_26">
-    <!-- 556 ms -->
-    <g transform="translate(370.972735 235.304301)rotate(-90)scale(0.1 -0.1)">
+    <!-- 550 ms -->
+    <g transform="translate(370.972735 236.828166) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- 283 ms (x 1.96) -->
-    <g transform="translate(392.849415 304.171047)rotate(-90)scale(0.1 -0.1)">
+    <!-- 281 ms (x 1.94) -->
+    <g transform="translate(392.849415 304.763994) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1538,66 +1540,15 @@ z
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 159 ms (x 3.49) -->
-    <g transform="translate(414.726094 335.630736)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-33" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 125 ms (x 4.44) -->
-    <g transform="translate(436.602774 344.254068)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-34" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
      <use xlink:href="#DejaVuSans-34" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_30">
-    <!-- 540 ms -->
-    <g transform="translate(502.232814 239.398815)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 278 ms (x 1.93) -->
-    <g transform="translate(524.109494 305.629347)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+   <g id="text_28">
+    <!-- 158 ms (x 3.46) -->
+    <g transform="translate(414.726094 335.925659) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1606,39 +1557,19 @@ z
      <use xlink:href="#DejaVuSans-28" x="403.955078"/>
      <use xlink:href="#DejaVuSans-78" x="442.96875"/>
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 155 ms (x 3.45) -->
-    <g transform="translate(545.986173 336.575874)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-34" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_33">
-    <!-- 121 ms (x 4.42) -->
-    <g transform="translate(567.862853 345.199313)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_29">
+    <!-- 123 ms (x 4.42) -->
+    <g transform="translate(436.602774 344.603187) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1653,121 +1584,192 @@ z
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
+   <g id="text_30">
+    <!-- 533 ms -->
+    <g transform="translate(502.232814 241.011887) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 277 ms (x 1.91) -->
+    <g transform="translate(524.109494 305.763001) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 154 ms (x 3.43) -->
+    <g transform="translate(545.986173 336.755173) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-33" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- 120 ms (x 4.40) -->
+    <g transform="translate(567.862853 345.387709) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-34" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-30" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
    <g id="text_34">
     <!--  1 -->
-    <g transform="translate(100.922889 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(100.922889 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_35">
     <!--  2 -->
-    <g transform="translate(122.799569 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(122.799569 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_36">
     <!--  4 -->
-    <g transform="translate(144.676249 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(144.676249 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_37">
     <!--  6 -->
-    <g transform="translate(166.552929 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(166.552929 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_38">
     <!--  1 -->
-    <g transform="translate(232.182968 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(232.182968 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_39">
     <!--  2 -->
-    <g transform="translate(254.059648 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(254.059648 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_40">
     <!--  4 -->
-    <g transform="translate(275.936328 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(275.936328 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_41">
     <!--  6 -->
-    <g transform="translate(297.813008 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(297.813008 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_42">
     <!--  1 -->
-    <g transform="translate(363.443047 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(363.443047 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_43">
     <!--  2 -->
-    <g transform="translate(385.319727 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(385.319727 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_44">
     <!--  4 -->
-    <g transform="translate(407.196407 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(407.196407 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_45">
     <!--  6 -->
-    <g transform="translate(429.073087 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(429.073087 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_46">
     <!--  1 -->
-    <g transform="translate(494.703126 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(494.703126 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_47">
     <!--  2 -->
-    <g transform="translate(516.579806 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(516.579806 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_48">
     <!--  4 -->
-    <g transform="translate(538.456486 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(538.456486 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_49">
     <!--  6 -->
-    <g transform="translate(560.333166 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(560.333166 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_50">
     <!-- lines random n=1000 -->
-    <g transform="translate(259.321562 20.88)scale(0.12 -0.12)">
+    <g transform="translate(259.321562 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -1835,7 +1837,7 @@ z
     </g>
     <g id="text_51">
      <!-- serial no mask -->
-     <g transform="translate(399.71875 43.478437)scale(0.1 -0.1)">
+     <g transform="translate(399.71875 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1862,7 +1864,7 @@ z
     </g>
     <g id="text_52">
      <!-- threaded no mask -->
-     <g transform="translate(399.71875 58.156562)scale(0.1 -0.1)">
+     <g transform="translate(399.71875 58.156562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-74"/>
       <use xlink:href="#DejaVuSans-68" x="39.208984"/>
       <use xlink:href="#DejaVuSans-72" x="102.587891"/>
@@ -1881,7 +1883,7 @@ z
       <use xlink:href="#DejaVuSans-6b" x="851.65625"/>
      </g>
      <!-- (thread count shown at bottom of bar) -->
-     <g transform="translate(399.71875 69.354375)scale(0.1 -0.1)">
+     <g transform="translate(399.71875 69.354375) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-77" d="M 269 3500 
 L 844 3500 
@@ -1943,7 +1945,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p9b495342ae">
+  <clipPath id="p6edf6ef829">
    <rect x="47.72" y="26.88" width="553.48" height="353.912"/>
   </clipPath>
  </defs>

--- a/docs/_static/threaded_lines_simple.svg
+++ b/docs/_static/threaded_lines_simple.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2022-08-27T19:39:34.300468</dc:date>
+    <dc:date>2022-10-23T17:46:36.670257</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.6.1, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -31,11 +31,11 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 54.11 380.792 
+    <path d="M 60.32 380.792 
 L 601.2 380.792 
 L 601.2 26.88 
-L 54.11 26.88 
-L 54.11 380.792 
+L 60.32 26.88 
+L 60.32 380.792 
 z
 " style="fill: none"/>
    </g>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m2e5888787a" d="M 0 0 
+       <path id="m32d5d6660f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2e5888787a" x="133.038004" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32d5d6660f" x="138.352095" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Separate -->
-      <g transform="translate(110.392691 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(115.706782 395.390437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
@@ -223,12 +223,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m2e5888787a" x="262.782668" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32d5d6660f" x="266.624032" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Separate -->
-      <g transform="translate(240.137355 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(243.978719 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -239,7 +239,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(249.981105 406.58825)scale(0.1 -0.1)">
+      <g transform="translate(253.822469 406.58825) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -320,12 +320,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m2e5888787a" x="392.527332" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32d5d6660f" x="394.895968" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g transform="translate(376.634363 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(379.003 395.390437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -409,7 +409,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(367.123426 406.58825)scale(0.1 -0.1)">
+      <g transform="translate(369.492062 406.58825) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -491,7 +491,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(379.72577 417.786062)scale(0.1 -0.1)">
+      <g transform="translate(382.094406 417.786062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -502,12 +502,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2e5888787a" x="522.271996" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32d5d6660f" x="523.167905" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g transform="translate(506.379027 395.390437)scale(0.1 -0.1)">
+      <g transform="translate(507.274936 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -515,7 +515,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(496.86809 406.58825)scale(0.1 -0.1)">
+      <g transform="translate(497.763999 406.58825) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -526,7 +526,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(507.17434 417.786062)scale(0.1 -0.1)">
+      <g transform="translate(508.070249 417.786062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -615,23 +615,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_5">
-      <path d="M 54.11 380.792 
+      <path d="M 60.32 380.792 
 L 601.2 380.792 
-" clip-path="url(#p3d48f47177)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p1fe4612315)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m66747c6027" d="M 0 0 
+       <path id="m24f4d2a08e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m66747c6027" x="54.11" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24f4d2a08e" x="60.32" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
-      <!-- 0.00 -->
-      <g transform="translate(24.844375 384.591219)scale(0.1 -0.1)">
+      <!-- 0.000 -->
+      <g transform="translate(24.691875 384.591219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -666,23 +666,24 @@ z
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
        <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_7">
-      <path d="M 54.11 340.845956 
-L 601.2 340.845956 
-" clip-path="url(#p3d48f47177)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 334.247842 
+L 601.2 334.247842 
+" clip-path="url(#p1fe4612315)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m66747c6027" x="54.11" y="340.845956" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24f4d2a08e" x="60.32" y="334.247842" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
-      <!-- 0.02 -->
-      <g transform="translate(24.844375 344.645175)scale(0.1 -0.1)">
+      <!-- 0.025 -->
+      <g transform="translate(24.691875 338.047061) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -708,185 +709,110 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
        <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_9">
-      <path d="M 54.11 300.899912 
-L 601.2 300.899912 
-" clip-path="url(#p3d48f47177)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 287.703684 
+L 601.2 287.703684 
+" clip-path="url(#p1fe4612315)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m66747c6027" x="54.11" y="300.899912" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24f4d2a08e" x="60.32" y="287.703684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
-      <!-- 0.04 -->
-      <g transform="translate(24.844375 304.69913)scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
+      <!-- 0.050 -->
+      <g transform="translate(24.691875 291.502903) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_11">
-      <path d="M 54.11 260.953867 
-L 601.2 260.953867 
-" clip-path="url(#p3d48f47177)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 241.159526 
+L 601.2 241.159526 
+" clip-path="url(#p1fe4612315)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m66747c6027" x="54.11" y="260.953867" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24f4d2a08e" x="60.32" y="241.159526" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
-      <!-- 0.06 -->
-      <g transform="translate(24.844375 264.753086)scale(0.1 -0.1)">
+      <!-- 0.075 -->
+      <g transform="translate(24.691875 244.958745) scale(0.1 -0.1)">
        <defs>
-        <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_13">
-      <path d="M 54.11 221.007823 
-L 601.2 221.007823 
-" clip-path="url(#p3d48f47177)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 194.615368 
+L 601.2 194.615368 
+" clip-path="url(#p1fe4612315)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m66747c6027" x="54.11" y="221.007823" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24f4d2a08e" x="60.32" y="194.615368" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
-      <!-- 0.08 -->
-      <g transform="translate(24.844375 224.807042)scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_15">
-      <path d="M 54.11 181.061779 
-L 601.2 181.061779 
-" clip-path="url(#p3d48f47177)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_16">
-      <g>
-       <use xlink:href="#m66747c6027" x="54.11" y="181.061779" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_10">
-      <!-- 0.10 -->
-      <g transform="translate(24.844375 184.860998)scale(0.1 -0.1)">
+      <!-- 0.100 -->
+      <g transform="translate(24.691875 198.414587) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -907,75 +833,79 @@ z
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
        <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <path d="M 60.32 148.07121 
+L 601.2 148.07121 
+" clip-path="url(#p1fe4612315)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m24f4d2a08e" x="60.32" y="148.07121" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.125 -->
+      <g transform="translate(24.691875 151.870429) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_17">
-      <path d="M 54.11 141.115735 
-L 601.2 141.115735 
-" clip-path="url(#p3d48f47177)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 101.527052 
+L 601.2 101.527052 
+" clip-path="url(#p1fe4612315)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m66747c6027" x="54.11" y="141.115735" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24f4d2a08e" x="60.32" y="101.527052" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
-      <!-- 0.12 -->
-      <g transform="translate(24.844375 144.914954)scale(0.1 -0.1)">
+      <!-- 0.150 -->
+      <g transform="translate(24.691875 105.326271) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_19">
-      <path d="M 54.11 101.169691 
-L 601.2 101.169691 
-" clip-path="url(#p3d48f47177)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 60.32 54.982894 
+L 601.2 54.982894 
+" clip-path="url(#p1fe4612315)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m66747c6027" x="54.11" y="101.169691" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24f4d2a08e" x="60.32" y="54.982894" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
-      <!-- 0.14 -->
-      <g transform="translate(24.844375 104.968909)scale(0.1 -0.1)">
+      <!-- 0.175 -->
+      <g transform="translate(24.691875 58.782113) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_21">
-      <path d="M 54.11 61.223647 
-L 601.2 61.223647 
-" clip-path="url(#p3d48f47177)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_22">
-      <g>
-       <use xlink:href="#m66747c6027" x="54.11" y="61.223647" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_13">
-      <!-- 0.16 -->
-      <g transform="translate(24.844375 65.022865)scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_14">
+    <g id="text_13">
      <!-- Time (seconds) -->
-     <g transform="translate(18.764688 241.997719)rotate(-90)scale(0.1 -0.1)">
+     <g transform="translate(18.612188 241.997719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1055,8 +985,8 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 54.11 380.792 
-L 54.11 26.88 
+    <path d="M 60.32 380.792 
+L 60.32 26.88 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
@@ -1065,414 +995,50 @@ L 601.2 26.88
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 54.11 380.792 
+    <path d="M 60.32 380.792 
 L 601.2 380.792 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 54.11 26.88 
+    <path d="M 60.32 26.88 
 L 601.2 26.88 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 78.977727 380.792 
-L 100.601838 380.792 
-L 100.601838 127.649583 
-L 78.977727 127.649583 
+    <path d="M 84.905455 380.792 
+L 106.284111 380.792 
+L 106.284111 127.105993 
+L 84.905455 127.105993 
 z
-" clip-path="url(#p3d48f47177)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1fe4612315)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 208.722391 380.792 
-L 230.346502 380.792 
-L 230.346502 126.90704 
-L 208.722391 126.90704 
+    <path d="M 213.177391 380.792 
+L 234.556047 380.792 
+L 234.556047 126.575682 
+L 213.177391 126.575682 
 z
-" clip-path="url(#p3d48f47177)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1fe4612315)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 338.467055 380.792 
-L 360.091166 380.792 
-L 360.091166 127.042103 
-L 338.467055 127.042103 
+    <path d="M 341.449328 380.792 
+L 362.827984 380.792 
+L 362.827984 125.444237 
+L 341.449328 125.444237 
 z
-" clip-path="url(#p3d48f47177)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1fe4612315)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 468.211719 380.792 
-L 489.83583 380.792 
-L 489.83583 127.349838 
-L 468.211719 127.349838 
+    <path d="M 469.721265 380.792 
+L 491.099921 380.792 
+L 491.099921 125.617958 
+L 469.721265 125.617958 
 z
-" clip-path="url(#p3d48f47177)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1fe4612315)" style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_15">
-    <!-- 127 ms -->
-    <g transform="translate(92.549158 122.649583)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_16">
-    <!-- 127 ms -->
-    <g transform="translate(222.293822 121.90704)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_17">
-    <!-- 127 ms -->
-    <g transform="translate(352.038486 122.042103)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 127 ms -->
-    <g transform="translate(481.78315 122.349838)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_11">
-    <path d="M 100.601838 380.792 
-L 122.225949 380.792 
-L 122.225949 128.141931 
-L 100.601838 128.141931 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 122.225949 380.792 
-L 143.850059 380.792 
-L 143.850059 211.365608 
-L 122.225949 211.365608 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 143.850059 380.792 
-L 165.47417 380.792 
-L 165.47417 266.78935 
-L 143.850059 266.78935 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 165.47417 380.792 
-L 187.098281 380.792 
-L 187.098281 283.897427 
-L 165.47417 283.897427 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 230.346502 380.792 
-L 251.970613 380.792 
-L 251.970613 127.940281 
-L 230.346502 127.940281 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 251.970613 380.792 
-L 273.594723 380.792 
-L 273.594723 211.715148 
-L 251.970613 211.715148 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 273.594723 380.792 
-L 295.218834 380.792 
-L 295.218834 266.790218 
-L 273.594723 266.790218 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 295.218834 380.792 
-L 316.842945 380.792 
-L 316.842945 283.679771 
-L 295.218834 283.679771 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 360.091166 380.792 
-L 381.715277 380.792 
-L 381.715277 125.444237 
-L 360.091166 125.444237 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 381.715277 380.792 
-L 403.339387 380.792 
-L 403.339387 209.983428 
-L 381.715277 209.983428 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 403.339387 380.792 
-L 424.963498 380.792 
-L 424.963498 264.273018 
-L 403.339387 264.273018 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_22">
-    <path d="M 424.963498 380.792 
-L 446.587609 380.792 
-L 446.587609 281.633631 
-L 424.963498 281.633631 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_23">
-    <path d="M 489.83583 380.792 
-L 511.459941 380.792 
-L 511.459941 127.925781 
-L 489.83583 127.925781 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 511.459941 380.792 
-L 533.084051 380.792 
-L 533.084051 211.012669 
-L 511.459941 211.012669 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 533.084051 380.792 
-L 554.708162 380.792 
-L 554.708162 264.152929 
-L 533.084051 264.152929 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 554.708162 380.792 
-L 576.332273 380.792 
-L 576.332273 283.744694 
-L 554.708162 283.744694 
-z
-" clip-path="url(#p3d48f47177)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 126 ms -->
-    <g transform="translate(114.173268 123.141931)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 84.8 ms (x 1.49) -->
-    <g transform="translate(135.797379 206.365608)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-39" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 57.1 ms (x 2.22) -->
-    <g transform="translate(157.42149 261.78935)rotate(-90)scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-32" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 48.5 ms (x 2.61) -->
-    <g transform="translate(179.0456 278.897427)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 127 ms -->
-    <g transform="translate(243.917932 122.940281)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 84.7 ms (x 1.50) -->
-    <g transform="translate(265.542043 206.715148)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 57.1 ms (x 2.23) -->
-    <g transform="translate(287.166154 261.790218)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_14">
+    <!-- 136 ms -->
+    <g transform="translate(98.354158 122.105993) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1506,138 +1072,310 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-32" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 48.6 ms (x 2.61) -->
-    <g transform="translate(308.790264 278.679771)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 128 ms -->
-    <g transform="translate(373.662596 120.444237)rotate(-90)scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- 85.5 ms (x 1.49) -->
-    <g transform="translate(395.286707 204.983428)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-39" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 58.3 ms (x 2.18) -->
-    <g transform="translate(416.910818 259.273018)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 49.6 ms (x 2.56) -->
-    <g transform="translate(438.534928 276.633631)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 127 ms -->
-    <g transform="translate(503.40726 122.925781)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_15">
+    <!-- 137 ms -->
+    <g transform="translate(226.626094 121.575682) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_32">
-    <!-- 85.0 ms (x 1.49) -->
-    <g transform="translate(525.031371 206.012669)rotate(-90)scale(0.1 -0.1)">
+   <g id="text_16">
+    <!-- 137 ms -->
+    <g transform="translate(354.898031 120.444237) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 137 ms -->
+    <g transform="translate(483.169968 120.617958) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_11">
+    <path d="M 106.284111 380.792 
+L 127.662767 380.792 
+L 127.662767 126.973548 
+L 106.284111 126.973548 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 127.662767 380.792 
+L 149.041423 380.792 
+L 149.041423 213.457102 
+L 127.662767 213.457102 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 149.041423 380.792 
+L 170.420079 380.792 
+L 170.420079 268.382607 
+L 149.041423 268.382607 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 170.420079 380.792 
+L 191.798735 380.792 
+L 191.798735 285.519649 
+L 170.420079 285.519649 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 234.556047 380.792 
+L 255.934704 380.792 
+L 255.934704 127.206494 
+L 234.556047 127.206494 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 255.934704 380.792 
+L 277.31336 380.792 
+L 277.31336 214.877003 
+L 255.934704 214.877003 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 277.31336 380.792 
+L 298.692016 380.792 
+L 298.692016 268.23182 
+L 277.31336 268.23182 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 298.692016 380.792 
+L 320.070672 380.792 
+L 320.070672 285.109541 
+L 298.692016 285.109541 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 362.827984 380.792 
+L 384.20664 380.792 
+L 384.20664 126.709085 
+L 362.827984 126.709085 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 384.20664 380.792 
+L 405.585296 380.792 
+L 405.585296 213.403402 
+L 384.20664 213.403402 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 405.585296 380.792 
+L 426.963953 380.792 
+L 426.963953 267.650807 
+L 405.585296 267.650807 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 426.963953 380.792 
+L 448.342609 380.792 
+L 448.342609 284.837976 
+L 426.963953 284.837976 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 491.099921 380.792 
+L 512.478577 380.792 
+L 512.478577 127.659451 
+L 491.099921 127.659451 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 512.478577 380.792 
+L 533.857233 380.792 
+L 533.857233 213.166062 
+L 512.478577 213.166062 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 533.857233 380.792 
+L 555.235889 380.792 
+L 555.235889 268.376288 
+L 533.857233 268.376288 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 555.235889 380.792 
+L 576.614545 380.792 
+L 576.614545 284.797858 
+L 555.235889 284.797858 
+z
+" clip-path="url(#p1fe4612315)" style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_18">
+    <!-- 136 ms -->
+    <g transform="translate(119.732814 121.973548) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 89.9 ms (x 1.52) -->
+    <g transform="translate(141.11147 208.457102) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1647,16 +1385,37 @@ z
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-31" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-39" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_33">
-    <!-- 58.4 ms (x 2.17) -->
-    <g transform="translate(546.655482 259.152929)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+   <g id="text_20">
+    <!-- 60.4 ms (x 2.26) -->
+    <g transform="translate(162.490126 263.382607) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1668,16 +1427,238 @@ z
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-32" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 51.2 ms (x 2.66) -->
+    <g transform="translate(183.868782 280.519649) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-36" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 136 ms -->
+    <g transform="translate(248.00475 122.206494) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 89.1 ms (x 1.53) -->
+    <g transform="translate(269.383407 209.877003) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 60.5 ms (x 2.26) -->
+    <g transform="translate(290.762063 263.23182) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-32" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 51.4 ms (x 2.66) -->
+    <g transform="translate(312.140719 280.109541) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-36" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 136 ms -->
+    <g transform="translate(376.276687 121.709085) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- 89.9 ms (x 1.53) -->
+    <g transform="translate(397.655343 208.403402) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 60.8 ms (x 2.26) -->
+    <g transform="translate(419.034 262.650807) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-32" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 51.5 ms (x 2.66) -->
+    <g transform="translate(440.412656 279.837976) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-36" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 136 ms -->
+    <g transform="translate(504.548624 122.659451) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 90.0 ms (x 1.52) -->
+    <g transform="translate(525.92728 208.166062) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 60.4 ms (x 2.27) -->
+    <g transform="translate(547.305936 263.376288) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-32" x="661.132812"/>
      <use xlink:href="#DejaVuSans-37" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_34">
-    <!-- 48.6 ms (x 2.61) -->
-    <g transform="translate(568.279592 278.744694)rotate(-90)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+   <g id="text_33">
+    <!-- 51.6 ms (x 2.66) -->
+    <g transform="translate(568.684592 279.797858) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1690,125 +1671,125 @@ z
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-36" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_35">
+   <g id="text_34">
     <!--  1 -->
-    <g transform="translate(106.643581 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(112.203126 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!--  2 -->
+    <g transform="translate(133.581782 378.712312) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_36">
-    <!--  2 -->
-    <g transform="translate(128.267691 378.712312)scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(154.960438 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_37">
-    <!--  4 -->
-    <g transform="translate(149.891802 378.712312)scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(176.339095 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_38">
-    <!--  6 -->
-    <g transform="translate(171.515913 378.712312)scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(240.475063 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_39">
-    <!--  1 -->
-    <g transform="translate(236.388245 378.712312)scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(261.853719 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_40">
-    <!--  2 -->
-    <g transform="translate(258.012355 378.712312)scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(283.232375 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_41">
-    <!--  4 -->
-    <g transform="translate(279.636466 378.712312)scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(304.611031 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_42">
-    <!--  6 -->
-    <g transform="translate(301.260577 378.712312)scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(368.747 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_43">
-    <!--  1 -->
-    <g transform="translate(366.132909 378.712312)scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(390.125656 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_44">
-    <!--  2 -->
-    <g transform="translate(387.75702 378.712312)scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_45">
     <!--  4 -->
-    <g transform="translate(409.38113 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(411.504312 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_46">
+   <g id="text_45">
     <!--  6 -->
-    <g transform="translate(431.005241 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(432.882968 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_47">
+   <g id="text_46">
     <!--  1 -->
-    <g transform="translate(495.877573 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(497.018937 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_48">
+   <g id="text_47">
     <!--  2 -->
-    <g transform="translate(517.501684 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(518.397593 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_49">
+   <g id="text_48">
     <!--  4 -->
-    <g transform="translate(539.125794 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(539.776249 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_50">
+   <g id="text_49">
     <!--  6 -->
-    <g transform="translate(560.749905 378.712312)scale(0.1 -0.1)">
+    <g transform="translate(561.154905 378.712312) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_51">
+   <g id="text_50">
     <!-- lines simple n=1000 -->
-    <g transform="translate(265.9825 20.88)scale(0.12 -0.12)">
+    <g transform="translate(269.0875 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -1874,9 +1855,9 @@ L 371.71875 36.478437
 z
 " style="fill: #77aadd; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_52">
+    <g id="text_51">
      <!-- serial no mask -->
-     <g transform="translate(399.71875 43.478437)scale(0.1 -0.1)">
+     <g transform="translate(399.71875 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
       <use xlink:href="#DejaVuSans-72" x="113.623047"/>
@@ -1901,9 +1882,9 @@ L 371.71875 57.795312
 z
 " style="fill: #99ddff; stroke: #444444; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_53">
+    <g id="text_52">
      <!-- threaded no mask -->
-     <g transform="translate(399.71875 58.156562)scale(0.1 -0.1)">
+     <g transform="translate(399.71875 58.156562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-74"/>
       <use xlink:href="#DejaVuSans-68" x="39.208984"/>
       <use xlink:href="#DejaVuSans-72" x="102.587891"/>
@@ -1922,7 +1903,7 @@ z
       <use xlink:href="#DejaVuSans-6b" x="851.65625"/>
      </g>
      <!-- (thread count shown at bottom of bar) -->
-     <g transform="translate(399.71875 69.354375)scale(0.1 -0.1)">
+     <g transform="translate(399.71875 69.354375) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-77" d="M 269 3500 
 L 844 3500 
@@ -1984,8 +1965,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p3d48f47177">
-   <rect x="54.11" y="26.88" width="547.09" height="353.912"/>
+  <clipPath id="p1fe4612315">
+   <rect x="60.32" y="26.88" width="540.88" height="353.912"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/benchmarks/calculation.rst
+++ b/docs/benchmarks/calculation.rst
@@ -26,13 +26,13 @@ Contour lines
 .. image:: ../_static/lines_simple_1000.svg
 
 For the ``simple`` dataset above the performance of ``serial`` for contour lines is the same
-regardless of ``LineType``. It is slightly faster than ``mpl2005`` and significantly faster than
+regardless of ``LineType``. It is slightly slower than ``mpl2005`` and significantly faster than
 ``mpl2014`` with a speedup of 1.7-1.9.
 
 .. image:: ../_static/lines_random_1000.svg
 
 For the ``random`` dataset above the performance of ``serial`` varies significantly by ``LineType``.
-For ``LineType.SeparateCode`` ``serial`` is 10-15% faster than ``mpl2005`` and is slightly faster
+For ``LineType.SeparateCode`` ``serial`` is 10-20% faster than ``mpl2005`` and is slightly faster
 than ``mpl2014`` when ``z`` is masked but about 5% slower when ``z`` is not masked.
 
 Other ``LineType`` are faster.  ``LineType.Separate`` has a speedup of about 1.4 compared to
@@ -50,15 +50,15 @@ Filled contours
 .. image:: ../_static/filled_simple_1000.svg
 
 For the ``simple`` dataset above the performance of ``serial`` for filled contours is the same
-regardless of ``FillType``.  It has about the same performance as ``mpl2005`` and is significantly
-faster than ``mpl2014`` with a speedup of 1.75-1.9.
+regardless of ``FillType``.  It it 5-20% slower than ``mpl2005`` and significantly
+faster than ``mpl2014`` with a speedup of 1.6-1.7.
 
 .. image:: ../_static/filled_random_1000.svg
 
 For the ``random`` dataset above the performance of ``serial`` varies significantly by ``FillType``.
-For ``FillType.OuterCode`` it is faster than ``mpl2014`` with a speedup of about 1.3.  It is also
+For ``FillType.OuterCode`` it is faster than ``mpl2014`` with a speedup of 1.3-1.4.  It is also
 faster than ``mpl2005`` but only the ``corner_mask=False`` option is shown in full as the unmasked
-benchmark here is off the scale at 12.1 seconds.  The ``mpl2005`` algorithm calculates points for
+benchmark here is off the scale at 11.4 seconds.  The ``mpl2005`` algorithm calculates points for
 outer and hole boundaries in an interleaved format which need to be reordered, and this approach
 scales badly for a large outer boundary containing many holes as occurs here for unmasked ``z``.
 
@@ -66,9 +66,9 @@ Other ``FillType`` are faster, although ``FillType.OuterOffset`` is only margina
 creates the same number of `NumPy`_ arrays as ``FillType.OuterCode`` but the arrays are shorter.
 
 The other four ``FillType`` can be grouped in pairs: ``FillType.ChunkCombinedCodeOffset`` and
-``FillType.ChunkCombinedOffsetOffset`` have a speedup of 1.8-1.95 compared to
+``FillType.ChunkCombinedOffsetOffset`` have a speedup of 1.8-2 compared to
 ``FillType.OuterCode``; whereas ``FillType.ChunkCombinedCode`` and
-``FillType.ChunkCombinedOffset`` are marginally faster with a speedup of 1.9-2.  The speed
+``FillType.ChunkCombinedOffset`` are marginally faster with a speedup of 1.9-2.1.  The speed
 improvement has the usual explanation that they only allocate a small number of arrays whereas
 ``FillType.OuterCode`` allocates 1.7 million arrays.  ``FillType.ChunkCombinedCode`` and
 ``FillType.ChunkCombinedOffset`` are slightly faster than the other two because they do not

--- a/docs/benchmarks/chunks.rst
+++ b/docs/benchmarks/chunks.rst
@@ -8,12 +8,12 @@ increased from 1 to 120.
 
 .. image:: ../_static/chunk_filled_simple.svg
 
-The performance of the  ``simple`` dataset varies by only a small amount (2.5%) for a
+The performance of the  ``simple`` dataset varies by only a small amount (3.5%) for a
 ``total_chunk_count`` of up to 120.
 
 .. image:: ../_static/chunk_lines_random.svg
 
 .. image:: ../_static/chunk_filled_random.svg
 
-For the ``random`` dataset the variations are greater at up to 13% and are usually, but not always,
+For the ``random`` dataset the variations are greater at up to 14% and are usually, but not always,
 slower for increasing ``total_chunk_count``.

--- a/docs/benchmarks/index.rst
+++ b/docs/benchmarks/index.rst
@@ -24,7 +24,7 @@ the results in a web browser using:
 For further information see the ``README.md`` document in the ``benchmarks`` directory.
 
 There follows a summary of key benchmark results taken on a 6-core Intel Core i7-10750H processor
-for commit ``c4959cfb``.
+using Python 3.10.6 on Ubuntu 22.04 for commit ``996a72e3``.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/benchmarks/rendering.rst
+++ b/docs/benchmarks/rendering.rst
@@ -10,7 +10,7 @@ Contour lines
 .. image:: ../_static/lines_simple_1000_render.svg
 
 For the ``simple`` dataset above the performance of ``serial`` for contour lines is the same
-regardless of ``LineType``. It is slightly faster than ``mpl2005`` and significantly faster than
+regardless of ``LineType``. It is slightly slower than ``mpl2005`` and significantly faster than
 ``mpl2014`` with a speedup of about 1.4.  Comparing these times with the calculation-only times of
 the previous section shows that the rendering time here is only about 120 ms so there is a fairly
 even split between calculation and rendering time for ``serial``.
@@ -27,7 +27,7 @@ codes yourself or allow `Matplotlib`_ to generate them for you, either way is sl
 ``contourpy`` to generate them for you in C++.
 
 ``LineType.ChunkCombinedCode`` is significantly faster than ``LineType.SeparateCode`` with a speedup
-of 1.9-2.3.  This means that use of the ``serial`` algorithm with ``LineType.ChunkCombinedCode``
+of 2-2.3.  This means that use of the ``serial`` algorithm with ``LineType.ChunkCombinedCode``
 could halve the calculation and rendering time in `Matplotlib`_ for such complicated datasets.
 The benefit here is in just having two `NumPy`_ arrays per chunk, one for points and one for codes,
 which are ultimately used by `Matplotlib`_'s Agg renderer.  Compare this with
@@ -40,8 +40,8 @@ Filled contours
 .. image:: ../_static/filled_simple_1000_render.svg
 
 As usual, for the ``simple`` dataset above the performance of ``serial`` for filled contours is the
-same regardless of ``FillType``.  It has about the same performance as ``mpl2005`` and is faster
-than ``mpl2014`` with a speedup of 1.4-1.5.  As with ``lines`` the rendering time here is only
+same regardless of ``FillType``.  It is slightly slower than ``mpl2005`` and is faster
+than ``mpl2014`` with a speedup of 1.3-1.4.  As with ``lines`` the rendering time here is only
 about 120 ms so there is a fairly even split between calculation and rendering time for ``serial``.
 
 .. image:: ../_static/filled_random_1000_render.svg
@@ -56,7 +56,7 @@ C++, or in the case of ``FillType.ChunkCombinedCodeOffset`` by breaking up the l
 codes arrays into many smaller arrays, one per polygon (outer plus holes).
 
 ``FillType.ChunkCombinedCode`` and ``FillType.ChunkCombinedOffset`` are significantly faster than
-``FillType.OuterCode`` with a speedup of 2.7-3.2 compared to ``serial`` and 3.1-3.5 compared to
+``FillType.OuterCode`` with a speedup of 2.7-3.1 compared to ``serial`` and 3-3.5 compared to
 ``mpl2014``.  Again this only has to send two `NumPy`_ arrays to `Matplotlib`_ for rendering rather
 than 850 thousand pairs of them.
 

--- a/docs/benchmarks/threads.rst
+++ b/docs/benchmarks/threads.rst
@@ -9,8 +9,8 @@ of 1000 and a ``total_chunk_count`` of 40 for up to 6 threads.
 .. image:: ../_static/threaded_filled_simple.svg
 
 For the ``simple`` dataset contour calculations are faster with more threads but it does not scale
-particulary well.  The speedup with 6 threads is about 2.6 for :func:`~contourpy.ContourGenerator.lines`
-and about 2.7 for :func:`~contourpy.ContourGenerator.filled`.  This problem dataset is perhaps not
+particulary well.  The speedup with 6 threads is about 2.7 for :func:`~contourpy.ContourGenerator.lines`
+and about 2.8 for :func:`~contourpy.ContourGenerator.filled`.  This problem dataset is perhaps not
 computationally expensive enough to justify the use of multiple threads.
 
 .. image:: ../_static/threaded_lines_random.svg
@@ -19,7 +19,7 @@ computationally expensive enough to justify the use of multiple threads.
 
 For the ``random`` dataset contour calculations scale much better with increasing number of threads
 as long as one of the ``ChunkCombined...`` line or fill types is being used.
-Using 6 threads the speedup is about 4.4 for :func:`~contourpy.ContourGenerator.lines` and 5.2 for
+Using 6 threads the speedup is about 4.4 for :func:`~contourpy.ContourGenerator.lines` and 5.1 for
 :func:`~contourpy.ContourGenerator.filled`.
 
 The ``LineType`` and ``FillType`` options that do not scale well are those that return individual


### PR DESCRIPTION
This updates the benchmark section of the docs in line with recent changes to the threaded code. In fact the threaded changes are insignificant, much more significant are changes to overall `serial` vs `mpl2005` and `mpl2014` speed due to change in OS (Ubuntu 22.04) and version of Python used to run the benchmarks (3.10.6). But overall conclusions are unchanged.