### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         debug: [0]
         test-image: [1]
         include:
@@ -27,10 +27,6 @@ jobs:
             debug: 1
             test-image: 1
           # PyPy only tested on ubuntu for speed, without image tests.
-          - os: ubuntu-latest
-            python-version: 'pypy3.7'
-            debug: 0
-            test-image: 0
           - os: ubuntu-latest
             python-version: 'pypy3.8'
             debug: 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,10 @@ skip_gitignore = true
 [tool.cibuildwheel]
 build-frontend = "build"
 build-verbosity = "2"
-build = "cp37-* cp38-* cp39-* cp310-* cp311-* pp37-* pp38-* pp39-*"
+build = "cp38-* cp39-* cp310-* cp311-* pp38-* pp39-*"
 test-command = 'python -c "import contourpy as c; c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9)"'
 # Only test combinations for which a numpy wheel exists, and macos universal unnecessary.
-test-skip = "pp37-* pp38-*-aarch64 pp39-* *musllinux* *-macosx_arm64 *-macosx_universal2"
+test-skip = "pp38-*-aarch64 pp39-* *musllinux* *-macosx_arm64 *-macosx_universal2"
 
 [tool.cibuildwheel.linux]
 archs = "auto aarch64"

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: C++
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -31,7 +30,7 @@ install_requires =
 package_dir =
     = lib
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 zip_safe = False
 
 [options.extras_require]


### PR DESCRIPTION
Drop support for CPython and PyPy 3.7. NumPy did this back in mid-August.