### PR TITLE
Update setup-qemu-action to v2

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: all
 


### PR DESCRIPTION
Update `setup-qemu-action` to v2 as recommended when building v1.0.6 wheels.