### PR TITLE
Type annotations for test directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,14 +90,13 @@ profile = "hug"
 skip_gitignore = true
 
 [tool.mypy]
-files = ["lib/contourpy"]
+files = ["lib/contourpy", "tests"]
 python_version = "3.8"
 
 check_untyped_defs = true
 disallow_untyped_defs = true
 no_implicit_optional = true
 strict = true
-warn_return_any = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
 import pytest
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
@@ -10,14 +14,14 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     config.addinivalue_line("markers", "text: mark test as outputting text")
     config.addinivalue_line("markers", "image: mark test as generating comparison image")
     config.addinivalue_line("markers", "threads: mark test as using multiple threads")
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(config: pytest.Config, items: Sequence[Any]) -> None:
     if not config.getoption("--runslow"):
         skip_slow = pytest.mark.skip(reason="use --runslow option to run")
         for item in items:

--- a/tests/image_comparison.py
+++ b/tests/image_comparison.py
@@ -1,11 +1,22 @@
+from __future__ import annotations
+
 import os
 from shutil import copyfile
+from typing import TYPE_CHECKING
 
 import numpy as np
 
+if TYPE_CHECKING:
+    import io
 
-def compare_images(test_buffer, baseline_filename, test_filename_suffix=None, max_threshold=None,
-                   mean_threshold=None):
+
+def compare_images(
+    test_buffer: io.BytesIO,
+    baseline_filename: str,
+    test_filename_suffix: str | None = None,
+    max_threshold: int | None = None,
+    mean_threshold: float | None = None,
+) -> None:
     from PIL import Image
 
     if max_threshold is None:

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from subprocess import run
 
@@ -8,13 +10,13 @@ import contourpy
 
 
 # From PEP440 appendix.
-def version_is_canonical(version):
+def version_is_canonical(version: str) -> bool:
     return re.match(
         r"^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?"
         r"(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$", version) is not None
 
 
-def test_cppcheck():
+def test_cppcheck() -> None:
     # Skip test if cppcheck is not installed.
     cmd = ["cppcheck", "--version"]
     try:
@@ -36,7 +38,7 @@ def test_cppcheck():
     assert proc.returncode == 0, f"cppcheck issues:\n{proc.stderr.decode('utf-8')}"
 
 
-def test_version():
+def test_version() -> None:
     version_python = contourpy.__version__
     assert version_is_canonical(version_python)
     version_cxx = contourpy._contourpy.__version__

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from . import util_test
@@ -7,7 +9,7 @@ from . import util_test
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_config_filled(show_text, name):
+def test_config_filled(show_text: bool, name: str) -> None:
     from . import util_config
     from .image_comparison import compare_images
 
@@ -21,7 +23,7 @@ def test_config_filled(show_text, name):
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
-def test_config_filled_quad_as_tri(show_text, name):
+def test_config_filled_quad_as_tri(show_text: bool, name: str) -> None:
     from . import util_config
     from .image_comparison import compare_images
 
@@ -35,7 +37,7 @@ def test_config_filled_quad_as_tri(show_text, name):
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
-def test_config_filled_corner(show_text, name):
+def test_config_filled_corner(show_text: bool, name: str) -> None:
     from . import util_config
     from .image_comparison import compare_images
 
@@ -49,7 +51,7 @@ def test_config_filled_corner(show_text, name):
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_config_lines(show_text, name):
+def test_config_lines(show_text: bool, name: str) -> None:
     from . import util_config
     from .image_comparison import compare_images
 
@@ -65,7 +67,7 @@ def test_config_lines(show_text, name):
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
-def test_config_lines_quad_as_tri(show_text, name):
+def test_config_lines_quad_as_tri(show_text: bool, name: str) -> None:
     from . import util_config
     from .image_comparison import compare_images
 
@@ -79,7 +81,7 @@ def test_config_lines_quad_as_tri(show_text, name):
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
-def test_config_lines_corner(show_text, name):
+def test_config_lines_corner(show_text: bool, name: str) -> None:
     from . import util_config
     from .image_comparison import compare_images
 

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -5,9 +10,14 @@ from contourpy import ContourGenerator, FillType, LineType, ZInterp, contour_gen
 
 from . import util_test
 
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from contourpy._contourpy import CoordinateArray
+
 
 @pytest.fixture
-def xyz_3x3_as_lists():
+def xyz_3x3_as_lists() -> tuple[list[list[int]], ...]:
     x = [[0, 1, 2], [0, 1, 2], [0, 1, 2]]
     y = [[0, 0, 0], [1, 1, 1], [2, 2, 2]]
     z = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
@@ -15,7 +25,7 @@ def xyz_3x3_as_lists():
 
 
 @pytest.fixture
-def xyz_2x3_as_lists():  # shape (2, 3)
+def xyz_2x3_as_lists() -> tuple[list[list[int]], ...]:  # shape (2, 3)
     x = [[0, 1, 2], [0, 1, 2]]
     y = [[0, 0, 0], [1, 1, 1]]
     z = [[0, 1, 2], [3, 4, 5]]
@@ -23,7 +33,7 @@ def xyz_2x3_as_lists():  # shape (2, 3)
 
 
 @pytest.fixture
-def xyz_7x5_as_arrays():  # shape (7, 5)
+def xyz_7x5_as_arrays() -> tuple[CoordinateArray, ...]:  # shape (7, 5)
     x, y = np.meshgrid([0, 1, 2, 3, 4], [0, 1, 2, 3, 4, 5, 6])
     z = x + y
     return x, y, z
@@ -31,7 +41,11 @@ def xyz_7x5_as_arrays():  # shape (7, 5)
 
 @pytest.mark.parametrize("name", util_test.all_names())
 @pytest.mark.parametrize("z", ([1], [[[1]]]))
-def test_ndim_z(xyz_3x3_as_lists, name, z):
+def test_ndim_z(
+    xyz_3x3_as_lists: tuple[list[list[int]], ...],
+    name: str,
+    z: ArrayLike,
+) -> None:
     x, y, _ = xyz_3x3_as_lists
     with pytest.raises(TypeError):
         contour_generator(x, y, z, name=name)
@@ -39,14 +53,18 @@ def test_ndim_z(xyz_3x3_as_lists, name, z):
 
 @pytest.mark.parametrize("name", util_test.all_names())
 @pytest.mark.parametrize("all_xyz", ([[1]], [[1], [2]], [[1, 2]]))
-def test_z_shape_too_small(all_xyz, name):
+def test_z_shape_too_small(all_xyz: ArrayLike, name: str) -> None:
     with pytest.raises(TypeError):
-        contour_generator(all_xyz, all_xyz, all_xyz, name=name)
+        contour_generator(z=all_xyz, name=name)
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
 @pytest.mark.parametrize("wrong_ndim", (None, [1], [[[1]]]))
-def test_diff_ndim_xy(xyz_3x3_as_lists, name, wrong_ndim):
+def test_diff_ndim_xy(
+    xyz_3x3_as_lists: tuple[list[list[int]], ...],
+    name: str,
+    wrong_ndim: ArrayLike,
+) -> None:
     x, y, z = xyz_3x3_as_lists
     with pytest.raises(TypeError):
         contour_generator(wrong_ndim, y, z, name=name)
@@ -55,19 +73,19 @@ def test_diff_ndim_xy(xyz_3x3_as_lists, name, wrong_ndim):
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_xy_None(xyz_3x3_as_lists, name):
+def test_xy_None(xyz_3x3_as_lists: tuple[list[list[int]], ...], name: str) -> None:
     _, _, z = xyz_3x3_as_lists
     contour_generator(None, None, z, name=name)
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_xy_not_specified(xyz_3x3_as_lists, name):
+def test_xy_not_specified(xyz_3x3_as_lists: tuple[list[list[int]], ...], name: str) -> None:
     _, _, z = xyz_3x3_as_lists
     contour_generator(z=z, name=name)
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_xy_1d(name):
+def test_xy_1d(name: str) -> None:
     z = [[0, 1, 2], [3, 4, 5]]
     contour_generator([0, 1, 2], [0, 1], z, name=name)
     with pytest.raises(TypeError):
@@ -81,7 +99,7 @@ def test_xy_1d(name):
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_xy_ndim_more_than_2(name):
+def test_xy_ndim_more_than_2(name: str) -> None:
     z = [[0, 1, 2], [3, 4, 5]]
     msg = "Inputs x and y must be None, 1D or 2D, not 3D"
     with pytest.raises(TypeError, match=msg):
@@ -90,7 +108,11 @@ def test_xy_ndim_more_than_2(name):
 
 @pytest.mark.parametrize("name", util_test.all_names())
 @pytest.mark.parametrize("diff_shape", ([[1, 2, 3, 4], [5, 6, 7, 8]], [[1, 2], [3, 4], [5, 6]]))
-def test_xyz_diff_shapes(xyz_3x3_as_lists, name, diff_shape):
+def test_xyz_diff_shapes(
+    xyz_3x3_as_lists: tuple[list[list[int]], ...],
+    name: str,
+    diff_shape: ArrayLike,
+) -> None:
     x, y, z = xyz_3x3_as_lists
     with pytest.raises(TypeError):
         contour_generator(diff_shape, y, z, name=name)
@@ -101,14 +123,14 @@ def test_xyz_diff_shapes(xyz_3x3_as_lists, name, diff_shape):
 
 
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
-def test_corner_mask(xyz_3x3_as_lists, name):
+def test_corner_mask(xyz_3x3_as_lists: tuple[list[list[int]], ...], name: str) -> None:
     x, y, z = xyz_3x3_as_lists
     for corner_mask in [False, True]:
         cont_gen = contour_generator(x, y, z, name=name, corner_mask=corner_mask)
         assert cont_gen.corner_mask == corner_mask
 
 
-def test_corner_mask_not_supported(xyz_3x3_as_lists):
+def test_corner_mask_not_supported(xyz_3x3_as_lists: tuple[list[list[int]], ...]) -> None:
     name = "mpl2005"
     x, y, z = xyz_3x3_as_lists
     msg = f"{name} contour generator does not support corner_mask=True"
@@ -117,7 +139,7 @@ def test_corner_mask_not_supported(xyz_3x3_as_lists):
 
 
 @pytest.mark.parametrize('name', util_test.all_names())
-def test_chunk_size_negative(xyz_3x3_as_lists, name):
+def test_chunk_size_negative(xyz_3x3_as_lists: tuple[list[list[int]], ...], name: str) -> None:
     x, y, z = xyz_3x3_as_lists
     msg = "chunk_size cannot be negative"
     with pytest.raises(ValueError, match=msg):
@@ -130,7 +152,11 @@ def test_chunk_size_negative(xyz_3x3_as_lists, name):
 
 @pytest.mark.parametrize("name", util_test.all_names())
 @pytest.mark.parametrize("chunk_size", np.arange(9))
-def test_chunk_size_1d(xyz_7x5_as_arrays, name, chunk_size):
+def test_chunk_size_1d(
+    xyz_7x5_as_arrays: tuple[CoordinateArray, ...],
+    name: str,
+    chunk_size: int,
+) -> None:
     x, y, z = xyz_7x5_as_arrays
     ny, nx = z.shape
     cont_gen = contour_generator(x, y, z, name=name, chunk_size=chunk_size)
@@ -151,7 +177,12 @@ def test_chunk_size_1d(xyz_7x5_as_arrays, name, chunk_size):
 @pytest.mark.parametrize("name", util_test.all_names())
 @pytest.mark.parametrize("x_chunk_size", np.arange(9))
 @pytest.mark.parametrize("y_chunk_size", np.arange(9))
-def test_chunk_size_2d(xyz_7x5_as_arrays, name, x_chunk_size, y_chunk_size):
+def test_chunk_size_2d(
+    xyz_7x5_as_arrays: tuple[CoordinateArray, ...],
+    name: str,
+    x_chunk_size: int,
+    y_chunk_size: int,
+) -> None:
     x, y, z = xyz_7x5_as_arrays
     ny, nx = z.shape
     cont_gen = contour_generator(x, y, z, name=name, chunk_size=(y_chunk_size, x_chunk_size))
@@ -171,7 +202,7 @@ def test_chunk_size_2d(xyz_7x5_as_arrays, name, x_chunk_size, y_chunk_size):
     assert (ret_x_chunk_count-1)*ret_x_chunk_size < nx-1
 
 
-def test_chunk_size_and_count(xyz_7x5_as_arrays):
+def test_chunk_size_and_count(xyz_7x5_as_arrays: tuple[CoordinateArray, ...]) -> None:
     x, y, z = xyz_7x5_as_arrays
     name = "serial"
     msg = "Only one of chunk_size, chunk_count and total_chunk_count should be set"
@@ -188,7 +219,12 @@ def test_chunk_size_and_count(xyz_7x5_as_arrays):
     "chunk_count, ret_chunk_count",
     [[0, (1, 1)], [1, (1, 1)], [2, (2, 2)], [3, (3, 2)], [4, (3, 4)], [9, (6, 4)]],
 )
-def test_chunk_count_1d(xyz_7x5_as_arrays, name, chunk_count, ret_chunk_count):
+def test_chunk_count_1d(
+    xyz_7x5_as_arrays: tuple[CoordinateArray, ...],
+    name: str,
+    chunk_count: int,
+    ret_chunk_count: tuple[int, int],
+) -> None:
     x, y, z = xyz_7x5_as_arrays
     ny, nx = z.shape
     cont_gen = contour_generator(x, y, z, name=name, chunk_count=chunk_count)
@@ -207,7 +243,12 @@ def test_chunk_count_1d(xyz_7x5_as_arrays, name, chunk_count, ret_chunk_count):
     [[(0, 1), (1, 1)], [(1, 0), (1, 1)], [(2, 3), (2, 2)], [(3, 2), (3, 2)], [(1, 9), (1, 4)],
      [(9, 1), (6, 1)]],
 )
-def test_chunk_count_2d(xyz_7x5_as_arrays, name, chunk_count, ret_chunk_count):
+def test_chunk_count_2d(
+    xyz_7x5_as_arrays: tuple[CoordinateArray, ...],
+    name: str,
+    chunk_count: tuple[int, int],
+    ret_chunk_count: tuple[int, int],
+) -> None:
     x, y, z = xyz_7x5_as_arrays
     ny, nx = z.shape
     cont_gen = contour_generator(x, y, z, name=name, chunk_count=chunk_count)
@@ -226,7 +267,12 @@ def test_chunk_count_2d(xyz_7x5_as_arrays, name, chunk_count, ret_chunk_count):
     [[0, (1, 1)], [1, (1, 1)], [2, (2, 1)], [3, (3, 1)], [4, (2, 2)], [6, (3, 2)], [9, (3, 2)],
      [25, (6, 4)]],
 )
-def test_total_chunk_count(xyz_7x5_as_arrays, name, total_chunk_count, ret_chunk_count):
+def test_total_chunk_count(
+    xyz_7x5_as_arrays: tuple[CoordinateArray, ...],
+    name: str,
+    total_chunk_count: int,
+    ret_chunk_count: tuple[int, int],
+) -> None:
     x, y, z = xyz_7x5_as_arrays
     ny, nx = z.shape
     cont_gen = contour_generator(x, y, z, name=name, total_chunk_count=total_chunk_count)
@@ -239,7 +285,7 @@ def test_total_chunk_count(xyz_7x5_as_arrays, name, total_chunk_count, ret_chunk
     assert (ret_x_chunk_count-1)*ret_x_chunk_size < nx-1
 
 
-def test_name_invalid(xyz_3x3_as_lists):
+def test_name_invalid(xyz_3x3_as_lists: tuple[list[list[int]], ...]) -> None:
     x, y, z = xyz_3x3_as_lists
     name = "some invalid name"
     msg = f"Unrecognised contour generator name: {name}"
@@ -250,7 +296,11 @@ def test_name_invalid(xyz_3x3_as_lists):
 @pytest.mark.parametrize("name", ["mpl2005", "mpl2014"])
 @pytest.mark.parametrize(
     "line_type", [LineType.Separate, LineType.ChunkCombinedCode, LineType.ChunkCombinedOffset])
-def test_line_type_not_supported(xyz_3x3_as_lists, name, line_type):
+def test_line_type_not_supported(
+    xyz_3x3_as_lists: tuple[list[list[int]], ...],
+    name: str,
+    line_type: LineType,
+) -> None:
     x, y, z = xyz_3x3_as_lists
     msg = f"{name} contour generator does not support line_type {line_type}"
     with pytest.raises(ValueError, match=msg):
@@ -261,7 +311,11 @@ def test_line_type_not_supported(xyz_3x3_as_lists, name, line_type):
 @pytest.mark.parametrize("fill_type", [
     FillType.OuterOffset, FillType.ChunkCombinedCode, FillType.ChunkCombinedOffset,
     FillType.ChunkCombinedCodeOffset, FillType.ChunkCombinedOffsetOffset])
-def test_fill_type_not_supported(xyz_3x3_as_lists, name, fill_type):
+def test_fill_type_not_supported(
+    xyz_3x3_as_lists: tuple[list[list[int]], ...],
+    name: str,
+    fill_type: FillType,
+) -> None:
     x, y, z = xyz_3x3_as_lists
     msg = f"{name} contour generator does not support fill_type {fill_type}"
     with pytest.raises(ValueError, match=msg):
@@ -269,7 +323,7 @@ def test_fill_type_not_supported(xyz_3x3_as_lists, name, fill_type):
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_properties(xyz_3x3_as_lists, name):
+def test_properties(xyz_3x3_as_lists: tuple[list[list[int]], ...], name: str) -> None:
     # Test that each ContourGenerator class implements all the required properties.
     x, y, z = xyz_3x3_as_lists
     cont_gen = contour_generator(x, y, z, name=name)
@@ -284,14 +338,14 @@ def test_properties(xyz_3x3_as_lists, name):
 
 
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
-def test_quad_as_tri(xyz_3x3_as_lists, name):
+def test_quad_as_tri(xyz_3x3_as_lists: tuple[list[list[int]], ...], name: str) -> None:
     x, y, z = xyz_3x3_as_lists
     for quad_as_tri in [False, True]:
         cont_gen = contour_generator(x, y, z, name=name, quad_as_tri=quad_as_tri)
         assert cont_gen.quad_as_tri == quad_as_tri
 
 
-def test_quad_as_tri_not_supported(xyz_3x3_as_lists):
+def test_quad_as_tri_not_supported(xyz_3x3_as_lists: tuple[list[list[int]], ...]) -> None:
     x, y, z = xyz_3x3_as_lists
     name = "mpl2005"
     msg = f"{name} contour generator does not support quad_as_tri=True"
@@ -301,13 +355,17 @@ def test_quad_as_tri_not_supported(xyz_3x3_as_lists):
 
 @pytest.mark.parametrize("chunk_size", [0, 1, 2])
 @pytest.mark.parametrize("thread_count", [0, 1, 2])
-def test_thread_count(xyz_7x5_as_arrays, chunk_size, thread_count):
+def test_thread_count(
+    xyz_7x5_as_arrays: tuple[CoordinateArray, ...],
+    chunk_size: int,
+    thread_count: int,
+) -> None:
     name = "threaded"
     x, y, z = xyz_7x5_as_arrays
     cont_gen = contour_generator(
         x, y, z, name=name, chunk_size=chunk_size, thread_count=thread_count)
     ret_thread_count = cont_gen.thread_count
-    ret_chunk_count = np.prod(cont_gen.chunk_count)
+    ret_chunk_count = math.prod(cont_gen.chunk_count)
     max_thread_count = max_threads()
     if chunk_size == 0:
         assert ret_chunk_count == 1
@@ -319,7 +377,10 @@ def test_thread_count(xyz_7x5_as_arrays, chunk_size, thread_count):
 
 
 @pytest.mark.parametrize("name", util_test.all_names(exclude="threaded"))
-def test_thread_count_not_supported(xyz_3x3_as_lists, name):
+def test_thread_count_not_supported(
+    xyz_3x3_as_lists: tuple[list[list[int]], ...],
+    name: str,
+) -> None:
     x, y, z = xyz_3x3_as_lists
     thread_count = 2
     msg = f"{name} contour generator does not support thread_count {thread_count}"
@@ -327,7 +388,7 @@ def test_thread_count_not_supported(xyz_3x3_as_lists, name):
         contour_generator(x, y, z, name=name, thread_count=thread_count)
 
 
-def test_enums_as_strings(xyz_3x3_as_lists):
+def test_enums_as_strings(xyz_3x3_as_lists: tuple[list[list[int]], ...]) -> None:
     x, y, z = xyz_3x3_as_lists
     cg = contour_generator(
         x, y, z, line_type="SeparateCode", fill_type="ChunkCombinedCodeOffset", z_interp="Log")
@@ -337,21 +398,21 @@ def test_enums_as_strings(xyz_3x3_as_lists):
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_is_contour_generator(name, xyz_3x3_as_lists):
+def test_is_contour_generator(name: str, xyz_3x3_as_lists: tuple[list[list[int]], ...]) -> None:
     x, y, z = xyz_3x3_as_lists
     cg = contour_generator(x, y, z, name=name)
     assert isinstance(cg, ContourGenerator)
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_z_interp_none_to_linear(name, xyz_3x3_as_lists):
+def test_z_interp_none_to_linear(name: str, xyz_3x3_as_lists: tuple[list[list[int]], ...]) -> None:
     x, y, z = xyz_3x3_as_lists
     cg = contour_generator(x, y, z, name=name, z_interp=None)
     assert cg.z_interp == ZInterp.Linear
 
 
 @pytest.mark.parametrize("name", ["mpl2005", "mpl2014"])
-def test_z_interp_not_supported(name, xyz_3x3_as_lists):
+def test_z_interp_not_supported(name: str, xyz_3x3_as_lists: tuple[list[list[int]], ...]) -> None:
     x, y, z = xyz_3x3_as_lists
     msg = f"{name} contour generator does not support z_interp ZInterp.Log"
     with pytest.raises(ValueError, match=msg):

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Callable
+
 import pytest
 
 from contourpy import FillType, LineType, ZInterp
@@ -7,20 +11,20 @@ from . import util_test
 
 
 @pytest.mark.parametrize("name, value", util_test.all_fill_types_str_value())
-def test_fill_type(name, value):
+def test_fill_type(name: str, value: int) -> None:
     t = FillType.__members__[name]
     assert t.name == name
     assert t.value == value
 
 
 @pytest.mark.parametrize("name, value", util_test.all_line_types_str_value())
-def test_line_type(name, value):
+def test_line_type(name: str, value: int) -> None:
     t = LineType.__members__[name]
     assert t.name == name
     assert t.value == value
 
 
-def test_all_fill_types():
+def test_all_fill_types() -> None:
     # Check that all_fill_types() matches FillType.__members__
     fill_types = dict(util_test.all_fill_types_str_value())
     for name, enum in dict(FillType.__members__).items():
@@ -28,7 +32,7 @@ def test_all_fill_types():
         assert fill_types[name] == enum.value
 
 
-def test_all_line_types():
+def test_all_line_types() -> None:
     # Check that all_line_types() matches LineType.__members__
     line_types = dict(util_test.all_line_types_str_value())
     for name, enum in dict(LineType.__members__).items():
@@ -36,7 +40,7 @@ def test_all_line_types():
         assert line_types[name] == enum.value
 
 
-def test_all_z_interps():
+def test_all_z_interps() -> None:
     # Check that all_z_interps() matches ZInterp.__members__
     z_interps = dict(util_test.all_z_interps_str_value())
     for name, enum in dict(ZInterp.__members__).items():
@@ -47,7 +51,11 @@ def test_all_z_interps():
 @pytest.mark.parametrize(
     ["enum_type", "from_string_function"],
     [(FillType, as_fill_type), (LineType, as_line_type), (ZInterp, as_z_interp)])
-def test_string_to_enum(enum_type, from_string_function):
+def test_string_to_enum(
+    enum_type: FillType | LineType | ZInterp,
+    from_string_function: Callable[[FillType | LineType | ZInterp | str],
+                                   FillType | LineType | ZInterp],
+) -> None:
     for name, enum in enum_type.__members__.items():
         line_type = from_string_function(name)
         assert line_type == enum

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from functools import reduce
 from operator import add
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
@@ -10,9 +13,12 @@ from contourpy.util.data import random, simple
 
 from . import util_test
 
+if TYPE_CHECKING:
+    import contourpy._contourpy as cpy
+
 
 @pytest.fixture
-def two_outers_one_hole():
+def two_outers_one_hole() -> tuple[cpy.CoordinateArray, ...]:
     x, y = np.meshgrid([0., 1., 2., 3.], [0., 1., 2.])
     z = np.array([[1.5, 1.5, 0.9, 0.0],
                   [1.5, 2.8, 0.4, 0.8],
@@ -21,14 +27,14 @@ def two_outers_one_hole():
 
 
 @pytest.fixture
-def xyz_chunk_test():
+def xyz_chunk_test() -> tuple[cpy.CoordinateArray, ...]:
     x, y = np.meshgrid(np.arange(5), np.arange(5))
     z = 0.5*np.abs(y - 2) + 0.1*(x - 2)
     return x, y, z
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_filled_decreasing_levels(name):
+def test_filled_decreasing_levels(name: str) -> None:
     cont_gen = contour_generator(z=[[0, 1], [2, 3]], name=name, fill_type=FillType.OuterCode)
     with pytest.raises(ValueError, match="upper and lower levels are the wrong way round"):
         cont_gen.filled(2.0, 1.0)
@@ -36,7 +42,7 @@ def test_filled_decreasing_levels(name):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
-def test_filled_simple(name, fill_type):
+def test_filled_simple(name: str, fill_type: FillType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -59,7 +65,7 @@ def test_filled_simple(name, fill_type):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
-def test_filled_simple_chunk(name, fill_type):
+def test_filled_simple_chunk(name: str, fill_type: FillType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -88,7 +94,7 @@ def test_filled_simple_chunk(name, fill_type):
 @pytest.mark.threads
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 @pytest.mark.parametrize("thread_count", util_test.thread_counts())
-def test_filled_simple_chunk_threads(fill_type, thread_count):
+def test_filled_simple_chunk_threads(fill_type: FillType, thread_count: int) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -115,7 +121,7 @@ def test_filled_simple_chunk_threads(fill_type, thread_count):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
-def test_filled_simple_no_corner_mask(name, fill_type):
+def test_filled_simple_no_corner_mask(name: str, fill_type: FillType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -138,7 +144,7 @@ def test_filled_simple_no_corner_mask(name, fill_type):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
-def test_filled_simple_no_corner_mask_chunk(name, fill_type):
+def test_filled_simple_no_corner_mask_chunk(name: str, fill_type: FillType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -168,7 +174,7 @@ def test_filled_simple_no_corner_mask_chunk(name, fill_type):
 @pytest.mark.threads
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 @pytest.mark.parametrize("thread_count", util_test.thread_counts())
-def test_filled_simple_no_corner_mask_chunk_threads(fill_type, thread_count):
+def test_filled_simple_no_corner_mask_chunk_threads(fill_type: FillType, thread_count: int) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -197,7 +203,7 @@ def test_filled_simple_no_corner_mask_chunk_threads(fill_type, thread_count):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
-def test_filled_simple_corner_mask(name):
+def test_filled_simple_corner_mask(name: str) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -221,7 +227,7 @@ def test_filled_simple_corner_mask(name):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
-def test_filled_simple_corner_mask_chunk(name):
+def test_filled_simple_corner_mask_chunk(name: str) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -252,7 +258,7 @@ def test_filled_simple_corner_mask_chunk(name):
 @pytest.mark.threads
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 @pytest.mark.parametrize("thread_count", util_test.thread_counts())
-def test_filled_simple_corner_mask_chunk_threads(fill_type, thread_count):
+def test_filled_simple_corner_mask_chunk_threads(fill_type: FillType, thread_count: int) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -282,7 +288,7 @@ def test_filled_simple_corner_mask_chunk_threads(fill_type, thread_count):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
-def test_filled_simple_quad_as_tri(name):
+def test_filled_simple_quad_as_tri(name: str) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -306,7 +312,7 @@ def test_filled_simple_quad_as_tri(name):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
-def test_filled_random(name, fill_type):
+def test_filled_random(name: str, fill_type: FillType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -329,7 +335,7 @@ def test_filled_random(name, fill_type):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
-def test_filled_random_chunk(name, fill_type):
+def test_filled_random_chunk(name: str, fill_type: FillType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -372,7 +378,7 @@ def test_filled_random_chunk(name, fill_type):
 @pytest.mark.threads
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 @pytest.mark.parametrize("thread_count", util_test.thread_counts())
-def test_filled_random_chunk_threads(fill_type, thread_count):
+def test_filled_random_chunk_threads(fill_type: FillType, thread_count: int) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -407,7 +413,7 @@ def test_filled_random_chunk_threads(fill_type, thread_count):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
-def test_filled_random_no_corner_mask(name, fill_type):
+def test_filled_random_no_corner_mask(name: str, fill_type: FillType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -430,7 +436,7 @@ def test_filled_random_no_corner_mask(name, fill_type):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
-def test_filled_random_no_corner_mask_chunk(name, fill_type):
+def test_filled_random_no_corner_mask_chunk(name: str, fill_type: FillType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -473,7 +479,7 @@ def test_filled_random_no_corner_mask_chunk(name, fill_type):
 @pytest.mark.threads
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 @pytest.mark.parametrize("thread_count", util_test.thread_counts())
-def test_filled_random_no_corner_mask_chunk_threads(fill_type, thread_count):
+def test_filled_random_no_corner_mask_chunk_threads(fill_type: FillType, thread_count: int) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -509,7 +515,7 @@ def test_filled_random_no_corner_mask_chunk_threads(fill_type, thread_count):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
-def test_filled_random_corner_mask(name):
+def test_filled_random_corner_mask(name: str) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -533,7 +539,7 @@ def test_filled_random_corner_mask(name):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
-def test_filled_random_corner_mask_chunk(name):
+def test_filled_random_corner_mask_chunk(name: str) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -570,7 +576,7 @@ def test_filled_random_corner_mask_chunk(name):
 @pytest.mark.threads
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 @pytest.mark.parametrize("thread_count", util_test.thread_counts())
-def test_filled_random_corner_mask_chunk_threads(fill_type, thread_count):
+def test_filled_random_corner_mask_chunk_threads(fill_type: FillType, thread_count: int) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -600,7 +606,7 @@ def test_filled_random_corner_mask_chunk_threads(fill_type, thread_count):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
-def test_filled_random_quad_as_tri(name):
+def test_filled_random_quad_as_tri(name: str) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -623,7 +629,11 @@ def test_filled_random_quad_as_tri(name):
 
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 @pytest.mark.parametrize("name", ["serial", "threaded"])
-def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
+def test_return_by_fill_type(
+    two_outers_one_hole: tuple[cpy.CoordinateArray, ...],
+    name: str,
+    fill_type: FillType,
+) -> None:
     x, y, z = two_outers_one_hole
     cont_gen = contour_generator(x, y, z, name=name, fill_type=fill_type)
 
@@ -634,50 +644,96 @@ def test_return_by_fill_type(two_outers_one_hole, name, fill_type):
 
     util_test.assert_filled(filled, fill_type)
 
-    if fill_type in (FillType.OuterCode, FillType.OuterOffset):
-        points = filled[0]
-        assert len(points) == 2
+    # Helper functions to avoid code duplication for the different FillTypes.
+    def assert_outer_points(points: list[cpy.PointArray]) -> None:
+        assert isinstance(points, list) and len(points) == 2
         assert points[0].shape == (13, 2)
         assert points[1].shape == (4, 2)
         assert_array_equal(points[0][0], points[0][7])
         assert_array_equal(points[0][8], points[0][12])
         assert_array_equal(points[1][0], points[1][3])
-        if fill_type == FillType.OuterCode:
-            codes = filled[1]
-            assert_array_equal(codes[0], [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79])
-            assert_array_equal(codes[1], [1, 2, 2, 79])
-        else:
-            offsets = filled[1]
-            assert_array_equal(offsets[0], [0, 8, 13])
-            assert_array_equal(offsets[1], [0, 4])
-    else:
-        points = filled[0]
-        assert len(points) == 1
-        points = points[0]
+
+    def assert_chunk_points(points_or_none: list[cpy.PointArray | None]) -> None:
+        assert isinstance(points_or_none, list) and len(points_or_none) == 1
+        assert points_or_none[0] is not None
+        points = points_or_none[0]
         assert points.shape == (17, 2)
         assert_array_equal(points[0], points[7])
         assert_array_equal(points[8], points[12])
         assert_array_equal(points[13], points[16])
-        if fill_type in (FillType.ChunkCombinedCode, FillType.ChunkCombinedCodeOffset):
-            codes = filled[1][0]
-            assert_array_equal(codes, [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79, 1, 2, 2, 79])
-        else:
-            offsets = filled[1][0]
-            assert_array_equal(offsets, [0, 8, 13, 17])
 
-        if fill_type == FillType.ChunkCombinedCodeOffset:
-            outer_offsets = filled[2][0]
-            assert_array_equal(outer_offsets, [0, 13, 17])
-        elif fill_type == FillType.ChunkCombinedOffsetOffset:
-            outer_offsets = filled[2][0]
-            assert_array_equal(outer_offsets, [0, 2, 3])
+    def assert_chunk_codes(codes_or_none: list[cpy.CodeArray | None]) -> None:
+        assert isinstance(codes_or_none, list) and len(codes_or_none) == 1
+        assert codes_or_none[0] is not None
+        codes = codes_or_none[0]
+        assert_array_equal(codes, [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79, 1, 2, 2, 79])
+
+    def assert_chunk_offsets(offsets_or_none: list[cpy.OffsetArray | None]) -> None:
+        assert isinstance(offsets_or_none, list) and len(offsets_or_none) == 1
+        assert offsets_or_none[0] is not None
+        offsets = offsets_or_none[0]
+        assert_array_equal(offsets, [0, 8, 13, 17])
+
+    if fill_type == FillType.OuterCode:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_OuterCode, filled)
+        assert_outer_points(filled[0])
+        codes = filled[1]
+        assert isinstance(codes, list) and len(codes) == 2
+        assert_array_equal(codes[0], [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79])
+        assert_array_equal(codes[1], [1, 2, 2, 79])
+    elif fill_type == FillType.OuterOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_OuterOffset, filled)
+        assert_outer_points(filled[0])
+        offsets = filled[1]
+        assert isinstance(offsets, list) and len(offsets) == 2
+        assert_array_equal(offsets[0], [0, 8, 13])
+        assert_array_equal(offsets[1], [0, 4])
+    elif fill_type == FillType.ChunkCombinedCode:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedCode, filled)
+        assert_chunk_points(filled[0])
+        assert_chunk_codes(filled[1])
+    elif fill_type == FillType.ChunkCombinedOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedOffset, filled)
+        assert_chunk_points(filled[0])
+        assert_chunk_offsets(filled[1])
+    elif fill_type == FillType.ChunkCombinedCodeOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedCodeOffset, filled)
+        assert_chunk_points(filled[0])
+        assert_chunk_codes(filled[1])
+
+        outer_offsets_or_none = filled[2]
+        assert isinstance(outer_offsets_or_none, list) and len(outer_offsets_or_none) == 1
+        assert outer_offsets_or_none[0] is not None
+        assert_array_equal(outer_offsets_or_none[0], [0, 13, 17])
+    elif fill_type == FillType.ChunkCombinedOffsetOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedOffsetOffset, filled)
+        assert_chunk_points(filled[0])
+        assert_chunk_offsets(filled[1])
+
+        outer_offsets_or_none = filled[2]
+        assert isinstance(outer_offsets_or_none, list) and len(outer_offsets_or_none) == 1
+        assert outer_offsets_or_none[0] is not None
+        assert_array_equal(outer_offsets_or_none[0], [0, 2, 3])
+    else:
+        raise RuntimeError(f"Unexpected fill_type {fill_type}")
 
 
 @pytest.mark.threads
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 @pytest.mark.parametrize("name, thread_count",
                          [("serial", 1), ("threaded", 1), ("threaded", 2)])
-def test_return_by_fill_type_chunk(xyz_chunk_test, name, thread_count, fill_type):
+def test_return_by_fill_type_chunk(
+    xyz_chunk_test: tuple[cpy.CoordinateArray, ...],
+    name: str,
+    thread_count: int,
+    fill_type: FillType,
+) -> None:
     x, y, z = xyz_chunk_test
     cont_gen = contour_generator(
         x, y, z, name=name, fill_type=fill_type, chunk_count=2, thread_count=thread_count,
@@ -693,20 +749,20 @@ def test_return_by_fill_type_chunk(xyz_chunk_test, name, thread_count, fill_type
     util_test.assert_filled(filled, fill_type)
 
     # Expected points by chunk.
-    expected = (
-        [[0.0, 0.7], [0.0, 0.5], [1.0, 0.7], [2.0, 0.9], [2.0, 1.0], [2.0, 1.1], [1.5, 1.0],
-         [1.0, 0.9], [0.0, 0.7]],
-        [[2.0, 1.0], [2.0, 0.9], [2.5, 1.0], [3.0, 1.1], [4.0, 1.3], [4.0, 1.5], [3.0, 1.3],
-         [2.0, 1.1], [2.0, 1.0]],
-        [[1.5, 3.0], [2.0, 2.9], [2.0, 3.0], [2.0, 3.1], [1.0, 3.3], [0.0, 3.5], [0.0, 3.3],
-         [1.0, 3.1], [1.5, 3.0]],
-        [[2.0, 3.0], [2.0, 2.9], [3.0, 2.7], [4.0, 2.5], [4.0, 2.7], [3.0, 2.9], [2.5, 3.0],
-         [2.0, 3.1], [2.0, 3.0]],
-    )
+    expected: list[cpy.PointArray] = [
+        np.asarray([[0.0, 0.7], [0.0, 0.5], [1.0, 0.7], [2.0, 0.9], [2.0, 1.0], [2.0, 1.1],
+                    [1.5, 1.0], [1.0, 0.9], [0.0, 0.7]]),
+        np.asarray([[2.0, 1.0], [2.0, 0.9], [2.5, 1.0], [3.0, 1.1], [4.0, 1.3], [4.0, 1.5],
+                    [3.0, 1.3], [2.0, 1.1], [2.0, 1.0]]),
+        np.asarray([[1.5, 3.0], [2.0, 2.9], [2.0, 3.0], [2.0, 3.1], [1.0, 3.3], [0.0, 3.5],
+                    [0.0, 3.3], [1.0, 3.1], [1.5, 3.0]]),
+        np.asarray([[2.0, 3.0], [2.0, 2.9], [3.0, 2.7], [4.0, 2.5], [4.0, 2.7], [3.0, 2.9],
+                    [2.5, 3.0], [2.0, 3.1], [2.0, 3.0]]),
+    ]
 
-    if fill_type in (FillType.OuterCode, FillType.OuterOffset):
-        points = filled[0]
-        assert len(points) == 4
+    # Helper functions to avoid code duplication for the different FillTypes.
+    def assert_outer_points(points: list[cpy.PointArray], expected: list[cpy.PointArray]) -> None:
+        assert isinstance(points, list) and len(points) == 4
         if name == "threaded" and cont_gen.thread_count > 1:
             # Polygons may be in any order so sort lines and expected.
             points = util_test.sort_by_first_xy(points)
@@ -714,47 +770,94 @@ def test_return_by_fill_type_chunk(xyz_chunk_test, name, thread_count, fill_type
         for chunk in range(4):
             assert_allclose(points[chunk], expected[chunk])
 
-        if fill_type == FillType.OuterCode:
-            codes = filled[1]
-            for chunk in range(4):
-                assert_array_equal(codes[chunk], [1, 2, 2, 2, 2, 2, 2, 2, 79])
-        else:
-            offsets = filled[1]
-            for chunk in range(4):
-                assert_array_equal(offsets[chunk], [0, 9])
-    else:
-        points = filled[0]
-        assert len(points) == 4
+    def assert_chunk_points(
+        points_or_none: list[cpy.PointArray | None], expected: list[cpy.PointArray],
+    ) -> None:
+        assert isinstance(points_or_none, list) and len(points_or_none) == 4
         for chunk in range(4):
-            assert_allclose(points[chunk], expected[chunk])
+            chunk_points = points_or_none[chunk]
+            assert chunk_points is not None
+            assert_allclose(chunk_points, expected[chunk])
 
-        if fill_type in (FillType.ChunkCombinedCode, FillType.ChunkCombinedCodeOffset):
-            codes = filled[1]
-            for chunk in range(4):
-                assert_array_equal(codes[chunk], [1, 2, 2, 2, 2, 2, 2, 2, 79])
-        else:
-            offsets = filled[1]
-            for chunk in range(4):
-                assert_array_equal(offsets[chunk], [0, 9])
+    def assert_chunk_codes(codes_or_none: list[cpy.CodeArray | None]) -> None:
+        assert isinstance(codes_or_none, list) and len(codes_or_none) == 4
+        for chunk in range(4):
+            chunk_codes = codes_or_none[chunk]
+            assert chunk_codes is not None
+            assert_array_equal(chunk_codes, [1, 2, 2, 2, 2, 2, 2, 2, 79])
 
-        if fill_type == FillType.ChunkCombinedCodeOffset:
-            outer_offsets = filled[2]
-            for chunk in range(4):
-                assert_array_equal(outer_offsets[chunk], [0, 9])
-        elif fill_type == FillType.ChunkCombinedOffsetOffset:
-            outer_offsets = filled[2]
-            for chunk in range(4):
-                assert_array_equal(outer_offsets[chunk], [0, 1])
+    def assert_chunk_offsets(offsets_or_none: list[cpy.OffsetArray | None]) -> None:
+        assert isinstance(offsets_or_none, list) and len(offsets_or_none) == 4
+        for chunk in range(4):
+            chunk_offsets = offsets_or_none[chunk]
+            assert chunk_offsets is not None
+            assert_array_equal(chunk_offsets, [0, 9])
+
+    if fill_type == FillType.OuterCode:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_OuterCode, filled)
+        assert_outer_points(filled[0], expected)
+        codes = filled[1]
+        assert isinstance(codes, list) and len(codes) == 4
+        for chunk in range(4):
+            assert_array_equal(codes[chunk], [1, 2, 2, 2, 2, 2, 2, 2, 79])
+    elif fill_type == FillType.OuterOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_OuterOffset, filled)
+        assert_outer_points(filled[0], expected)
+        offsets = filled[1]
+        assert isinstance(offsets, list) and len(offsets) == 4
+        for chunk in range(4):
+            assert_array_equal(offsets[chunk], [0, 9])
+    elif fill_type == FillType.ChunkCombinedCode:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedCode, filled)
+        assert_chunk_points(filled[0], expected)
+        assert_chunk_codes(filled[1])
+    elif fill_type == FillType.ChunkCombinedOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedOffset, filled)
+        assert_chunk_points(filled[0], expected)
+        assert_chunk_offsets(filled[1])
+    elif fill_type == FillType.ChunkCombinedCodeOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedCodeOffset, filled)
+        assert_chunk_points(filled[0], expected)
+        assert_chunk_codes(filled[1])
+
+        outer_offsets_or_none = filled[2]
+        assert isinstance(outer_offsets_or_none, list) and len(outer_offsets_or_none) == 4
+        for chunk in range(4):
+            chunk_outer_offsets = outer_offsets_or_none[chunk]
+            assert chunk_outer_offsets is not None
+            assert_array_equal(chunk_outer_offsets, [0, 9])
+    elif fill_type == FillType.ChunkCombinedOffsetOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedOffsetOffset, filled)
+        assert_chunk_points(filled[0], expected)
+        assert_chunk_offsets(filled[1])
+
+        outer_offsets_or_none = filled[2]
+        assert isinstance(outer_offsets_or_none, list) and len(outer_offsets_or_none) == 4
+        for chunk in range(4):
+            chunk_outer_offsets = outer_offsets_or_none[chunk]
+            assert chunk_outer_offsets is not None
+            assert_array_equal(chunk_outer_offsets, [0, 1])
+    else:
+        raise RuntimeError(f"Unexpected fill_type {fill_type}")
 
 
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
 @pytest.mark.parametrize("corner_mask", [None, False, True])
-def test_filled_random_big(name, fill_type, corner_mask):
+def test_filled_random_big(name: str, fill_type: FillType, corner_mask: bool | None) -> None:
     if corner_mask and name in ["mpl2005", "mpl2014"]:
         pytest.skip()
 
     x, y, z = random((1000, 1000), mask_fraction=0.0 if corner_mask is None else 0.05)
-    cont_gen = contour_generator(x, y, z, name=name, corner_mask=corner_mask, fill_type=fill_type)
+    cont_gen = contour_generator(
+        x, y, z, name=name, corner_mask=corner_mask if isinstance(corner_mask, bool) else False,
+        fill_type=fill_type,
+    )
     levels = np.arange(0.0, 1.01, 0.1)
 
     assert cont_gen.fill_type == fill_type
@@ -766,7 +869,7 @@ def test_filled_random_big(name, fill_type, corner_mask):
 
 @pytest.mark.slow
 @pytest.mark.parametrize('seed', np.arange(10))
-def test_filled_compare_slow(seed):
+def test_filled_compare_slow(seed: int) -> None:
     x, y, z = random((1000, 1000), mask_fraction=0.05, seed=seed)
     levels = np.arange(0.0, 1.01, 0.1)
 
@@ -784,21 +887,30 @@ def test_filled_compare_slow(seed):
         filled_serial = cont_gen_serial.filled(levels[i], levels[i+1])
         util_test.assert_filled(filled_serial, cont_gen_serial.fill_type)
 
+        if TYPE_CHECKING:
+            filled_mpl2014 = cast(cpy.FillReturn_OuterCode, filled_mpl2014)
+            filled_serial = cast(cpy.FillReturn_ChunkCombinedOffsetOffset, filled_serial)
+
         # Check same results obtained for each in terms of number of points, etc.
         code_list = filled_mpl2014[1]
         n_points = reduce(add, map(len, code_list))
         n_outers = len(code_list)
         n_lines = reduce(add, map(lambda c: np.count_nonzero(c == 1), code_list))
 
+        assert filled_serial[0][0] is not None
         assert n_points == len(filled_serial[0][0])
+
+        assert filled_serial[1][0] is not None
         assert n_lines == len(filled_serial[1][0]) - 1
+
+        assert filled_serial[2][0] is not None
         assert n_outers == len(filled_serial[2][0]) - 1
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
 @pytest.mark.parametrize("z", [np.nan, -np.nan, np.inf, -np.inf])
 @pytest.mark.parametrize("zlevel", [0.0, np.nan, -np.nan, np.inf, -np.inf])
-def test_filled_z_nonfinite(name, z, zlevel):
+def test_filled_z_nonfinite(name: str, z: float, zlevel: float) -> None:
     cont_gen = contour_generator(z=[[z, z], [z, z]], name=name, fill_type=FillType.OuterCode)
     filled = cont_gen.filled(zlevel, zlevel)
     assert filled == ([], [])

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
@@ -7,19 +11,24 @@ from contourpy.util.data import random, simple
 
 from . import util_test
 
-
-@pytest.fixture
-def xy_2x2():
-    return np.meshgrid([0.0, 1.0], [0.0, 1.0])
+if TYPE_CHECKING:
+    import contourpy._contourpy as cpy
 
 
 @pytest.fixture
-def xy_3x3():
-    return np.meshgrid([0.0, 0.5, 1.0], [0.0, 0.5, 1.0])
+def xy_2x2() -> tuple[cpy.CoordinateArray, ...]:
+    x, y = np.meshgrid([0.0, 1.0], [0.0, 1.0])
+    return x, y
 
 
 @pytest.fixture
-def one_loop_one_strip():
+def xy_3x3() -> tuple[cpy.CoordinateArray, ...]:
+    x, y = np.meshgrid([0.0, 0.5, 1.0], [0.0, 0.5, 1.0])
+    return x, y
+
+
+@pytest.fixture
+def one_loop_one_strip() -> tuple[cpy.PointArray, ...]:
     x, y = np.meshgrid([0., 1., 2., 3.], [0., 1., 2.])
     z = np.array([[1.5, 1.5, 0.9, 0.0],
                   [1.5, 2.8, 0.4, 0.8],
@@ -28,7 +37,7 @@ def one_loop_one_strip():
 
 
 @pytest.fixture
-def xyz_chunk_test():
+def xyz_chunk_test() -> tuple[cpy.CoordinateArray, ...]:
     x, y = np.meshgrid(np.arange(5), np.arange(5))
     z = 0.5*np.abs(y - 2) + 0.1*(x - 2)
     return x, y, z
@@ -36,11 +45,13 @@ def xyz_chunk_test():
 
 @pytest.mark.parametrize("name", util_test.all_names())
 @pytest.mark.parametrize("zlevel", [-1e-10, 1.0+1e10, np.nan, -np.nan, np.inf, -np.inf])
-def test_level_outside(xy_2x2, name, zlevel):
+def test_level_outside(xy_2x2: tuple[cpy.CoordinateArray, ...], name: str, zlevel: float) -> None:
     x, y = xy_2x2
     z = x
     cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCode)
     lines = cont_gen.lines(zlevel)
+    if TYPE_CHECKING:
+        lines = cast(cpy.LineReturn_SeparateCode, lines)
     assert isinstance(lines, tuple) and len(lines) == 2
     points, codes = lines
     assert isinstance(points, list) and len(points) == 0
@@ -48,11 +59,13 @@ def test_level_outside(xy_2x2, name, zlevel):
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_w_to_e(xy_2x2, name):
+def test_w_to_e(xy_2x2: tuple[cpy.CoordinateArray, ...], name: str) -> None:
     x, y = xy_2x2
     z = y.copy()
     cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCode)
     lines = cont_gen.lines(0.5)
+    if TYPE_CHECKING:
+        lines = cast(cpy.LineReturn_SeparateCode, lines)
     assert isinstance(lines, tuple) and len(lines) == 2
     points, codes = lines
     assert isinstance(points, list) and len(points) == 1
@@ -62,11 +75,13 @@ def test_w_to_e(xy_2x2, name):
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_e_to_w(xy_2x2, name):
+def test_e_to_w(xy_2x2: tuple[cpy.CoordinateArray, ...], name: str) -> None:
     x, y = xy_2x2
     z = 1.0 - y.copy()
     cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCode)
     lines = cont_gen.lines(0.5)
+    if TYPE_CHECKING:
+        lines = cast(cpy.LineReturn_SeparateCode, lines)
     assert isinstance(lines, tuple) and len(lines) == 2
     points, codes = lines
     assert isinstance(points, list) and len(points) == 1
@@ -79,12 +94,14 @@ def test_e_to_w(xy_2x2, name):
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
-def test_loop(xy_3x3, name):
+def test_loop(xy_3x3: tuple[cpy.CoordinateArray, ...], name: str) -> None:
     x, y = xy_3x3
     z = np.zeros_like(x)
     z[1, 1] = 1.0
     cont_gen = contour_generator(x, y, z, name=name, line_type=LineType.SeparateCode)
     lines = cont_gen.lines(0.5)
+    if TYPE_CHECKING:
+        lines = cast(cpy.LineReturn_SeparateCode, lines)
     assert isinstance(lines, tuple) and len(lines) == 2
     points, codes = lines
     assert isinstance(points, list) and len(points) == 1
@@ -97,7 +114,7 @@ def test_loop(xy_3x3, name):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
-def test_lines_simple(name, line_type):
+def test_lines_simple(name: str, line_type: LineType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -120,7 +137,7 @@ def test_lines_simple(name, line_type):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
-def test_lines_simple_chunk(name, line_type):
+def test_lines_simple_chunk(name: str, line_type: LineType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -147,7 +164,7 @@ def test_lines_simple_chunk(name, line_type):
 @pytest.mark.threads
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 @pytest.mark.parametrize("thread_count", util_test.thread_counts())
-def test_lines_simple_chunk_threads(line_type, thread_count):
+def test_lines_simple_chunk_threads(line_type: LineType, thread_count: int) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -172,7 +189,7 @@ def test_lines_simple_chunk_threads(line_type, thread_count):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
-def test_lines_simple_no_corner_mask(name, line_type):
+def test_lines_simple_no_corner_mask(name: str, line_type: LineType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -195,7 +212,7 @@ def test_lines_simple_no_corner_mask(name, line_type):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
-def test_lines_simple_no_corner_mask_chunk(name, line_type):
+def test_lines_simple_no_corner_mask_chunk(name: str, line_type: LineType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -222,7 +239,7 @@ def test_lines_simple_no_corner_mask_chunk(name, line_type):
 @pytest.mark.threads
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 @pytest.mark.parametrize("thread_count", util_test.thread_counts())
-def test_lines_simple_no_corner_mask_chunk_threads(line_type, thread_count):
+def test_lines_simple_no_corner_mask_chunk_threads(line_type: LineType, thread_count: int) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -250,7 +267,7 @@ def test_lines_simple_no_corner_mask_chunk_threads(line_type, thread_count):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
-def test_lines_simple_corner_mask(name):
+def test_lines_simple_corner_mask(name: str) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -274,7 +291,7 @@ def test_lines_simple_corner_mask(name):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
-def test_lines_simple_corner_mask_chunk(name):
+def test_lines_simple_corner_mask_chunk(name: str) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -302,7 +319,7 @@ def test_lines_simple_corner_mask_chunk(name):
 @pytest.mark.threads
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 @pytest.mark.parametrize("thread_count", util_test.thread_counts())
-def test_lines_simple_corner_mask_chunk_threads(line_type, thread_count):
+def test_lines_simple_corner_mask_chunk_threads(line_type: LineType, thread_count: int) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -330,7 +347,7 @@ def test_lines_simple_corner_mask_chunk_threads(line_type, thread_count):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
-def test_lines_simple_quad_as_tri(name):
+def test_lines_simple_quad_as_tri(name: str) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -354,7 +371,7 @@ def test_lines_simple_quad_as_tri(name):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
-def test_lines_random(name, line_type):
+def test_lines_random(name: str, line_type: LineType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -377,7 +394,7 @@ def test_lines_random(name, line_type):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
-def test_lines_random_chunk(name, line_type):
+def test_lines_random_chunk(name: str, line_type: LineType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -413,7 +430,7 @@ def test_lines_random_chunk(name, line_type):
 @pytest.mark.threads
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 @pytest.mark.parametrize("thread_count", util_test.thread_counts())
-def test_lines_random_chunk_threads(line_type, thread_count):
+def test_lines_random_chunk_threads(line_type: LineType, thread_count: int) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -440,7 +457,7 @@ def test_lines_random_chunk_threads(line_type, thread_count):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
-def test_lines_random_no_corner_mask(name, line_type):
+def test_lines_random_no_corner_mask(name: str, line_type: LineType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -463,7 +480,7 @@ def test_lines_random_no_corner_mask(name, line_type):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
-def test_lines_random_no_corner_mask_chunk(name, line_type):
+def test_lines_random_no_corner_mask_chunk(name: str, line_type: LineType) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -493,7 +510,7 @@ def test_lines_random_no_corner_mask_chunk(name, line_type):
 @pytest.mark.threads
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 @pytest.mark.parametrize("thread_count", util_test.thread_counts())
-def test_lines_random_no_corner_mask_chunk_threads(line_type, thread_count):
+def test_lines_random_no_corner_mask_chunk_threads(line_type: LineType, thread_count: int) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -521,7 +538,7 @@ def test_lines_random_no_corner_mask_chunk_threads(line_type, thread_count):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
-def test_lines_random_corner_mask(name):
+def test_lines_random_corner_mask(name: str) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -545,7 +562,7 @@ def test_lines_random_corner_mask(name):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name", util_test.corner_mask_names())
-def test_lines_random_corner_mask_chunk(name):
+def test_lines_random_corner_mask_chunk(name: str) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -573,7 +590,7 @@ def test_lines_random_corner_mask_chunk(name):
 @pytest.mark.threads
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 @pytest.mark.parametrize("thread_count", util_test.thread_counts())
-def test_lines_random_corner_mask_chunk_threads(line_type, thread_count):
+def test_lines_random_corner_mask_chunk_threads(line_type: LineType, thread_count: int) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -601,7 +618,7 @@ def test_lines_random_corner_mask_chunk_threads(line_type, thread_count):
 
 @pytest.mark.image
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
-def test_lines_random_quad_as_tri(name):
+def test_lines_random_quad_as_tri(name: str) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -625,7 +642,11 @@ def test_lines_random_quad_as_tri(name):
 
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 @pytest.mark.parametrize("name", ["serial", "threaded"])
-def test_return_by_line_type(one_loop_one_strip, name, line_type):
+def test_return_by_line_type(
+    one_loop_one_strip: tuple[cpy.PointArray, ...],
+    name: str,
+    line_type: LineType,
+) -> None:
     x, y, z = one_loop_one_strip
     cont_gen = contour_generator(x, y, z, name=name, line_type=line_type)
 
@@ -638,11 +659,15 @@ def test_return_by_line_type(one_loop_one_strip, name, line_type):
     util_test.assert_lines(lines, line_type)
 
     if line_type == LineType.Separate:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_Separate, lines)
         points = lines
         assert len(points) == 2
         assert points[0].shape == (5, 2)
         assert points[1].shape == (2, 2)
     elif line_type == LineType.SeparateCode:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_SeparateCode, lines)
         points, codes = lines
         assert len(points) == 2
         assert points[0].shape == (5, 2)
@@ -650,22 +675,37 @@ def test_return_by_line_type(one_loop_one_strip, name, line_type):
         assert_array_equal(codes[0], [1, 2, 2, 2, 79])
         assert_array_equal(codes[1], [1, 2])
     elif line_type == LineType.ChunkCombinedCode:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_ChunkCombinedCode, lines)
         assert len(lines[0]) == 1  # Single chunk.
-        points, codes = lines[0][0], lines[1][0]
-        assert points.shape == (7, 2)
-        assert_array_equal(codes, [1, 2, 2, 2, 79, 1, 2])
+        points_or_none, codes_or_none = lines[0][0], lines[1][0]
+        assert points_or_none is not None
+        assert codes_or_none is not None
+        assert points_or_none.shape == (7, 2)
+        assert_array_equal(codes_or_none, [1, 2, 2, 2, 79, 1, 2])
     elif line_type == LineType.ChunkCombinedOffset:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_ChunkCombinedOffset, lines)
         assert len(lines[0]) == 1  # Single chunk.
-        points, offsets = lines[0][0], lines[1][0]
-        assert points.shape == (7, 2)
-        assert_array_equal(offsets, [0, 5, 7])
+        points_or_none, offsets_or_none = lines[0][0], lines[1][0]
+        assert points_or_none is not None
+        assert offsets_or_none is not None
+        assert points_or_none.shape == (7, 2)
+        assert_array_equal(offsets_or_none, [0, 5, 7])
+    else:
+        raise RuntimeError(f"Unexpected line_type {line_type}")
 
 
 @pytest.mark.threads
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 @pytest.mark.parametrize("name, thread_count",
                          [("serial", 1), ("threaded", 1), ("threaded", 2)])
-def test_return_by_line_type_chunk(xyz_chunk_test, name, thread_count, line_type):
+def test_return_by_line_type_chunk(
+    xyz_chunk_test: tuple[cpy.CoordinateArray, ...],
+    name: str,
+    thread_count: int,
+    line_type: LineType,
+) -> None:
     x, y, z = xyz_chunk_test
     cont_gen = contour_generator(
         x, y, z, name=name, line_type=line_type, chunk_count=2, thread_count=thread_count,
@@ -681,14 +721,16 @@ def test_return_by_line_type_chunk(xyz_chunk_test, name, thread_count, line_type
     util_test.assert_lines(lines, line_type)
 
     # Expected points by chunk.
-    expected = (
-        [[2.0, 1.1], [1.5, 1.0], [1.0, 0.9], [0.0, 0.7]],
-        [[4.0, 1.5], [3.0, 1.3], [2.0, 1.1]],
-        [[0.0, 3.3], [1.0, 3.1], [1.5, 3.0], [2.0, 2.9]],
-        [[2.0, 2.9], [3.0, 2.7], [4.0, 2.5]],
-    )
+    expected: list[cpy.PointArray] = [
+        np.asarray([[2.0, 1.1], [1.5, 1.0], [1.0, 0.9], [0.0, 0.7]]),
+        np.asarray([[4.0, 1.5], [3.0, 1.3], [2.0, 1.1]]),
+        np.asarray([[0.0, 3.3], [1.0, 3.1], [1.5, 3.0], [2.0, 2.9]]),
+        np.asarray([[2.0, 2.9], [3.0, 2.7], [4.0, 2.5]]),
+    ]
 
     if line_type == LineType.Separate:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_Separate, lines)
         assert len(lines) == 4
         if name == "threaded" and cont_gen.thread_count > 1:
             # Lines may be in any order so sort lines and expected.
@@ -697,6 +739,8 @@ def test_return_by_line_type_chunk(xyz_chunk_test, name, thread_count, line_type
         for chunk in range(4):
             assert_allclose(lines[chunk], expected[chunk])
     elif line_type == LineType.SeparateCode:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_SeparateCode, lines)
         assert len(lines[0]) == 4
         if name == "threaded" and cont_gen.thread_count > 1:
             # Lines may be in any order so sort lines and expected.
@@ -706,20 +750,32 @@ def test_return_by_line_type_chunk(xyz_chunk_test, name, thread_count, line_type
             assert_allclose(lines[0][chunk], expected[chunk])
             assert_array_equal(lines[1][chunk], [1] + [2]*(len(expected[chunk])-1))
     elif line_type == LineType.ChunkCombinedCode:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_ChunkCombinedCode, lines)
         assert len(lines[0]) == 4
         for chunk in range(4):
-            assert_allclose(lines[0][chunk], expected[chunk])
-            assert_array_equal(lines[1][chunk], [1] + [2]*(len(expected[chunk])-1))
+            points_or_none, codes_or_none = lines[0][chunk], lines[1][chunk]
+            assert points_or_none is not None
+            assert codes_or_none is not None
+            assert_allclose(points_or_none, expected[chunk])
+            assert_array_equal(codes_or_none, [1] + [2]*(len(expected[chunk])-1))
     elif line_type == LineType.ChunkCombinedOffset:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_ChunkCombinedOffset, lines)
         assert len(lines[0]) == 4
         for chunk in range(4):
-            assert_allclose(lines[0][chunk], expected[chunk])
-            assert_array_equal(lines[1][chunk], [0, len(expected[chunk])])
+            points_or_none, offsets_or_none = lines[0][chunk], lines[1][chunk]
+            assert points_or_none is not None
+            assert offsets_or_none is not None
+            assert_allclose(points_or_none, expected[chunk])
+            assert_array_equal(offsets_or_none, [0, len(expected[chunk])])
+    else:
+        raise RuntimeError(f"Unexpected line_type {line_type}")
 
 
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
 @pytest.mark.parametrize("corner_mask", [None, False, True])
-def test_lines_random_big(name, line_type, corner_mask):
+def test_lines_random_big(name: str, line_type: LineType, corner_mask: bool) -> None:
     if corner_mask and name in ["mpl2005", "mpl2014"]:
         pytest.skip()
 
@@ -739,7 +795,7 @@ def test_lines_random_big(name, line_type, corner_mask):
 @pytest.mark.parametrize("name", util_test.all_names())
 @pytest.mark.parametrize("z", [np.nan, -np.nan, np.inf, -np.inf])
 @pytest.mark.parametrize("zlevel", [0.0, np.nan, -np.nan, np.inf, -np.inf])
-def test_lines_z_nonfinite(name, z, zlevel):
+def test_lines_z_nonfinite(name: str, z: float, zlevel: float) -> None:
     cont_gen = contour_generator(z=[[z, z], [z, z]], name=name, line_type=LineType.SeparateCode)
     lines = cont_gen.lines(zlevel)
     assert lines == ([], [])

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,15 +1,17 @@
+from __future__ import annotations
+
 import numpy as np
 
 from contourpy import _remove_z_mask, max_threads
 
 
-def test_max_threads():
+def test_max_threads() -> None:
     n = max_threads()
     # Assume testing on machine with 2 or more cores.
     assert n > 1
 
 
-def test_remove_z_mask():
+def test_remove_z_mask() -> None:
     zlist = [[1.0, 2.0], [3.0, 4.0]]
 
     zz, mask = _remove_z_mask(zlist)
@@ -21,12 +23,12 @@ def test_remove_z_mask():
     assert isinstance(zz, np.ndarray)
     assert mask is None
 
-    z = np.ma.array(zlist, mask=[[0, 0], [0, 0]])
+    z = np.ma.array(zlist, mask=[[0, 0], [0, 0]])  # type: ignore[no-untyped-call]
     zz, mask = _remove_z_mask(zarr)
     assert isinstance(zz, np.ndarray)
     assert mask is None
 
-    z = np.ma.array(zlist, mask=[[1, 0], [0, 0]])
+    z = np.ma.array(zlist, mask=[[1, 0], [0, 0]])  # type: ignore[no-untyped-call]
     zz, mask = _remove_z_mask(z)
     assert isinstance(zz, np.ndarray)
     assert isinstance(mask, np.ndarray)
@@ -40,7 +42,7 @@ def test_remove_z_mask():
     assert mask.dtype == bool
     np.testing.assert_array_equal(mask, [[False, True], [False, True]])
 
-    z = np.ma.array(zlist, mask=[[1, 0], [0, 0]])
+    z = np.ma.array(zlist, mask=[[1, 0], [0, 0]])  # type: ignore[no-untyped-call]
     z[1][1] = np.nan
     zz, mask = _remove_z_mask(z)
     assert isinstance(zz, np.ndarray)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 
@@ -10,14 +12,14 @@ from contourpy.util.data import random
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 @pytest.mark.parametrize("renderer_type", ["mpl", "bokeh"])
-def test_renderer_filled(show_text, fill_type, renderer_type):
-    if renderer_type == "mpl":
-        from contourpy.util.mpl_renderer import MplRenderer as Renderer
-    elif renderer_type == "bokeh":
+def test_renderer_filled(show_text: bool, fill_type: FillType, renderer_type: str) -> None:
+    if renderer_type == "bokeh":
         try:
             from contourpy.util.bokeh_renderer import BokehRenderer as Renderer
         except ImportError:
             pytest.skip("Optional bokeh dependencies not installed")
+    elif renderer_type == "mpl":
+        from contourpy.util.mpl_renderer import MplRenderer as Renderer  # type: ignore[no-redef]
     else:
         raise ValueError(f"Unrecognised renderer type {renderer_type}")
 
@@ -58,14 +60,14 @@ def test_renderer_filled(show_text, fill_type, renderer_type):
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 @pytest.mark.parametrize("renderer_type", ["mpl", "bokeh"])
-def test_renderer_lines(show_text, line_type, renderer_type):
-    if renderer_type == "mpl":
-        from contourpy.util.mpl_renderer import MplRenderer as Renderer
-    elif renderer_type == "bokeh":
+def test_renderer_lines(show_text: bool, line_type: LineType, renderer_type: str) -> None:
+    if renderer_type == "bokeh":
         try:
             from contourpy.util.bokeh_renderer import BokehRenderer as Renderer
         except ImportError:
             pytest.skip("Optional bokeh dependencies not installed")
+    elif renderer_type == "mpl":
+        from contourpy.util.mpl_renderer import MplRenderer as Renderer  # type: ignore[no-redef]
     else:
         raise ValueError(f"Unrecognised renderer type {renderer_type}")
 

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
+from typing import Type
+
 import pytest
 
 from contourpy import (
-    FillType, LineType, Mpl2005ContourGenerator, Mpl2014ContourGenerator, SerialContourGenerator,
-    ThreadedContourGenerator,
+    ContourGenerator, FillType, LineType, Mpl2005ContourGenerator, Mpl2014ContourGenerator,
+    SerialContourGenerator, ThreadedContourGenerator,
 )
 
 from . import util_test
 
-_lookup = {
+_lookup: dict[str, Type[ContourGenerator]] = {
     "Mpl2005ContourGenerator": Mpl2005ContourGenerator,
     "Mpl2014ContourGenerator": Mpl2014ContourGenerator,
     "SerialContourGenerator": SerialContourGenerator,
@@ -15,12 +19,12 @@ _lookup = {
 }
 
 
-def get_class_from_name(class_name):
+def get_class_from_name(class_name: str) -> Type[ContourGenerator]:
     return _lookup[class_name]
 
 
 @pytest.mark.parametrize("class_name", util_test.all_class_names())
-def test_default_fill_type(class_name):
+def test_default_fill_type(class_name: str) -> None:
     cls = get_class_from_name(class_name)
     default = cls.default_fill_type
     assert isinstance(default, FillType)
@@ -32,7 +36,7 @@ def test_default_fill_type(class_name):
 
 
 @pytest.mark.parametrize("class_name", util_test.all_class_names())
-def test_default_line_type(class_name):
+def test_default_line_type(class_name: str) -> None:
     cls = get_class_from_name(class_name)
     default = cls.default_line_type
     assert isinstance(default, LineType)
@@ -44,7 +48,7 @@ def test_default_line_type(class_name):
 
 
 @pytest.mark.parametrize("class_name", util_test.all_class_names())
-def test_has_lines_and_filled(class_name):
+def test_has_lines_and_filled(class_name: str) -> None:
     cls = get_class_from_name(class_name)
     for func_name in ["create_contour", "create_filled_contour", "filled", "lines"]:
         assert hasattr(cls, func_name)
@@ -52,7 +56,7 @@ def test_has_lines_and_filled(class_name):
 
 
 @pytest.mark.parametrize("class_name", util_test.all_class_names())
-def test_supports_corner_mask(class_name):
+def test_supports_corner_mask(class_name: str) -> None:
     cls = get_class_from_name(class_name)
     supports = cls.supports_corner_mask()
     assert isinstance(supports, bool)
@@ -61,7 +65,7 @@ def test_supports_corner_mask(class_name):
 
 
 @pytest.mark.parametrize("class_name", util_test.all_class_names())
-def test_supports_fill_type(class_name):
+def test_supports_fill_type(class_name: str) -> None:
     cls = get_class_from_name(class_name)
     supports = cls.supports_fill_type(FillType.OuterCode)
     assert isinstance(supports, bool)
@@ -74,7 +78,7 @@ def test_supports_fill_type(class_name):
 
 
 @pytest.mark.parametrize("class_name", util_test.all_class_names())
-def test_supports_line_type(class_name):
+def test_supports_line_type(class_name: str) -> None:
     cls = get_class_from_name(class_name)
     supports = cls.supports_line_type(LineType.SeparateCode)
     assert isinstance(supports, bool)
@@ -87,7 +91,7 @@ def test_supports_line_type(class_name):
 
 
 @pytest.mark.parametrize("class_name", util_test.all_class_names())
-def test_supports_quad_as_tri(class_name):
+def test_supports_quad_as_tri(class_name: str) -> None:
     cls = get_class_from_name(class_name)
     supports = cls.supports_quad_as_tri()
     assert isinstance(supports, bool)
@@ -96,7 +100,7 @@ def test_supports_quad_as_tri(class_name):
 
 
 @pytest.mark.parametrize("class_name", util_test.all_class_names())
-def test_supports_threads(class_name):
+def test_supports_threads(class_name: str) -> None:
     cls = get_class_from_name(class_name)
     supports = cls.supports_threads()
     assert isinstance(supports, bool)
@@ -105,7 +109,7 @@ def test_supports_threads(class_name):
 
 
 @pytest.mark.parametrize("class_name", util_test.all_class_names())
-def test_supports_z_interp(class_name):
+def test_supports_z_interp(class_name: str) -> None:
     cls = get_class_from_name(class_name)
     supports = cls.supports_z_interp()
     assert isinstance(supports, bool)


### PR DESCRIPTION
This PR adds type annotations for the `tests` directory, following on from #199.

There are some improvements to `util_config.py` to make better use of inheritance, improving the code quality and making the typing easier.  There also improvements to the code that checks that the data returned from `lines()` and `filled()` in `util_test.py`, `test_filled.py` and `test_lines.py`.