### PR TITLE
Add abstract base class Renderer

### DIFF
--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -11,6 +11,9 @@ period.
 .. automodule:: contourpy.util.data
    :members:
 
+.. automodule:: contourpy.util.renderer
+   :members:
+
 .. automodule:: contourpy.util.bokeh_renderer
    :members:
 

--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -9,9 +9,10 @@ from bokeh.plotting import figure
 import numpy as np
 
 from .bokeh_util import filled_to_bokeh, lines_to_bokeh
+from .renderer import Renderer
 
 
-class BokehRenderer:
+class BokehRenderer(Renderer):
     """Utility renderer using Bokeh to render a grid of plots over the same (x, y) range.
 
     Args:
@@ -60,13 +61,6 @@ class BokehRenderer:
         if isinstance(ax, int):
             ax = self._figures[ax]
         return ax
-
-    def _grid_as_2d(self, x, y):
-        x = np.asarray(x)
-        y = np.asarray(y)
-        if x.ndim == 1:
-            x, y = np.meshgrid(x, y)
-        return x, y
 
     def filled(self, filled, fill_type, ax=0, color="C0", alpha=0.7):
         """Plot filled contours on a single plot.

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -7,9 +7,10 @@ import numpy as np
 from contourpy import FillType, LineType
 
 from .mpl_util import filled_to_mpl_paths, lines_to_mpl_paths, mpl_codes_to_offsets
+from .renderer import Renderer
 
 
-class MplRenderer:
+class MplRenderer(Renderer):
     """Utility renderer using Matplotlib to render a grid of plots over the same (x, y) range.
 
     Args:
@@ -62,13 +63,6 @@ class MplRenderer:
         if isinstance(ax, int):
             ax = self._axes[ax]
         return ax
-
-    def _grid_as_2d(self, x, y):
-        x = np.asarray(x)
-        y = np.asarray(y)
-        if x.ndim == 1:
-            x, y = np.meshgrid(x, y)
-        return x, y
 
     def filled(self, filled, fill_type, ax=0, color="C0", alpha=0.7):
         """Plot filled contours on a single Axes.

--- a/lib/contourpy/util/renderer.py
+++ b/lib/contourpy/util/renderer.py
@@ -1,0 +1,50 @@
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+
+class Renderer(ABC):
+    """Abstract base class for renderers, defining the interface that they must implement."""
+
+    def _grid_as_2d(self, x, y):
+        x = np.asarray(x)
+        y = np.asarray(y)
+        if x.ndim == 1:
+            x, y = np.meshgrid(x, y)
+        return x, y
+
+    @abstractmethod
+    def filled(self, filled, fill_type, ax=0, color="C0", alpha=0.7):
+        pass
+
+    @abstractmethod
+    def grid(self, x, y, ax=0, color="black", alpha=0.1, point_color=None, quad_as_tri_alpha=0):
+        pass
+
+    @abstractmethod
+    def lines(self, lines, line_type, ax=0, color="C0", alpha=1.0, linewidth=1):
+        pass
+
+    @abstractmethod
+    def mask(self, x, y, z, ax=0, color="black"):
+        pass
+
+    @abstractmethod
+    def save(self, filename, transparent=False):
+        pass
+
+    @abstractmethod
+    def save_to_buffer(self):
+        pass
+
+    @abstractmethod
+    def show(self):
+        pass
+
+    @abstractmethod
+    def title(self, title, ax=0, color=None):
+        pass
+
+    @abstractmethod
+    def z_values(self, x, y, z, ax=0, color="green", fmt=".1f", quad_as_tri=False):
+        pass


### PR DESCRIPTION
This PR adds a new abstract base class `Renderer` that defines the interface that the concrete derived classes `BokehRenderer` and `MplRenderer` implement.