### PR TITLE
Remove unneeded doc dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,6 @@ requires-python = ">=3.8"
 
 [project.optional-dependencies]
 docs = [
-    "docutils <0.18",
-    "sphinx <=5.2.0",
     "sphinx-rtd-theme",
 ]
 bokeh = [


### PR DESCRIPTION
This removes two unneeded doc build dependencies. Use of latest `sphinx-rtd-theme` is sufficient now.