### PR TITLE
Add bokeh tests to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,8 +75,8 @@ jobs:
           else
             echo "Install numpy from sdist with debug asserts enabled"
             CFLAGS=-UNDEBUG pip install -v --no-binary=numpy numpy
-            echo "Install contourpy in debug mode with test dependencies"
-            CONTOURPY_DEBUG=1 CONTOURPY_CXX11=1 python -m pip install -ve .[test]
+            echo "Install contourpy in debug mode with test and bokeh dependencies"
+            CONTOURPY_DEBUG=1 CONTOURPY_CXX11=1 python -m pip install -ve .[bokeh,test]
           fi
           python -m pip list
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: pre-commit/action@v3.0.0
 
   test:
-    name: Test ${{ matrix.python-version }} ${{ matrix.os }} ${{ matrix.debug == 1 && 'debug' || '' }}
+    name: Test ${{ matrix.python-version }} ${{ matrix.os }} ${{ matrix.numpy-debug == 1 && 'numpy-debug' || '' }} ${{ matrix.debug == 1 && 'debug' || '' }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -30,21 +30,31 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
         debug: [0]
+        numpy-debug: [0]
         test-image: [1]
         include:
-          # Add debug build and test to matrix.
+          # Debug build including bokeh tests.
           - os: ubuntu-latest
             python-version: '3.10'
             debug: 1
+            numpy-debug: 0
+            test-image: 1
+          # Test against numpy debug build.
+          - os: ubuntu-latest
+            python-version: '3.10'
+            debug: 1
+            numpy-debug: 1
             test-image: 1
           # PyPy only tested on ubuntu for speed, without image tests.
           - os: ubuntu-latest
             python-version: 'pypy3.8'
             debug: 0
+            numpy-debug: 0
             test-image: 0
           - os: ubuntu-latest
             python-version: 'pypy3.9'
             debug: 0
+            numpy-debug: 0
             test-image: 0
 
     steps:
@@ -57,6 +67,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Build and install numpy from sdist with debug asserts enabled
+        if: matrix.numpy-debug == '1'
+        shell: bash
+        run: |
+          CFLAGS=-UNDEBUG pip install -v --no-binary=numpy numpy
 
       - name: Install contourpy
         shell: bash
@@ -73,8 +89,7 @@ jobs:
               python -m pip install -ve .[test-no-images]
             fi
           else
-            echo "Install numpy from sdist with debug asserts enabled"
-            CFLAGS=-UNDEBUG pip install -v --no-binary=numpy numpy
+            chromium --version
             echo "Install contourpy in debug mode with test and bokeh dependencies"
             CONTOURPY_DEBUG=1 CONTOURPY_CXX11=1 python -m pip install -ve .[bokeh,test]
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           # Test against numpy debug build.
           - os: ubuntu-latest
             python-version: '3.10'
-            debug: 1
+            debug: 0
             numpy-debug: 1
             test-image: 1
           # PyPy only tested on ubuntu for speed, without image tests.

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -47,7 +47,10 @@ def test_renderer_filled(show_text, fill_type, renderer_type):
 
     image_buffer = renderer.save_to_buffer()
     suffix = "" if show_text else "_no_text"
-    compare_images(image_buffer, f"renderer_filled_{renderer_type}{suffix}.png", f"{fill_type}")
+    compare_images(
+        image_buffer, f"renderer_filled_{renderer_type}{suffix}.png", f"{fill_type}",
+        mean_threshold=0.03 if renderer_type == "bokeh" else None,
+    )
 
 
 @pytest.mark.image


### PR DESCRIPTION
Add bokeh tests to CI. Using the `debug` CI run as this will ultimately be the coverage CI run which wants the maximum number of tests run and debug mode so that C++ asserts are included in the coverage report.