### PR TITLE
Add git pre-commit

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -81,4 +81,3 @@ For answers to common questions about this code of conduct, see the FAQ at [http
 [Mozilla CoC]: https://github.com/mozilla/diversity
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,11 +66,11 @@ jobs:
           then
             if [[ ${{ matrix.test-image }} == 1 ]];
             then
-              echo "Install contourpy with full test dependencies"
+              echo "Install contourpy with standard test dependencies"
               python -m pip install -ve .[test]
             else
-              echo "Install contourpy with minimal test dependencies"
-              python -m pip install -ve .[test-minimal]
+              echo "Install contourpy with non-image-generating test dependencies"
+              python -m pip install -ve .[test-no-images]
             fi
           else
             echo "Install numpy from sdist with debug asserts enabled"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,14 @@ on:
     - cron: '42 01 * * SUN'
 
 jobs:
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0
+
   test:
     name: Test ${{ matrix.python-version }} ${{ matrix.os }} ${{ matrix.debug == 1 && 'debug' || '' }}
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+exclude: \.(png|svg)$
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-builtin-literals
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/PyCQA/isort
+    rev: v5.11.3
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.10.1
+    hooks:
+      - id: validate-pyproject

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,6 +83,7 @@ rst_epilog = """
 .. _conda-forge: https://anaconda.org/conda-forge/contourpy/
 .. _default: https://anaconda.org/anaconda/contourpy/
 .. _github: https://www.github.com/contourpy/contourpy/
+.. _pre-commit: https://pre-commit.com/
 .. _pybind11: https://pybind11.readthedocs.io/
 """
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -125,3 +125,33 @@ To build the documentation:
 
    although use this with care as it will also delete any new files that you have created that have
    not been added to ``git`` and are not mentioned in the ``.gitignore`` file.
+
+
+Notes for contributors
+----------------------
+
+Contributors are recommended to install `pre-commit`_ hooks which will automatically run various
+checks whenever ``git commit`` is run. First install ``pre-commit`` using either
+
+   .. code-block:: bash
+
+      $ pip install pre-commit
+
+or
+
+   .. code-block:: bash
+
+      $ conda install -c conda-forge pre-commit
+
+and then install the hooks using
+
+   .. code-block:: bash
+
+      $ pre-commit install
+
+The hooks will then be run on each ``git commit``. You can manually run the hooks outside of a
+```git commit`` using
+
+   .. code-block:: bash
+
+      $ pre-commit run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,13 @@ bokeh = [
     # Also need geckodriver and firefox, or chromedriver and chrome, for export to PNG/SVG/buffer.
 ]
 test = [
+    # Standard test dependencies.
     "matplotlib",
     "Pillow",
+    "pytest",
+]
+test-no-images = [
+    # Dependencies to run tests excluding image-generating tests.
     "pytest",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,20 +45,10 @@ bokeh = [
     "selenium",
     # Also need geckodriver and firefox, or chromedriver and chrome, for export to PNG/SVG/buffer.
 ]
-test-minimal = [
-    "pytest",
-]
-test-no-codebase = [
-    # All test dependencies excluding codebase tests.
-    "contourpy[test-minimal]",
+test = [
     "matplotlib",
     "Pillow",
-]
-test = [
-    # All test dependencies.
-    "contourpy[test-no-codebase]",
-    "flake8",
-    "isort",
+    "pytest",
 ]
 
 [project.urls]

--- a/src/chunk_local.cpp
+++ b/src/chunk_local.cpp
@@ -57,4 +57,3 @@ std::ostream &operator<<(std::ostream &os, const ChunkLocal& local)
 }
 
 } // namespace contourpy
-

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -36,26 +36,6 @@ def test_cppcheck():
     assert proc.returncode == 0, f"cppcheck issues:\n{proc.stderr.decode('utf-8')}"
 
 
-def test_flake8():
-    cmd = ["flake8"]
-    try:
-        proc = run(cmd, capture_output=True)
-    except FileNotFoundError:
-        pytest.skip()
-
-    assert proc.returncode == 0, f"Flake8 issues:\n{proc.stdout.decode('utf-8')}"
-
-
-def test_isort():
-    cmd = ["isort", ".", "--diff", "--check-only"]
-    try:
-        proc = run(cmd, capture_output=True)
-    except FileNotFoundError:
-        pytest.skip()
-
-    assert proc.returncode == 0, f"isort issues:\n{proc.stderr.decode('utf-8')}"
-
-
 def test_version():
     version_python = contourpy.__version__
     assert version_is_canonical(version_python)


### PR DESCRIPTION
This adds a `.pre-commit-config.yaml` to the repo with a few standard pre-commit hooks, and moves `flake8` and `isort` tests from `test_codebase.py` to the pre-commit. Also added some contributor notes to the docs to explain how to install and use it, and added running it as part of CI.