### PR TITLE
Type annotations for lib directory

### DIFF
--- a/lib/contourpy/_contourpy.pyi
+++ b/lib/contourpy/_contourpy.pyi
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from typing import ClassVar, NoReturn
+
+import numpy as np
+import numpy.typing as npt
+from typing_extensions import TypeAlias
+
+import contourpy._contourpy
+
+# Input numpy array types, the same as in common.h
+CoordinateArray: TypeAlias = npt.NDArray[np.float64]
+MaskArray: TypeAlias = npt.NDArray[np.bool_]
+
+# Output numpy array types, the same as in common.h
+PointArray: TypeAlias = npt.NDArray[np.float64]
+CodeArray: TypeAlias = npt.NDArray[np.uint8]
+OffsetArray: TypeAlias = npt.NDArray[np.uint32]
+
+# Types returned from filled()
+FillReturn_OuterCode: TypeAlias = tuple[list[PointArray], list[CodeArray]]
+FillReturn_OuterOffset: TypeAlias = tuple[list[PointArray], list[OffsetArray]]
+FillReturn_ChunkCombinedCode: TypeAlias = tuple[list[PointArray | None], list[CodeArray | None]]
+FillReturn_ChunkCombinedOffset: TypeAlias = tuple[list[PointArray | None], list[OffsetArray | None]]
+FillReturn_ChunkCombinedCodeOffset: TypeAlias = tuple[list[PointArray | None], list[CodeArray | None], list[OffsetArray | None]]
+FillReturn_ChunkCombinedOffsetOffset: TypeAlias = tuple[list[PointArray | None], list[OffsetArray | None], list[OffsetArray | None]]
+FillReturn: TypeAlias = FillReturn_OuterCode | FillReturn_OuterOffset | FillReturn_ChunkCombinedCode | FillReturn_ChunkCombinedOffset | FillReturn_ChunkCombinedCodeOffset | FillReturn_ChunkCombinedOffsetOffset
+
+# Types returned from lines()
+LineReturn_Separate: TypeAlias = list[PointArray]
+LineReturn_SeparateCode: TypeAlias = tuple[list[PointArray], list[CodeArray]]
+LineReturn_ChunkCombinedCode: TypeAlias = tuple[list[PointArray | None], list[CodeArray | None]]
+LineReturn_ChunkCombinedOffset: TypeAlias = tuple[list[PointArray | None], list[OffsetArray | None]]
+LineReturn: TypeAlias = LineReturn_Separate | LineReturn_SeparateCode | LineReturn_ChunkCombinedCode | LineReturn_ChunkCombinedOffset
+
+
+CONTOURPY_CXX11: int
+CONTOURPY_DEBUG: int
+__version__: str
+
+class FillType:
+    ChunkCombinedCode: ClassVar[contourpy._contourpy.FillType]
+    ChunkCombinedCodeOffset: ClassVar[contourpy._contourpy.FillType]
+    ChunkCombinedOffset: ClassVar[contourpy._contourpy.FillType]
+    ChunkCombinedOffsetOffset: ClassVar[contourpy._contourpy.FillType]
+    OuterCode: ClassVar[contourpy._contourpy.FillType]
+    OuterOffset: ClassVar[contourpy._contourpy.FillType]
+    __members__: ClassVar[dict[str, contourpy._contourpy.FillType]]
+    def __eq__(self, other: object) -> bool: ...
+    def __getstate__(self) -> int: ...
+    def __hash__(self) -> int: ...
+    def __index__(self) -> int: ...
+    def __init__(self, value: int) -> None: ...
+    def __int__(self) -> int: ...
+    def __ne__(self, other: object) -> bool: ...
+    def __repr__(self) -> str: ...
+    def __setstate__(self, state: int) -> NoReturn: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def value(self) -> int: ...
+
+class LineType:
+    ChunkCombinedCode: ClassVar[contourpy._contourpy.LineType]
+    ChunkCombinedOffset: ClassVar[contourpy._contourpy.LineType]
+    Separate: ClassVar[contourpy._contourpy.LineType]
+    SeparateCode: ClassVar[contourpy._contourpy.LineType]
+    __members__: ClassVar[dict[str, contourpy._contourpy.LineType]]
+    def __eq__(self, other: object) -> bool: ...
+    def __getstate__(self) -> int: ...
+    def __hash__(self) -> int: ...
+    def __index__(self) -> int: ...
+    def __init__(self, value: int) -> None: ...
+    def __int__(self) -> int: ...
+    def __ne__(self, other: object) -> bool: ...
+    def __repr__(self) -> str: ...
+    def __setstate__(self, state: int) -> NoReturn: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def value(self) -> int: ...
+
+class ZInterp:
+    Linear: ClassVar[contourpy._contourpy.ZInterp]
+    Log: ClassVar[contourpy._contourpy.ZInterp]
+    __members__: ClassVar[dict[str, contourpy._contourpy.ZInterp]]
+    def __eq__(self, other: object) -> bool: ...
+    def __getstate__(self) -> int: ...
+    def __hash__(self) -> int: ...
+    def __index__(self) -> int: ...
+    def __init__(self, value: int) -> None: ...
+    def __int__(self) -> int: ...
+    def __ne__(self, other: object) -> bool: ...
+    def __repr__(self) -> str: ...
+    def __setstate__(self, state: int) -> NoReturn: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def value(self) -> int: ...
+
+def max_threads() -> int: ...
+
+class ContourGenerator:
+    def create_contour(self, level: float) -> LineReturn: ...
+    def create_filled_contour(self, lower_level: float, upper_level: float) -> FillReturn: ...
+    def filled(self, lower_level: float, upper_level: float) -> FillReturn: ...
+    def lines(self, level: float) -> LineReturn: ...
+    @staticmethod
+    def supports_corner_mask() -> bool: ...
+    @staticmethod
+    def supports_fill_type(fill_type: FillType) -> bool: ...
+    @staticmethod
+    def supports_line_type(line_type: LineType) -> bool: ...
+    @staticmethod
+    def supports_quad_as_tri() -> bool: ...
+    @staticmethod
+    def supports_threads() -> bool: ...
+    @staticmethod
+    def supports_z_interp() -> bool: ...
+    @property
+    def chunk_count(self) -> tuple[int, int]: ...
+    @property
+    def chunk_size(self) -> tuple[int, int]: ...
+    @property
+    def corner_mask(self) -> bool: ...
+    @property
+    def fill_type(self) -> FillType: ...
+    @property
+    def line_type(self) -> LineType: ...
+    @property
+    def quad_as_tri(self) -> bool: ...
+    @property
+    def thread_count(self) -> int: ...
+    @property
+    def z_interp(self) -> ZInterp: ...
+    default_fill_type: contourpy._contourpy.FillType
+    default_line_type: contourpy._contourpy.LineType
+
+class Mpl2005ContourGenerator(ContourGenerator):
+    def __init__(
+        self,
+        x: CoordinateArray,
+        y: CoordinateArray,
+        z: CoordinateArray,
+        mask: MaskArray,
+        *,
+        x_chunk_size: int = 0,
+        y_chunk_size: int = 0,
+    ) -> None: ...
+
+class Mpl2014ContourGenerator(ContourGenerator):
+    def __init__(
+        self,
+        x: CoordinateArray,
+        y: CoordinateArray,
+        z: CoordinateArray,
+        mask: MaskArray,
+        *,
+        corner_mask: bool,
+        x_chunk_size: int = 0,
+        y_chunk_size: int = 0,
+    ) -> None: ...
+
+class SerialContourGenerator(ContourGenerator):
+    def __init__(
+        self,
+        x: CoordinateArray,
+        y: CoordinateArray,
+        z: CoordinateArray,
+        mask: MaskArray,
+        *,
+        corner_mask: bool,
+        line_type: LineType,
+        fill_type: FillType,
+        quad_as_tri: bool,
+        z_interp: ZInterp,
+        x_chunk_size: int = 0,
+        y_chunk_size: int = 0,
+    ) -> None: ...
+    def _write_cache(self) -> NoReturn: ...
+
+class ThreadedContourGenerator(ContourGenerator):
+    def __init__(
+        self,
+        x: CoordinateArray,
+        y: CoordinateArray,
+        z: CoordinateArray,
+        mask: MaskArray,
+        *,
+        corner_mask: bool,
+        line_type: LineType,
+        fill_type: FillType,
+        quad_as_tri: bool,
+        z_interp: ZInterp,
+        x_chunk_size: int = 0,
+        y_chunk_size: int = 0,
+        thread_count: int = 0,
+    ) -> None: ...
+    def _write_cache(self) -> None: ...

--- a/lib/contourpy/_contourpy.pyi
+++ b/lib/contourpy/_contourpy.pyi
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.typing as npt
 from typing_extensions import TypeAlias
 
-import contourpy._contourpy
+from . import _contourpy as cpy
 
 # Input numpy array types, the same as in common.h
 CoordinateArray: TypeAlias = npt.NDArray[np.float64]
@@ -39,13 +39,13 @@ CONTOURPY_DEBUG: int
 __version__: str
 
 class FillType:
-    ChunkCombinedCode: ClassVar[contourpy._contourpy.FillType]
-    ChunkCombinedCodeOffset: ClassVar[contourpy._contourpy.FillType]
-    ChunkCombinedOffset: ClassVar[contourpy._contourpy.FillType]
-    ChunkCombinedOffsetOffset: ClassVar[contourpy._contourpy.FillType]
-    OuterCode: ClassVar[contourpy._contourpy.FillType]
-    OuterOffset: ClassVar[contourpy._contourpy.FillType]
-    __members__: ClassVar[dict[str, contourpy._contourpy.FillType]]
+    ChunkCombinedCode: ClassVar[cpy.FillType]
+    ChunkCombinedCodeOffset: ClassVar[cpy.FillType]
+    ChunkCombinedOffset: ClassVar[cpy.FillType]
+    ChunkCombinedOffsetOffset: ClassVar[cpy.FillType]
+    OuterCode: ClassVar[cpy.FillType]
+    OuterOffset: ClassVar[cpy.FillType]
+    __members__: ClassVar[dict[str, cpy.FillType]]
     def __eq__(self, other: object) -> bool: ...
     def __getstate__(self) -> int: ...
     def __hash__(self) -> int: ...
@@ -61,11 +61,11 @@ class FillType:
     def value(self) -> int: ...
 
 class LineType:
-    ChunkCombinedCode: ClassVar[contourpy._contourpy.LineType]
-    ChunkCombinedOffset: ClassVar[contourpy._contourpy.LineType]
-    Separate: ClassVar[contourpy._contourpy.LineType]
-    SeparateCode: ClassVar[contourpy._contourpy.LineType]
-    __members__: ClassVar[dict[str, contourpy._contourpy.LineType]]
+    ChunkCombinedCode: ClassVar[cpy.LineType]
+    ChunkCombinedOffset: ClassVar[cpy.LineType]
+    Separate: ClassVar[cpy.LineType]
+    SeparateCode: ClassVar[cpy.LineType]
+    __members__: ClassVar[dict[str, cpy.LineType]]
     def __eq__(self, other: object) -> bool: ...
     def __getstate__(self) -> int: ...
     def __hash__(self) -> int: ...
@@ -81,9 +81,9 @@ class LineType:
     def value(self) -> int: ...
 
 class ZInterp:
-    Linear: ClassVar[contourpy._contourpy.ZInterp]
-    Log: ClassVar[contourpy._contourpy.ZInterp]
-    __members__: ClassVar[dict[str, contourpy._contourpy.ZInterp]]
+    Linear: ClassVar[cpy.ZInterp]
+    Log: ClassVar[cpy.ZInterp]
+    __members__: ClassVar[dict[str, cpy.ZInterp]]
     def __eq__(self, other: object) -> bool: ...
     def __getstate__(self) -> int: ...
     def __hash__(self) -> int: ...
@@ -133,8 +133,8 @@ class ContourGenerator:
     def thread_count(self) -> int: ...
     @property
     def z_interp(self) -> ZInterp: ...
-    default_fill_type: contourpy._contourpy.FillType
-    default_line_type: contourpy._contourpy.LineType
+    default_fill_type: cpy.FillType
+    default_line_type: cpy.LineType
 
 class Mpl2005ContourGenerator(ContourGenerator):
     def __init__(

--- a/lib/contourpy/chunk.py
+++ b/lib/contourpy/chunk.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
 import math
 
 
-def calc_chunk_sizes(chunk_size, chunk_count, total_chunk_count, ny, nx):
+def calc_chunk_sizes(
+    chunk_size: int | tuple[int, int] | None,
+    chunk_count: int | tuple[int, int] | None,
+    total_chunk_count: int | None,
+    ny: int,
+    nx: int,
+) -> tuple[int, int]:
     """Calculate chunk sizes.
 
     Args:
@@ -59,7 +67,7 @@ def calc_chunk_sizes(chunk_size, chunk_count, total_chunk_count, ny, nx):
     return y_chunk_size, x_chunk_size
 
 
-def two_factors(n):
+def two_factors(n: int) -> tuple[int, int]:
     """Split an integer into two integer factors.
 
     The two factors will be as close as possible to the sqrt of n, and are returned in decreasing

--- a/lib/contourpy/enum_util.py
+++ b/lib/contourpy/enum_util.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from ._contourpy import FillType, LineType, ZInterp
 
 
-def as_fill_type(fill_type):
+def as_fill_type(fill_type: FillType | str) -> FillType:
     """Coerce a FillType or string value to a FillType.
 
     Args:
@@ -11,11 +13,12 @@ def as_fill_type(fill_type):
         FillType: Converted value.
     """
     if isinstance(fill_type, str):
-        fill_type = FillType.__members__[fill_type]
-    return fill_type
+        return FillType.__members__[fill_type]
+    else:
+        return fill_type
 
 
-def as_line_type(line_type):
+def as_line_type(line_type: LineType | str) -> LineType:
     """Coerce a LineType or string value to a LineType.
 
     Args:
@@ -25,11 +28,12 @@ def as_line_type(line_type):
         LineType: Converted value.
     """
     if isinstance(line_type, str):
-        line_type = LineType.__members__[line_type]
-    return line_type
+        return LineType.__members__[line_type]
+    else:
+        return line_type
 
 
-def as_z_interp(z_interp):
+def as_z_interp(z_interp: ZInterp | str) -> ZInterp:
     """Coerce a ZInterp or string value to a ZInterp.
 
     Args:
@@ -39,5 +43,6 @@ def as_z_interp(z_interp):
         ZInterp: Converted value.
     """
     if isinstance(z_interp, str):
-        z_interp = ZInterp.__members__[z_interp]
-    return z_interp
+        return ZInterp.__members__[z_interp]
+    else:
+        return z_interp

--- a/lib/contourpy/util/bokeh_util.py
+++ b/lib/contourpy/util/bokeh_util.py
@@ -1,11 +1,22 @@
-from contourpy import FillType, LineType
+from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+
+from .. import FillType, LineType
 from .mpl_util import mpl_codes_to_offsets
 
+if TYPE_CHECKING:
+    from .._contourpy import (
+        CoordinateArray, FillReturn, LineReturn, LineReturn_Separate, LineReturn_SeparateCode,
+    )
 
-def filled_to_bokeh(filled, fill_type):
-    xs = []
-    ys = []
+
+def filled_to_bokeh(
+    filled: FillReturn,
+    fill_type: FillType,
+) -> tuple[list[list[CoordinateArray]], list[list[CoordinateArray]]]:
+    xs: list[list[CoordinateArray]] = []
+    ys: list[list[CoordinateArray]] = []
     if fill_type in (FillType.OuterOffset, FillType.ChunkCombinedOffset,
                      FillType.OuterCode, FillType.ChunkCombinedCode):
         have_codes = fill_type in (FillType.OuterCode, FillType.ChunkCombinedCode)
@@ -43,15 +54,22 @@ def filled_to_bokeh(filled, fill_type):
     return xs, ys
 
 
-def lines_to_bokeh(lines, line_type):
-    xs = []
-    ys = []
+def lines_to_bokeh(
+    lines: LineReturn,
+    line_type: LineType,
+) -> tuple[list[CoordinateArray], list[CoordinateArray]]:
+    xs: list[CoordinateArray] = []
+    ys: list[CoordinateArray] = []
 
     if line_type == LineType.Separate:
+        if TYPE_CHECKING:
+            lines = cast(LineReturn_Separate, lines)
         for line in lines:
             xs.append(line[:, 0])
             ys.append(line[:, 1])
     elif line_type == LineType.SeparateCode:
+        if TYPE_CHECKING:
+            lines = cast(LineReturn_SeparateCode, lines)
         for line in lines[0]:
             xs.append(line[:, 0])
             ys.append(line[:, 1])

--- a/lib/contourpy/util/data.py
+++ b/lib/contourpy/util/data.py
@@ -1,7 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import numpy as np
 
+if TYPE_CHECKING:
+    from .._contourpy import CoordinateArray
 
-def simple(shape, want_mask=False):
+
+def simple(
+    shape: tuple[int, int], want_mask: bool = False
+) -> tuple[CoordinateArray, CoordinateArray, CoordinateArray | np.ma.MaskedArray[Any, Any]]:
     """Return simple test data consisting of the sum of two gaussians.
 
     Args:
@@ -34,12 +43,14 @@ def simple(shape, want_mask=False):
             ((x/xscale - 1.0)**2 / 0.2 + (y/yscale - 0.0)**2 / 0.1) < 1.0,
             ((x/xscale - 0.2)**2 / 0.02 + (y/yscale - 0.45)**2 / 0.08) < 1.0
         )
-        z = np.ma.array(z, mask=mask)
+        z = np.ma.array(z, mask=mask)  # type: ignore[no-untyped-call]
 
     return x, y, z
 
 
-def random(shape, seed=2187, mask_fraction=0.0):
+def random(
+    shape: tuple[int, int], seed: int = 2187, mask_fraction: float = 0.0
+) -> tuple[CoordinateArray, CoordinateArray, CoordinateArray | np.ma.MaskedArray[Any, Any]]:
     """Return random test data..
 
     Args:
@@ -62,6 +73,6 @@ def random(shape, seed=2187, mask_fraction=0.0):
     if mask_fraction > 0.0:
         mask_fraction = min(mask_fraction, 0.99)
         mask = rng.uniform(size=shape) < mask_fraction
-        z = np.ma.array(z, mask=mask)
+        z = np.ma.array(z, mask=mask)  # type: ignore[no-untyped-call]
 
     return x, y, z

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -1,16 +1,37 @@
+from __future__ import annotations
+
 import io
+from typing import TYPE_CHECKING
 
 import matplotlib.collections as mcollections
 import matplotlib.pyplot as plt
 import numpy as np
 
-from contourpy import FillType, LineType
-
+from .. import FillType, LineType
 from .mpl_util import filled_to_mpl_paths, lines_to_mpl_paths, mpl_codes_to_offsets
 from .renderer import Renderer
 
+if TYPE_CHECKING:
+    from typing import Any, cast
+
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+    from numpy.typing import ArrayLike
+
+    from .._contourpy import (
+        CoordinateArray, FillReturn, FillReturn_ChunkCombinedCode,
+        FillReturn_ChunkCombinedCodeOffset, FillReturn_ChunkCombinedOffset,
+        FillReturn_ChunkCombinedOffsetOffset, FillReturn_OuterCode, FillReturn_OuterOffset,
+        LineReturn, LineReturn_ChunkCombinedCode, LineReturn_ChunkCombinedOffset,
+        LineReturn_Separate, LineReturn_SeparateCode, OffsetArray, PointArray,
+    )
+
 
 class MplRenderer(Renderer):
+    _axes: Axes
+    _fig: Figure
+    _want_tight: bool
+
     """Utility renderer using Matplotlib to render a grid of plots over the same (x, y) range.
 
     Args:
@@ -24,8 +45,14 @@ class MplRenderer(Renderer):
             default None.
     """
     def __init__(
-        self, nrows=1, ncols=1, figsize=(9, 9), show_frame=True, backend=None, gridspec_kw=None,
-    ):
+        self,
+        nrows: int = 1,
+        ncols: int = 1,
+        figsize: tuple[int, int] = (9, 9),
+        show_frame: bool = True,
+        backend: str | None = None,
+        gridspec_kw: dict[str, Any] | None = None,
+    ) -> None:
         if backend is not None:
             import matplotlib
             matplotlib.use(backend)
@@ -44,11 +71,11 @@ class MplRenderer(Renderer):
 
         self._want_tight = True
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, "_fig"):
             plt.close(self._fig)
 
-    def _autoscale(self):
+    def _autoscale(self) -> None:
         # Using axes._need_autoscale attribute if need to autoscale before rendering after adding
         # lines/filled.  Only want to autoscale once per axes regardless of how many lines/filled
         # added.
@@ -59,12 +86,19 @@ class MplRenderer(Renderer):
         if self._want_tight and len(self._axes) > 1:
             self._fig.tight_layout()
 
-    def _get_ax(self, ax):
+    def _get_ax(self, ax: Axes | int) -> Axes:
         if isinstance(ax, int):
             ax = self._axes[ax]
         return ax
 
-    def filled(self, filled, fill_type, ax=0, color="C0", alpha=0.7):
+    def filled(
+        self,
+        filled: FillReturn,
+        fill_type: FillType,
+        ax: Axes | int = 0,
+        color: str = "C0",
+        alpha: float = 0.7,
+    ) -> None:
         """Plot filled contours on a single Axes.
 
         Args:
@@ -85,7 +119,16 @@ class MplRenderer(Renderer):
         ax.add_collection(collection)
         ax._need_autoscale = True
 
-    def grid(self, x, y, ax=0, color="black", alpha=0.1, point_color=None, quad_as_tri_alpha=0):
+    def grid(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        ax: Axes | int = 0,
+        color: str = "black",
+        alpha: float = 0.1,
+        point_color: str | None = None,
+        quad_as_tri_alpha: float = 0,
+    ) -> None:
         """Plot quad grid lines on a single Axes.
 
         Args:
@@ -123,7 +166,15 @@ class MplRenderer(Renderer):
             ax.scatter(x, y, color=point_color, alpha=alpha, marker='o')
         ax._need_autoscale = True
 
-    def lines(self, lines, line_type, ax=0, color="C0", alpha=1.0, linewidth=1):
+    def lines(
+        self,
+        lines: LineReturn,
+        line_type: LineType,
+        ax: Axes | int = 0,
+        color: str = "C0",
+        alpha: float = 1.0,
+        linewidth: float = 1,
+    ) -> None:
         """Plot contour lines on a single Axes.
 
         Args:
@@ -145,7 +196,14 @@ class MplRenderer(Renderer):
         ax.add_collection(collection)
         ax._need_autoscale = True
 
-    def mask(self, x, y, z, ax=0, color="black"):
+    def mask(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike | np.ma.MaskedArray[Any, Any],
+        ax: Axes | int = 0,
+        color: str = "black",
+    ) -> None:
         """Plot masked out grid points as circles on a single Axes.
 
         Args:
@@ -155,14 +213,14 @@ class MplRenderer(Renderer):
             ax (int or Matplotlib Axes, optional): Which Axes to plot on, default ``0``.
             color (str, optional): Circle color, default ``"black"``.
         """
-        mask = np.ma.getmask(z)
+        mask = np.ma.getmask(z)  # type: ignore[no-untyped-call]
         if mask is np.ma.nomask:
             return
         ax = self._get_ax(ax)
         x, y = self._grid_as_2d(x, y)
         ax.plot(x[mask], y[mask], 'o', c=color)
 
-    def save(self, filename, transparent=False):
+    def save(self, filename: str, transparent: bool = False) -> None:
         """Save plots to SVG or PNG file.
 
         Args:
@@ -173,7 +231,7 @@ class MplRenderer(Renderer):
         self._autoscale()
         self._fig.savefig(filename, transparent=transparent)
 
-    def save_to_buffer(self):
+    def save_to_buffer(self) -> io.BytesIO:
         """Save plots to an ``io.BytesIO`` buffer.
 
         Return:
@@ -185,13 +243,13 @@ class MplRenderer(Renderer):
         buf.seek(0)
         return buf
 
-    def show(self):
+    def show(self) -> None:
         """Show plots in an interactive window, in the usual Matplotlib manner.
         """
         self._autoscale()
         plt.show()
 
-    def title(self, title, ax=0, color=None):
+    def title(self, title: str, ax: Axes | int = 0, color: str | None = None) -> None:
         """Set the title of a single Axes.
 
         Args:
@@ -199,14 +257,24 @@ class MplRenderer(Renderer):
             ax (int or Matplotlib Axes, optional): Which Axes to set the title of, default ``0``.
             color (str, optional): Color to set title. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the
-                ``tab10`` colormap. Default ``None`` which is ``black``.
+                ``tab10`` colormap. Default is ``None`` which uses Matplotlib's default title color
+                that depends on the stylesheet in use.
         """
         if color:
             self._get_ax(ax).set_title(title, color=color)
         else:
             self._get_ax(ax).set_title(title)
 
-    def z_values(self, x, y, z, ax=0, color="green", fmt=".1f", quad_as_tri=False):
+    def z_values(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike,
+        ax: Axes | int = 0,
+        color: str = "green",
+        fmt: str = ".1f",
+        quad_as_tri: bool = False,
+    ) -> None:
         """Show ``z`` values on a single Axes.
 
         Args:
@@ -248,7 +316,7 @@ class MplTestRenderer(MplRenderer):
     No whitespace around plots and no spines/ticks displayed.
     Uses Agg backend, so can only save to file/buffer, cannot call ``show()``.
     """
-    def __init__(self, nrows=1, ncols=1, figsize=(9, 9)):
+    def __init__(self, nrows: int = 1, ncols: int = 1, figsize: tuple[int, int] = (9, 9)) -> None:
         gridspec = {
             "left": 0.01,
             "right": 0.99,
@@ -276,10 +344,24 @@ class MplDebugRenderer(MplRenderer):
     Extends ``MplRenderer`` to add extra information to help in debugging such as markers, arrows,
     text, etc.
     """
-    def __init__(self, nrows=1, ncols=1, figsize=(9, 9), show_frame=True):
+    def __init__(
+        self,
+        nrows: int = 1,
+        ncols: int = 1,
+        figsize: tuple[int, int] = (9, 9),
+        show_frame: bool = True,
+    ) -> None:
         super().__init__(nrows, ncols, figsize, show_frame)
 
-    def _arrow(self, ax, line_start, line_end, color, alpha, arrow_size):
+    def _arrow(
+        self,
+        ax: Axes,
+        line_start: CoordinateArray,
+        line_end: CoordinateArray,
+        color: str,
+        alpha: float,
+        arrow_size: float,
+    ) -> None:
         mid = 0.5*(line_start + line_end)
         along = line_end - line_start
         along /= np.sqrt(np.dot(along, along))  # Unit vector.
@@ -291,48 +373,118 @@ class MplDebugRenderer(MplRenderer):
         ))
         ax.plot(arrow[:, 0], arrow[:, 1], "-", c=color, alpha=alpha)
 
-    def filled(self, filled, fill_type, ax=0, color="C1", alpha=0.7, line_color="C0",
-               line_alpha=0.7, point_color="C0", start_point_color="red", arrow_size=0.1):
-        super().filled(filled, fill_type, ax, color, alpha)
-
-        if line_color is None and point_color is None:
-            return
-
-        ax = self._get_ax(ax)
-
+    def _filled_to_lists_of_points_and_offsets(
+        self,
+        filled: FillReturn,
+        fill_type: FillType,
+    ) -> tuple[list[PointArray], list[OffsetArray]]:
         if fill_type == FillType.OuterCode:
+            if TYPE_CHECKING:
+                filled = cast(FillReturn_OuterCode, filled)
             all_points = filled[0]
             all_offsets = [mpl_codes_to_offsets(codes) for codes in filled[1]]
         elif fill_type == FillType.ChunkCombinedCode:
+            if TYPE_CHECKING:
+                filled = cast(FillReturn_ChunkCombinedCode, filled)
             all_points = [points for points in filled[0] if points is not None]
             all_offsets = [mpl_codes_to_offsets(codes) for codes in filled[1] if codes is not None]
         elif fill_type == FillType.OuterOffset:
+            if TYPE_CHECKING:
+                filled = cast(FillReturn_OuterOffset, filled)
             all_points = filled[0]
             all_offsets = filled[1]
         elif fill_type == FillType.ChunkCombinedOffset:
+            if TYPE_CHECKING:
+                filled = cast(FillReturn_ChunkCombinedOffset, filled)
             all_points = [points for points in filled[0] if points is not None]
             all_offsets = [offsets for offsets in filled[1] if offsets is not None]
         elif fill_type == FillType.ChunkCombinedCodeOffset:
+            if TYPE_CHECKING:
+                filled = cast(FillReturn_ChunkCombinedCodeOffset, filled)
             all_points = []
             all_offsets = []
             for points, codes, outer_offsets in zip(*filled):
                 if points is None:
                     continue
+                if TYPE_CHECKING:
+                    assert codes is not None and outer_offsets is not None
                 all_points += np.split(points, outer_offsets[1:-1])
-                codes = np.split(codes, outer_offsets[1:-1])
-                all_offsets += [mpl_codes_to_offsets(codes) for codes in codes]
+                all_codes = np.split(codes, outer_offsets[1:-1])
+                all_offsets += [mpl_codes_to_offsets(codes) for codes in all_codes]
         elif fill_type == FillType.ChunkCombinedOffsetOffset:
+            if TYPE_CHECKING:
+                filled = cast(FillReturn_ChunkCombinedOffsetOffset, filled)
             all_points = []
             all_offsets = []
             for points, offsets, outer_offsets in zip(*filled):
                 if points is None:
                     continue
+                if TYPE_CHECKING:
+                    assert offsets is not None and outer_offsets is not None
                 for i in range(len(outer_offsets)-1):
                     offs = offsets[outer_offsets[i]:outer_offsets[i+1]+1]
                     all_points.append(points[offs[0]:offs[-1]])
                     all_offsets.append(offs - offs[0])
         else:
             raise RuntimeError(f"Rendering FillType {fill_type} not implemented")
+
+        return all_points, all_offsets
+
+    def _lines_to_list_of_points(self, lines: LineReturn, line_type: LineType) -> list[PointArray]:
+        if line_type == LineType.Separate:
+            if TYPE_CHECKING:
+                lines = cast(LineReturn_Separate, lines)
+            all_lines = lines
+        elif line_type == LineType.SeparateCode:
+            if TYPE_CHECKING:
+                lines = cast(LineReturn_SeparateCode, lines)
+            all_lines = lines[0]
+        elif line_type == LineType.ChunkCombinedCode:
+            if TYPE_CHECKING:
+                lines = cast(LineReturn_ChunkCombinedCode, lines)
+            all_lines = []
+            for points, codes in zip(*lines):
+                if points is not None:
+                    if TYPE_CHECKING:
+                        assert codes is not None
+                    offsets = mpl_codes_to_offsets(codes)
+                    for i in range(len(offsets)-1):
+                        all_lines.append(points[offsets[i]:offsets[i+1]])
+        elif line_type == LineType.ChunkCombinedOffset:
+            if TYPE_CHECKING:
+                lines = cast(LineReturn_ChunkCombinedOffset, lines)
+            all_lines = []
+            for points, all_offsets in zip(*lines):
+                if points is not None:
+                    if TYPE_CHECKING:
+                        assert all_offsets is not None
+                    for i in range(len(all_offsets)-1):
+                        all_lines.append(points[all_offsets[i]:all_offsets[i+1]])
+        else:
+            raise RuntimeError(f"Rendering LineType {line_type} not implemented")
+
+        return all_lines
+
+    def filled(
+        self,
+        filled: FillReturn,
+        fill_type: FillType,
+        ax: Axes | int = 0,
+        color: str = "C1",
+        alpha: float = 0.7,
+        line_color: str = "C0",
+        line_alpha: float = 0.7,
+        point_color: str = "C0",
+        start_point_color: str = "red",
+        arrow_size: float = 0.1,
+    ) -> None:
+        super().filled(filled, fill_type, ax, color, alpha)
+
+        if line_color is None and point_color is None:
+            return
+
+        ax = self._get_ax(ax)
+        all_points, all_offsets = self._filled_to_lists_of_points_and_offsets(filled, fill_type)
 
         # Lines.
         if line_color is not None:
@@ -361,34 +513,25 @@ class MplDebugRenderer(MplRenderer):
                     ax.plot(points[:, 0][start_indices], points[:, 1][start_indices], "o",
                             c=start_point_color, alpha=line_alpha)
 
-    def lines(self, lines, line_type, ax=0, color="C0", alpha=1.0, linewidth=1, point_color="C0",
-              start_point_color="red", arrow_size=0.1):
+    def lines(
+        self,
+        lines: LineReturn,
+        line_type: LineType,
+        ax: Axes | int = 0,
+        color: str = "C0",
+        alpha: float = 1.0,
+        linewidth: float = 1,
+        point_color: str = "C0",
+        start_point_color: str = "red",
+        arrow_size: float = 0.1,
+    ) -> None:
         super().lines(lines, line_type, ax, color, alpha, linewidth)
 
         if arrow_size == 0.0 and point_color is None:
             return
 
         ax = self._get_ax(ax)
-
-        if line_type == LineType.Separate:
-            all_lines = lines
-        elif line_type == LineType.SeparateCode:
-            all_lines = lines[0]
-        elif line_type == LineType.ChunkCombinedCode:
-            all_lines = []
-            for points, codes in zip(*lines):
-                if points is not None:
-                    offsets = mpl_codes_to_offsets(codes)
-                    for i in range(len(offsets)-1):
-                        all_lines.append(points[offsets[i]:offsets[i+1]])
-        elif line_type == LineType.ChunkCombinedOffset:
-            all_lines = []
-            for points, offsets in zip(*lines):
-                if points is not None:
-                    for i in range(len(offsets)-1):
-                        all_lines.append(points[offsets[i]:offsets[i+1]])
-        else:
-            raise RuntimeError(f"Rendering LineType {line_type} not implemented")
+        all_lines = self._lines_to_list_of_points(lines, line_type)
 
         if arrow_size > 0.0:
             for line in all_lines:
@@ -407,7 +550,14 @@ class MplDebugRenderer(MplRenderer):
                 ax.plot(line[start_index:end_index, 0], line[start_index:end_index, 1], "o",
                         c=color, alpha=alpha)
 
-    def point_numbers(self, x, y, z, ax=0, color="red"):
+    def point_numbers(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike,
+        ax: Axes | int = 0,
+        color: str = "red",
+    ) -> None:
         ax = self._get_ax(ax)
         x, y = self._grid_as_2d(x, y)
         z = np.asarray(z)
@@ -418,7 +568,14 @@ class MplDebugRenderer(MplRenderer):
                 ax.text(x[j, i], y[j, i], str(quad), ha="right", va="top", color=color,
                         clip_on=True)
 
-    def quad_numbers(self, x, y, z, ax=0, color="blue"):
+    def quad_numbers(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike,
+        ax: Axes | int = 0,
+        color: str = "blue",
+    ) -> None:
         ax = self._get_ax(ax)
         x, y = self._grid_as_2d(x, y)
         z = np.asarray(z)
@@ -430,7 +587,16 @@ class MplDebugRenderer(MplRenderer):
                 ymid = y[j-1:j+1, i-1:i+1].mean()
                 ax.text(xmid, ymid, str(quad), ha="center", va="center", color=color, clip_on=True)
 
-    def z_levels(self, x, y, z, lower_level, upper_level=None, ax=0, color="green"):
+    def z_levels(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike,
+        lower_level: float,
+        upper_level: float | None = None,
+        ax: Axes | int = 0,
+        color: str = "green",
+    ) -> None:
         ax = self._get_ax(ax)
         x, y = self._grid_as_2d(x, y)
         z = np.asarray(z)

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 import matplotlib.collections as mcollections
 import matplotlib.pyplot as plt
@@ -12,19 +12,11 @@ from .mpl_util import filled_to_mpl_paths, lines_to_mpl_paths, mpl_codes_to_offs
 from .renderer import Renderer
 
 if TYPE_CHECKING:
-    from typing import Any, cast
-
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
     from numpy.typing import ArrayLike
 
-    from .._contourpy import (
-        CoordinateArray, FillReturn, FillReturn_ChunkCombinedCode,
-        FillReturn_ChunkCombinedCodeOffset, FillReturn_ChunkCombinedOffset,
-        FillReturn_ChunkCombinedOffsetOffset, FillReturn_OuterCode, FillReturn_OuterOffset,
-        LineReturn, LineReturn_ChunkCombinedCode, LineReturn_ChunkCombinedOffset,
-        LineReturn_Separate, LineReturn_SeparateCode, OffsetArray, PointArray,
-    )
+    from .. import _contourpy as cpy
 
 
 class MplRenderer(Renderer):
@@ -93,7 +85,7 @@ class MplRenderer(Renderer):
 
     def filled(
         self,
-        filled: FillReturn,
+        filled: cpy.FillReturn,
         fill_type: FillType,
         ax: Axes | int = 0,
         color: str = "C0",
@@ -168,7 +160,7 @@ class MplRenderer(Renderer):
 
     def lines(
         self,
-        lines: LineReturn,
+        lines: cpy.LineReturn,
         line_type: LineType,
         ax: Axes | int = 0,
         color: str = "C0",
@@ -356,8 +348,8 @@ class MplDebugRenderer(MplRenderer):
     def _arrow(
         self,
         ax: Axes,
-        line_start: CoordinateArray,
-        line_end: CoordinateArray,
+        line_start: cpy.CoordinateArray,
+        line_end: cpy.CoordinateArray,
         color: str,
         alpha: float,
         arrow_size: float,
@@ -375,32 +367,32 @@ class MplDebugRenderer(MplRenderer):
 
     def _filled_to_lists_of_points_and_offsets(
         self,
-        filled: FillReturn,
+        filled: cpy.FillReturn,
         fill_type: FillType,
-    ) -> tuple[list[PointArray], list[OffsetArray]]:
+    ) -> tuple[list[cpy.PointArray], list[cpy.OffsetArray]]:
         if fill_type == FillType.OuterCode:
             if TYPE_CHECKING:
-                filled = cast(FillReturn_OuterCode, filled)
+                filled = cast(cpy.FillReturn_OuterCode, filled)
             all_points = filled[0]
             all_offsets = [mpl_codes_to_offsets(codes) for codes in filled[1]]
         elif fill_type == FillType.ChunkCombinedCode:
             if TYPE_CHECKING:
-                filled = cast(FillReturn_ChunkCombinedCode, filled)
+                filled = cast(cpy.FillReturn_ChunkCombinedCode, filled)
             all_points = [points for points in filled[0] if points is not None]
             all_offsets = [mpl_codes_to_offsets(codes) for codes in filled[1] if codes is not None]
         elif fill_type == FillType.OuterOffset:
             if TYPE_CHECKING:
-                filled = cast(FillReturn_OuterOffset, filled)
+                filled = cast(cpy.FillReturn_OuterOffset, filled)
             all_points = filled[0]
             all_offsets = filled[1]
         elif fill_type == FillType.ChunkCombinedOffset:
             if TYPE_CHECKING:
-                filled = cast(FillReturn_ChunkCombinedOffset, filled)
+                filled = cast(cpy.FillReturn_ChunkCombinedOffset, filled)
             all_points = [points for points in filled[0] if points is not None]
             all_offsets = [offsets for offsets in filled[1] if offsets is not None]
         elif fill_type == FillType.ChunkCombinedCodeOffset:
             if TYPE_CHECKING:
-                filled = cast(FillReturn_ChunkCombinedCodeOffset, filled)
+                filled = cast(cpy.FillReturn_ChunkCombinedCodeOffset, filled)
             all_points = []
             all_offsets = []
             for points, codes, outer_offsets in zip(*filled):
@@ -413,7 +405,7 @@ class MplDebugRenderer(MplRenderer):
                 all_offsets += [mpl_codes_to_offsets(codes) for codes in all_codes]
         elif fill_type == FillType.ChunkCombinedOffsetOffset:
             if TYPE_CHECKING:
-                filled = cast(FillReturn_ChunkCombinedOffsetOffset, filled)
+                filled = cast(cpy.FillReturn_ChunkCombinedOffsetOffset, filled)
             all_points = []
             all_offsets = []
             for points, offsets, outer_offsets in zip(*filled):
@@ -430,18 +422,21 @@ class MplDebugRenderer(MplRenderer):
 
         return all_points, all_offsets
 
-    def _lines_to_list_of_points(self, lines: LineReturn, line_type: LineType) -> list[PointArray]:
+    def _lines_to_list_of_points(
+        self, lines: cpy.LineReturn,
+        line_type: LineType
+    ) -> list[cpy.PointArray]:
         if line_type == LineType.Separate:
             if TYPE_CHECKING:
-                lines = cast(LineReturn_Separate, lines)
+                lines = cast(cpy.LineReturn_Separate, lines)
             all_lines = lines
         elif line_type == LineType.SeparateCode:
             if TYPE_CHECKING:
-                lines = cast(LineReturn_SeparateCode, lines)
+                lines = cast(cpy.LineReturn_SeparateCode, lines)
             all_lines = lines[0]
         elif line_type == LineType.ChunkCombinedCode:
             if TYPE_CHECKING:
-                lines = cast(LineReturn_ChunkCombinedCode, lines)
+                lines = cast(cpy.LineReturn_ChunkCombinedCode, lines)
             all_lines = []
             for points, codes in zip(*lines):
                 if points is not None:
@@ -452,7 +447,7 @@ class MplDebugRenderer(MplRenderer):
                         all_lines.append(points[offsets[i]:offsets[i+1]])
         elif line_type == LineType.ChunkCombinedOffset:
             if TYPE_CHECKING:
-                lines = cast(LineReturn_ChunkCombinedOffset, lines)
+                lines = cast(cpy.LineReturn_ChunkCombinedOffset, lines)
             all_lines = []
             for points, all_offsets in zip(*lines):
                 if points is not None:
@@ -467,7 +462,7 @@ class MplDebugRenderer(MplRenderer):
 
     def filled(
         self,
-        filled: FillReturn,
+        filled: cpy.FillReturn,
         fill_type: FillType,
         ax: Axes | int = 0,
         color: str = "C1",
@@ -515,7 +510,7 @@ class MplDebugRenderer(MplRenderer):
 
     def lines(
         self,
-        lines: LineReturn,
+        lines: cpy.LineReturn,
         line_type: LineType,
         ax: Axes | int = 0,
         color: str = "C0",

--- a/lib/contourpy/util/mpl_util.py
+++ b/lib/contourpy/util/mpl_util.py
@@ -1,10 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
 import matplotlib.path as mpath
 import numpy as np
 
-from contourpy import FillType, LineType
+from .. import FillType, LineType
+
+if TYPE_CHECKING:
+    from .._contourpy import CodeArray, FillReturn, LineReturn, LineReturn_Separate, OffsetArray
 
 
-def filled_to_mpl_paths(filled, fill_type):
+def filled_to_mpl_paths(filled: FillReturn, fill_type: FillType) -> list[mpath.Path]:
     if fill_type in (FillType.OuterCode, FillType.ChunkCombinedCode):
         paths = [mpath.Path(points, codes) for points, codes in zip(*filled) if points is not None]
     elif fill_type in (FillType.OuterOffset, FillType.ChunkCombinedOffset):
@@ -32,8 +39,10 @@ def filled_to_mpl_paths(filled, fill_type):
     return paths
 
 
-def lines_to_mpl_paths(lines, line_type):
+def lines_to_mpl_paths(lines: LineReturn, line_type: LineType) -> list[mpath.Path]:
     if line_type == LineType.Separate:
+        if TYPE_CHECKING:
+            lines = cast(LineReturn_Separate, lines)
         paths = []
         for line in lines:
             # Drawing as Paths so that they can be closed correctly.
@@ -55,13 +64,13 @@ def lines_to_mpl_paths(lines, line_type):
     return paths
 
 
-def mpl_codes_to_offsets(codes):
-    offsets = np.nonzero(codes == 1)[0]
+def mpl_codes_to_offsets(codes: CodeArray) -> OffsetArray:
+    offsets = np.nonzero(codes == 1)[0].astype(np.uint32)
     offsets = np.append(offsets, len(codes))
     return offsets
 
 
-def offsets_to_mpl_codes(offsets):
+def offsets_to_mpl_codes(offsets: OffsetArray) -> CodeArray:
     codes = np.full(offsets[-1]-offsets[0], 2, dtype=np.uint8)  # LINETO = 2
     codes[offsets[:-1]] = 1  # MOVETO = 1
     codes[offsets[1:]-1] = 79  # CLOSEPOLY 79

--- a/lib/contourpy/util/renderer.py
+++ b/lib/contourpy/util/renderer.py
@@ -1,12 +1,28 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
+
+if TYPE_CHECKING:
+    import io
+
+    from numpy.typing import ArrayLike
+
+    from .._contourpy import CoordinateArray, FillReturn, FillType, LineReturn, LineType
 
 
 class Renderer(ABC):
     """Abstract base class for renderers, defining the interface that they must implement."""
 
-    def _grid_as_2d(self, x, y):
+    def _grid_as_2d(self, x: ArrayLike, y: ArrayLike) -> tuple[CoordinateArray, CoordinateArray]:
+        x = np.asarray(x)
+        y = np.asarray(y)
+        if x.ndim == 1:
+            x, y = np.meshgrid(x, y)
+        return x, y
+
         x = np.asarray(x)
         y = np.asarray(y)
         if x.ndim == 1:
@@ -14,37 +30,77 @@ class Renderer(ABC):
         return x, y
 
     @abstractmethod
-    def filled(self, filled, fill_type, ax=0, color="C0", alpha=0.7):
+    def filled(
+        self,
+        filled: FillReturn,
+        fill_type: FillType,
+        ax: Any = 0,
+        color: str = "C0",
+        alpha: float = 0.7,
+    ) -> None:
         pass
 
     @abstractmethod
-    def grid(self, x, y, ax=0, color="black", alpha=0.1, point_color=None, quad_as_tri_alpha=0):
+    def grid(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        ax: Any = 0,
+        color: str = "black",
+        alpha: float = 0.1,
+        point_color: str | None = None,
+        quad_as_tri_alpha: float = 0,
+    ) -> None:
         pass
 
     @abstractmethod
-    def lines(self, lines, line_type, ax=0, color="C0", alpha=1.0, linewidth=1):
+    def lines(
+        self,
+        lines: LineReturn,
+        line_type: LineType,
+        ax: Any = 0,
+        color: str = "C0",
+        alpha: float = 1.0,
+        linewidth: float = 1,
+    ) -> None:
         pass
 
     @abstractmethod
-    def mask(self, x, y, z, ax=0, color="black"):
+    def mask(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike | np.ma.MaskedArray[Any, Any],
+        ax: Any = 0,
+        color: str = "black",
+    ) -> None:
         pass
 
     @abstractmethod
-    def save(self, filename, transparent=False):
+    def save(self, filename: str, transparent: bool = False) -> None:
         pass
 
     @abstractmethod
-    def save_to_buffer(self):
+    def save_to_buffer(self) -> io.BytesIO:
         pass
 
     @abstractmethod
-    def show(self):
+    def show(self) -> None:
         pass
 
     @abstractmethod
-    def title(self, title, ax=0, color=None):
+    def title(self, title: str, ax: Any = 0, color: str | None = None) -> None:
         pass
 
     @abstractmethod
-    def z_values(self, x, y, z, ax=0, color="green", fmt=".1f", quad_as_tri=False):
+    def z_values(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike,
+        ax: Any = 0,
+        color: str = "green",
+        fmt: str = ".1f",
+        quad_as_tri: bool = False,
+    ) -> None:
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,21 @@ force_sort_within_sections = true
 multi_line_output = 5
 profile = "hug"
 skip_gitignore = true
+
+[tool.mypy]
+files = ["lib/contourpy"]
+python_version = "3.8"
+
+check_untyped_defs = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+strict = true
+warn_return_any = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = [
+    "matplotlib",
+    "matplotlib.*",
+]
+ignore_missing_imports = true


### PR DESCRIPTION
This PR adds type annotations for the `lib/contourpy` directory, and is the start of adding type annotations to the whole library including tests and benchmarks.

The file `_contourpy.pyi` contains the type annotations for the `pybind11`-wrapped C++ shared library. It was originally created using `pybind11-stubgen` (https://github.com/sizmailov/pybind11-stubgen) and then modified by hand.

Tested using `mypy 0.991` by running `mypy` in the top-level directory. Eventually this will be set up to run in `pre-commit`.

Observations:

1. Valid algorithm `name` values are just strings. It may be more correct to use `Literal` instead but this will limit the allowed names to a specific set rather than allowing the future possibility of plugins registering new algorithms by name.
2. `matplotlib` isn't typed yet, but work on this has started.
3. There are a few `mypy` errors in `bokeh_renderer.py` which are currently excluded. I am not yet sure if this is a problem with `bokeh`, `contourpy` or my understanding of the typing system.
4. `numpy` has types for `ndarray` but not yet for `MaskedArray`.  