### PR TITLE
Update versions in github actions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -28,9 +28,9 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
+        uses: pypa/cibuildwheel@v2.11.1
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -56,6 +56,6 @@ jobs:
         run: |
           python -m build --sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         debug: [0]
         test-image: [1]
         include:
@@ -39,23 +39,10 @@ jobs:
             python-version: 'pypy3.9'
             debug: 0
             test-image: 0
-          # Pre-release Python version without image tests.
-          - os: ubuntu-latest
-            python-version: '3.11-dev'
-            debug: 0
-            test-image: 0
-          - os: macos-latest
-            python-version: '3.11-dev'
-            debug: 0
-            test-image: 0
-          - os: windows-latest
-            python-version: '3.11-dev'
-            debug: 0
-            test-image: 0
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -121,7 +108,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-artifacts
           path: test-artifacts/


### PR DESCRIPTION
Change python `3.11-dev` to `3.11` in `test.yml` now that it has been officially released, and move it to the standard `matrix` section so that it is tested on the 3 major platforms, with image tests.

Also update version numbers of various github actions used. 