### PR TITLE
Improved if statement

### DIFF
--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -2064,7 +2064,7 @@ void BaseContourGenerator<Derived>::march_chunk(
             // Number of starts at end of row.
             auto start_count =
                 (_identify_holes ? local.line_count - local.hole_count : local.line_count);
-            if (start_count - prev_start_count)
+            if (start_count > prev_start_count)
                 j_final_start = j;
             else
                 _cache[local.istart + j*_nx] |= MASK_NO_STARTS_IN_ROW;


### PR DESCRIPTION
Change to a single `if` statement in the `serial`/`threaded` C++ code. The original code was functionally equivalent, but this is better, more explicit, code.