### PR TITLE
Add scheduled CI test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+  schedule:
+    - cron: '42 01 * * SUN'
 
 jobs:
   test:


### PR DESCRIPTION
Add scheduled CI test run on Sunday mornings, and allow `workflow_dispatch` as well.