### PR TITLE
Type annotations for benchmarks directory

### DIFF
--- a/benchmarks/benchmarks/bench_base.py
+++ b/benchmarks/benchmarks/bench_base.py
@@ -1,12 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import numpy as np
 
 from contourpy.util.data import random, simple
 
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
 
 class BenchBase:
-    timeout = 120  # Some rendering benchmarks can take more than the default minute.
+    levels: npt.NDArray[np.float64]
+    timeout: int = 120  # Some rendering benchmarks can take more than the default minute.
+    x: npt.NDArray[np.float64]
+    y: npt.NDArray[np.float64]
+    z: npt.NDArray[np.float64] | np.ma.MaskedArray[Any, Any]
 
-    def set_xyz_and_levels(self, dataset, n, want_mask):
+    def set_xyz_and_levels(self, dataset: str, n: int, want_mask: bool) -> None:
         if dataset == "random":
             mask_fraction = 0.05 if want_mask else 0.0
             self.x, self.y, self.z = random((n, n), mask_fraction=mask_fraction)

--- a/benchmarks/benchmarks/bench_filled_mpl20xx.py
+++ b/benchmarks/benchmarks/bench_filled_mpl20xx.py
@@ -1,23 +1,30 @@
+from __future__ import annotations
+
 from contourpy import FillType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, problem_sizes
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, problem_sizes
 
 
 class BenchFilledMpl20xx(BenchBase):
-    params = (
-        ["mpl2005", "mpl2014"], datasets(), [FillType.OuterCode], corner_masks(), problem_sizes())
-    param_names = ("name", "dataset", "fill_type", "corner_mask", "n")
+    params: tuple[list[str], list[str], list[FillType], list[str | bool], list[int]] = (
+        ["mpl2005", "mpl2014"], datasets(), [FillType.OuterCode], corner_masks(), problem_sizes(),
+    )
+    param_names: tuple[str, ...] = ("name", "dataset", "fill_type", "corner_mask", "n")
 
-    def setup(self, name, dataset, fill_type, corner_mask, n):
+    def setup(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_filled_mpl20xx(self, name, dataset, fill_type, corner_mask, n):
+    def time_filled_mpl20xx(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+    ) -> None:
         if name == "mpl2005" and corner_mask is True:
             raise NotImplementedError  # Does not support corner_mask=True
-        if corner_mask == "no mask":
-            corner_mask = False
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, fill_type=fill_type, corner_mask=corner_mask)
+            self.x, self.y, self.z, name=name, fill_type=fill_type,
+            corner_mask=corner_mask_to_bool(corner_mask),
+        )
         for i in range(len(self.levels)-1):
             cont_gen.filled(self.levels[i], self.levels[i+1])

--- a/benchmarks/benchmarks/bench_filled_mpl20xx_render.py
+++ b/benchmarks/benchmarks/bench_filled_mpl20xx_render.py
@@ -1,25 +1,32 @@
+from __future__ import annotations
+
 from contourpy import FillType, contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, problem_sizes
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, problem_sizes
 
 
 class BenchFilledMpl20xxRender(BenchBase):
-    params = (
-        ["mpl2005", "mpl2014"], datasets(), [FillType.OuterCode], corner_masks(), problem_sizes())
-    param_names = ("name", "dataset", "fill_type", "corner_mask", "n")
+    params: tuple[list[str], list[str], list[FillType], list[str | bool], list[int]] = (
+        ["mpl2005", "mpl2014"], datasets(), [FillType.OuterCode], corner_masks(), problem_sizes(),
+    )
+    param_names: tuple[str, ...] = ("name", "dataset", "fill_type", "corner_mask", "n")
 
-    def setup(self, name, dataset, fill_type, corner_mask, n):
+    def setup(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_filled_mpl20xx_render(self, name, dataset, fill_type, corner_mask, n):
+    def time_filled_mpl20xx_render(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+    ) -> None:
         if name == "mpl2005" and corner_mask is True:
             raise NotImplementedError  # Does not support corner_mask=True
-        if corner_mask == "no mask":
-            corner_mask = False
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, fill_type=fill_type, corner_mask=corner_mask)
+            self.x, self.y, self.z, name=name, fill_type=fill_type,
+            corner_mask=corner_mask_to_bool(corner_mask),
+        )
         renderer = MplTestRenderer()
         for i in range(len(self.levels)-1):
             filled = cont_gen.filled(self.levels[i], self.levels[i+1])

--- a/benchmarks/benchmarks/bench_filled_serial.py
+++ b/benchmarks/benchmarks/bench_filled_serial.py
@@ -1,20 +1,28 @@
-from contourpy import contour_generator
+from __future__ import annotations
+
+from contourpy import FillType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, fill_types, problem_sizes
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, fill_types, problem_sizes
 
 
 class BenchFilledSerial(BenchBase):
-    params = (["serial"], datasets(), fill_types(), corner_masks(), problem_sizes())
-    param_names = ("name", "dataset", "fill_type", "corner_mask", "n")
+    params: tuple[list[str], list[str], list[FillType], list[str | bool], list[int]] = (
+        ["serial"], datasets(), fill_types(), corner_masks(), problem_sizes(),
+    )
+    param_names: tuple[str, ...] = ("name", "dataset", "fill_type", "corner_mask", "n")
 
-    def setup(self, name, dataset, fill_type, corner_mask, n):
+    def setup(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_filled_serial(self, name, dataset, fill_type, corner_mask, n):
-        if corner_mask == "no mask":
-            corner_mask = False
+    def time_filled_serial(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+    ) -> None:
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, fill_type=fill_type, corner_mask=corner_mask)
+            self.x, self.y, self.z, name=name, fill_type=fill_type,
+            corner_mask=corner_mask_to_bool(corner_mask),
+        )
         for i in range(len(self.levels)-1):
             cont_gen.filled(self.levels[i], self.levels[i+1])

--- a/benchmarks/benchmarks/bench_filled_serial_chunk.py
+++ b/benchmarks/benchmarks/bench_filled_serial_chunk.py
@@ -1,22 +1,32 @@
-from contourpy import contour_generator
+from __future__ import annotations
+
+from contourpy import FillType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, fill_types, total_chunk_counts
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, fill_types, total_chunk_counts
 
 
 class BenchFilledSerialChunk(BenchBase):
-    params = (
-        ["serial"], datasets(), fill_types(), corner_masks(), [1000], total_chunk_counts())
-    param_names = ("name", "dataset", "fill_type", "corner_mask", "n", "total_chunk_count")
+    params: tuple[list[str], list[str], list[FillType], list[str | bool], list[int], list[int]] = (
+        ["serial"], datasets(), fill_types(), corner_masks(), [1000], total_chunk_counts(),
+    )
+    param_names: tuple[str, ...] = (
+        "name", "dataset", "fill_type", "corner_mask", "n", "total_chunk_count",
+    )
 
-    def setup(self, name, dataset, fill_type, corner_mask, n, total_chunk_count):
+    def setup(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+        total_chunk_count: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_filled_serial_chunk(self, name, dataset, fill_type, corner_mask, n, total_chunk_count):
-        if corner_mask == "no mask":
-            corner_mask = False
+    def time_filled_serial_chunk(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+        total_chunk_count: int,
+    ) -> None:
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, fill_type=fill_type, corner_mask=corner_mask,
-            total_chunk_count=total_chunk_count)
+            self.x, self.y, self.z, name=name, fill_type=fill_type,
+            corner_mask=corner_mask_to_bool(corner_mask), total_chunk_count=total_chunk_count,
+        )
         for i in range(len(self.levels)-1):
             cont_gen.filled(self.levels[i], self.levels[i+1])

--- a/benchmarks/benchmarks/bench_filled_serial_quad_as_tri.py
+++ b/benchmarks/benchmarks/bench_filled_serial_quad_as_tri.py
@@ -1,21 +1,28 @@
+from __future__ import annotations
+
 from contourpy import FillType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, problem_sizes
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, problem_sizes
 
 
 class BenchFilledSerialQuadAsTri(BenchBase):
-    params = (["serial"], datasets(), [FillType.OuterCode], corner_masks(), problem_sizes())
-    param_names = ("name", "dataset", "fill_type", "corner_mask", "n")
+    params: tuple[list[str], list[str], list[FillType], list[str | bool], list[int]] = (
+        ["serial"], datasets(), [FillType.OuterCode], corner_masks(), problem_sizes(),
+    )
+    param_names: tuple[str, ...] = ("name", "dataset", "fill_type", "corner_mask", "n")
 
-    def setup(self, name, dataset, fill_type, corner_mask, n):
+    def setup(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_filled_serial_quad_as_tri(self, name, dataset, fill_type, corner_mask, n):
-        if corner_mask == "no mask":
-            corner_mask = False
+    def time_filled_serial_quad_as_tri(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+    ) -> None:
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, fill_type=fill_type, corner_mask=corner_mask,
-            quad_as_tri=True)
+            self.x, self.y, self.z, name=name, fill_type=fill_type,
+            corner_mask=corner_mask_to_bool(corner_mask), quad_as_tri=True,
+        )
         for i in range(len(self.levels)-1):
             cont_gen.filled(self.levels[i], self.levels[i+1])

--- a/benchmarks/benchmarks/bench_filled_serial_quad_as_tri_render.py
+++ b/benchmarks/benchmarks/bench_filled_serial_quad_as_tri_render.py
@@ -1,23 +1,30 @@
+from __future__ import annotations
+
 from contourpy import FillType, contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, problem_sizes
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, problem_sizes
 
 
 class BenchFilledSerialQuadAsTriRender(BenchBase):
-    params = (["serial"], datasets(), [FillType.OuterCode], corner_masks(), problem_sizes())
-    param_names = ("name", "dataset", "fill_type", "corner_mask", "n")
+    params: tuple[list[str], list[str], list[FillType], list[str | bool], list[int]] = (
+        ["serial"], datasets(), [FillType.OuterCode], corner_masks(), problem_sizes(),
+    )
+    param_names: tuple[str, ...] = ("name", "dataset", "fill_type", "corner_mask", "n")
 
-    def setup(self, name, dataset, fill_type, corner_mask, n):
+    def setup(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_filled_serial_quad_as_tri_render(self, name, dataset, fill_type, corner_mask, n):
-        if corner_mask == "no mask":
-            corner_mask = False
+    def time_filled_serial_quad_as_tri_render(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+    ) -> None:
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, fill_type=fill_type, corner_mask=corner_mask,
-            quad_as_tri=True)
+            self.x, self.y, self.z, name=name, fill_type=fill_type,
+            corner_mask=corner_mask_to_bool(corner_mask), quad_as_tri=True,
+        )
         renderer = MplTestRenderer()
         for i in range(len(self.levels)-1):
             filled = cont_gen.filled(self.levels[i], self.levels[i+1])

--- a/benchmarks/benchmarks/bench_filled_serial_render.py
+++ b/benchmarks/benchmarks/bench_filled_serial_render.py
@@ -1,22 +1,30 @@
-from contourpy import contour_generator
+from __future__ import annotations
+
+from contourpy import FillType, contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, fill_types, problem_sizes
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, fill_types, problem_sizes
 
 
 class BenchFilledSerialRender(BenchBase):
-    params = (["serial"], datasets(), fill_types(), corner_masks(), problem_sizes())
-    param_names = ("name", "dataset", "fill_type", "corner_mask", "n")
+    params: tuple[list[str], list[str], list[FillType], list[str | bool], list[int]] = (
+        ["serial"], datasets(), fill_types(), corner_masks(), problem_sizes(),
+    )
+    param_names: tuple[str, ...] = ("name", "dataset", "fill_type", "corner_mask", "n")
 
-    def setup(self, name, dataset, fill_type, corner_mask, n):
+    def setup(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_filled_serial_render(self, name, dataset, fill_type, corner_mask, n):
-        if corner_mask == "no mask":
-            corner_mask = False
+    def time_filled_serial_render(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+    ) -> None:
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, fill_type=fill_type, corner_mask=corner_mask)
+            self.x, self.y, self.z, name=name, fill_type=fill_type,
+            corner_mask=corner_mask_to_bool(corner_mask),
+        )
         renderer = MplTestRenderer()
         for i in range(len(self.levels)-1):
             filled = cont_gen.filled(self.levels[i], self.levels[i+1])

--- a/benchmarks/benchmarks/bench_filled_threaded.py
+++ b/benchmarks/benchmarks/bench_filled_threaded.py
@@ -1,25 +1,37 @@
-from contourpy import contour_generator
+from __future__ import annotations
+
+from contourpy import FillType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, fill_types, problem_sizes, thread_counts
+from .util_bench import (
+    corner_mask_to_bool, corner_masks, datasets, fill_types, problem_sizes, thread_counts,
+)
 
 
 class BenchFilledThreaded(BenchBase):
-    params = (
+    params: tuple[list[str], list[str], list[FillType], list[str | bool], list[int], list[int],
+                  list[int]] = (
         ["threaded"], datasets(), fill_types(), corner_masks(), problem_sizes(), [40],
-        thread_counts())
-    param_names = (
-        "name", "dataset", "fill_type", "corner_mask", "n", "total_chunk_count", "thread_count")
+        thread_counts(),
+    )
+    param_names: tuple[str, ...] = (
+        "name", "dataset", "fill_type", "corner_mask", "n", "total_chunk_count", "thread_count",
+    )
 
-    def setup(self, name, dataset, fill_type, corner_mask, n, total_chunk_count, thread_count):
+    def setup(
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+        total_chunk_count: int, thread_count: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
     def time_filled_threaded(
-            self, name, dataset, fill_type, corner_mask, n, total_chunk_count, thread_count):
-        if corner_mask == "no mask":
-            corner_mask = False
+        self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
+        total_chunk_count: int, thread_count: int,
+    ) -> None:
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, fill_type=fill_type, corner_mask=corner_mask,
-            total_chunk_count=total_chunk_count, thread_count=thread_count)
+            self.x, self.y, self.z, name=name, fill_type=fill_type,
+            corner_mask=corner_mask_to_bool(corner_mask), total_chunk_count=total_chunk_count,
+            thread_count=thread_count,
+        )
         for i in range(len(self.levels)-1):
             cont_gen.filled(self.levels[i], self.levels[i+1])

--- a/benchmarks/benchmarks/bench_lines_mpl20xx.py
+++ b/benchmarks/benchmarks/bench_lines_mpl20xx.py
@@ -1,24 +1,31 @@
+from __future__ import annotations
+
 from contourpy import LineType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, problem_sizes
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, problem_sizes
 
 
 class BenchLinesMpl20xx(BenchBase):
-    params = (
+    params: tuple[list[str], list[str], list[LineType], list[str | bool], list[int]] = (
         ["mpl2005", "mpl2014"], datasets(), [LineType.SeparateCode], corner_masks(),
-        problem_sizes())
-    param_names = ("name", "dataset", "line_type", "corner_mask", "n")
+        problem_sizes(),
+    )
+    param_names: tuple[str, ...] = ("name", "dataset", "line_type", "corner_mask", "n")
 
-    def setup(self, name, dataset, line_type, corner_mask, n):
+    def setup(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_lines_mpl20xx(self, name, dataset, line_type, corner_mask, n):
+    def time_lines_mpl20xx(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+    ) -> None:
         if name == "mpl2005" and corner_mask is True:
             raise NotImplementedError  # Does not support corner_mask=True
-        if corner_mask == "no mask":
-            corner_mask = False
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, line_type=line_type, corner_mask=corner_mask)
+            self.x, self.y, self.z, name=name, line_type=line_type,
+            corner_mask=corner_mask_to_bool(corner_mask),
+        )
         for level in self.levels:
             cont_gen.lines(level)

--- a/benchmarks/benchmarks/bench_lines_mpl20xx_render.py
+++ b/benchmarks/benchmarks/bench_lines_mpl20xx_render.py
@@ -1,26 +1,33 @@
+from __future__ import annotations
+
 from contourpy import LineType, contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, problem_sizes
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, problem_sizes
 
 
 class BenchLinesMpl20xxRender(BenchBase):
-    params = (
+    params: tuple[list[str], list[str], list[LineType], list[str | bool], list[int]] = (
         ["mpl2005", "mpl2014"], datasets(), [LineType.SeparateCode], corner_masks(),
-        problem_sizes())
-    param_names = ("name", "dataset", "line_type", "corner_mask", "n")
+        problem_sizes(),
+    )
+    param_names: tuple[str, ...] = ("name", "dataset", "line_type", "corner_mask", "n")
 
-    def setup(self, name, dataset, line_type, corner_mask, n):
+    def setup(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_lines_mpl20xx_render(self, name, dataset, line_type, corner_mask, n):
+    def time_lines_mpl20xx_render(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+    ) -> None:
         if name == "mpl2005" and corner_mask is True:
             raise NotImplementedError  # Does not support corner_mask=True
-        if corner_mask == "no mask":
-            corner_mask = False
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, line_type=line_type, corner_mask=corner_mask)
+            self.x, self.y, self.z, name=name, line_type=line_type,
+            corner_mask=corner_mask_to_bool(corner_mask),
+        )
         renderer = MplTestRenderer()
         for i, level in enumerate(self.levels):
             lines = cont_gen.lines(level)

--- a/benchmarks/benchmarks/bench_lines_serial.py
+++ b/benchmarks/benchmarks/bench_lines_serial.py
@@ -1,20 +1,28 @@
-from contourpy import contour_generator
+from __future__ import annotations
+
+from contourpy import LineType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, line_types, problem_sizes
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, line_types, problem_sizes
 
 
 class BenchLinesSerial(BenchBase):
-    params = (["serial"], datasets(), line_types(), corner_masks(), problem_sizes())
-    param_names = ("name", "dataset", "line_type", "corner_mask", "n")
+    params: tuple[list[str], list[str], list[LineType], list[str | bool], list[int]] = (
+        ["serial"], datasets(), line_types(), corner_masks(), problem_sizes(),
+    )
+    param_names: tuple[str, ...] = ("name", "dataset", "line_type", "corner_mask", "n")
 
-    def setup(self, name, dataset, line_type, corner_mask, n):
+    def setup(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_lines_serial(self, name, dataset, line_type, corner_mask, n):
-        if corner_mask == "no mask":
-            corner_mask = False
+    def time_lines_serial(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+    ) -> None:
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, line_type=line_type, corner_mask=corner_mask)
+            self.x, self.y, self.z, name=name, line_type=line_type,
+            corner_mask=corner_mask_to_bool(corner_mask),
+        )
         for level in self.levels:
             cont_gen.lines(level)

--- a/benchmarks/benchmarks/bench_lines_serial_chunk.py
+++ b/benchmarks/benchmarks/bench_lines_serial_chunk.py
@@ -1,22 +1,32 @@
-from contourpy import contour_generator
+from __future__ import annotations
+
+from contourpy import LineType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, line_types, total_chunk_counts
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, line_types, total_chunk_counts
 
 
 class BenchLinesSerialChunk(BenchBase):
-    params = (
-        ["serial"], datasets(), line_types(), corner_masks(), [1000], total_chunk_counts())
-    param_names = ("name", "dataset", "line_type", "corner_mask", "n", "total_chunk_count")
+    params: tuple[list[str], list[str], list[LineType], list[str | bool], list[int], list[int]] = (
+        ["serial"], datasets(), line_types(), corner_masks(), [1000], total_chunk_counts(),
+    )
+    param_names: tuple[str, ...] = (
+        "name", "dataset", "line_type", "corner_mask", "n", "total_chunk_count",
+    )
 
-    def setup(self, name, dataset, line_type, corner_mask, n, total_chunk_count):
+    def setup(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+        total_chunk_count: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_lines_serial_chunk(self, name, dataset, line_type, corner_mask, n, total_chunk_count):
-        if corner_mask == "no mask":
-            corner_mask = False
+    def time_lines_serial_chunk(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+        total_chunk_count: int,
+    ) -> None:
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, line_type=line_type, corner_mask=corner_mask,
-            total_chunk_count=total_chunk_count)
+            self.x, self.y, self.z, name=name, line_type=line_type,
+            corner_mask=corner_mask_to_bool(corner_mask), total_chunk_count=total_chunk_count,
+        )
         for level in self.levels:
             cont_gen.lines(level)

--- a/benchmarks/benchmarks/bench_lines_serial_quad_as_tri.py
+++ b/benchmarks/benchmarks/bench_lines_serial_quad_as_tri.py
@@ -1,21 +1,28 @@
+from __future__ import annotations
+
 from contourpy import LineType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, problem_sizes
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, problem_sizes
 
 
 class BenchLinesSerialQuadAsTri(BenchBase):
-    params = (["serial"], datasets(), [LineType.SeparateCode], corner_masks(), problem_sizes())
-    param_names = ("name", "dataset", "line_type", "corner_mask", "n")
+    params: tuple[list[str], list[str], list[LineType], list[str | bool], list[int]] = (
+        ["serial"], datasets(), [LineType.SeparateCode], corner_masks(), problem_sizes(),
+    )
+    param_names: tuple[str, ...] = ("name", "dataset", "line_type", "corner_mask", "n")
 
-    def setup(self, name, dataset, line_type, corner_mask, n):
+    def setup(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_lines_serial_quad_as_tri(self, name, dataset, line_type, corner_mask, n):
-        if corner_mask == "no mask":
-            corner_mask = False
+    def time_lines_serial_quad_as_tri(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+    ) -> None:
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, line_type=line_type, corner_mask=corner_mask,
-            quad_as_tri=True)
+            self.x, self.y, self.z, name=name, line_type=line_type,
+            corner_mask=corner_mask_to_bool(corner_mask), quad_as_tri=True,
+        )
         for level in self.levels:
             cont_gen.lines(level)

--- a/benchmarks/benchmarks/bench_lines_serial_quad_as_tri_render.py
+++ b/benchmarks/benchmarks/bench_lines_serial_quad_as_tri_render.py
@@ -1,23 +1,30 @@
+from __future__ import annotations
+
 from contourpy import LineType, contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, problem_sizes
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, problem_sizes
 
 
 class BenchLinesSerialQuadAsTriRender(BenchBase):
-    params = (["serial"], datasets(), [LineType.SeparateCode], corner_masks(), problem_sizes())
-    param_names = ("name", "dataset", "line_type", "corner_mask", "n")
+    params: tuple[list[str], list[str], list[LineType], list[str | bool], list[int]] = (
+        ["serial"], datasets(), [LineType.SeparateCode], corner_masks(), problem_sizes(),
+    )
+    param_names: tuple[str, ...] = ("name", "dataset", "line_type", "corner_mask", "n")
 
-    def setup(self, name, dataset, line_type, corner_mask, n):
+    def setup(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_lines_serial_quad_as_tri_render(self, name, dataset, line_type, corner_mask, n):
-        if corner_mask == "no mask":
-            corner_mask = False
+    def time_lines_serial_quad_as_tri_render(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+    ) -> None:
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, line_type=line_type, corner_mask=corner_mask,
-            quad_as_tri=True)
+            self.x, self.y, self.z, name=name, line_type=line_type,
+            corner_mask=corner_mask_to_bool(corner_mask), quad_as_tri=True,
+        )
         renderer = MplTestRenderer()
         for i, level in enumerate(self.levels):
             lines = cont_gen.lines(level)

--- a/benchmarks/benchmarks/bench_lines_serial_render.py
+++ b/benchmarks/benchmarks/bench_lines_serial_render.py
@@ -1,22 +1,30 @@
-from contourpy import contour_generator
+from __future__ import annotations
+
+from contourpy import LineType, contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, line_types, problem_sizes
+from .util_bench import corner_mask_to_bool, corner_masks, datasets, line_types, problem_sizes
 
 
 class BenchLinesSerialRender(BenchBase):
-    params = (["serial"], datasets(), line_types(), corner_masks(), problem_sizes())
-    param_names = ("name", "dataset", "line_type", "corner_mask", "n")
+    params: tuple[list[str], list[str], list[LineType], list[str | bool], list[int]] = (
+        ["serial"], datasets(), line_types(), corner_masks(), problem_sizes(),
+    )
+    param_names: tuple[str, ...] = ("name", "dataset", "line_type", "corner_mask", "n")
 
-    def setup(self, name, dataset, line_type, corner_mask, n):
+    def setup(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
-    def time_lines_serial_render(self, name, dataset, line_type, corner_mask, n):
-        if corner_mask == "no mask":
-            corner_mask = False
+    def time_lines_serial_render(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+    ) -> None:
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, line_type=line_type, corner_mask=corner_mask)
+            self.x, self.y, self.z, name=name, line_type=line_type,
+            corner_mask=corner_mask_to_bool(corner_mask),
+        )
         renderer = MplTestRenderer()
         for i, level in enumerate(self.levels):
             lines = cont_gen.lines(level)

--- a/benchmarks/benchmarks/bench_lines_threaded.py
+++ b/benchmarks/benchmarks/bench_lines_threaded.py
@@ -1,25 +1,37 @@
-from contourpy import contour_generator
+from __future__ import annotations
+
+from contourpy import LineType, contour_generator
 
 from .bench_base import BenchBase
-from .util_bench import corner_masks, datasets, line_types, problem_sizes, thread_counts
+from .util_bench import (
+    corner_mask_to_bool, corner_masks, datasets, line_types, problem_sizes, thread_counts,
+)
 
 
 class BenchLinesThreaded(BenchBase):
-    params = (
+    params: tuple[list[str], list[str], list[LineType], list[str | bool], list[int], list[int],
+                  list[int]] = (
         ["threaded"], datasets(), line_types(), corner_masks(), problem_sizes(), [40],
-        thread_counts())
-    param_names = (
-        "name", "dataset", "line_type", "corner_mask", "n", "total_chunk_count", "thread_count")
+        thread_counts(),
+    )
+    param_names: tuple[str, ...] = (
+        "name", "dataset", "line_type", "corner_mask", "n", "total_chunk_count", "thread_count",
+    )
 
-    def setup(self, name, dataset, line_type, corner_mask, n, total_chunk_count, thread_count):
+    def setup(
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+        total_chunk_count: int, thread_count: int,
+    ) -> None:
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
     def time_lines_threaded(
-            self, name, dataset, line_type, corner_mask, n, total_chunk_count, thread_count):
-        if corner_mask == "no mask":
-            corner_mask = False
+        self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
+        total_chunk_count: int, thread_count: int,
+    ) -> None:
         cont_gen = contour_generator(
-            self.x, self.y, self.z, name=name, line_type=line_type, corner_mask=corner_mask,
-            total_chunk_count=total_chunk_count, thread_count=thread_count)
+            self.x, self.y, self.z, name=name, line_type=line_type,
+            corner_mask=corner_mask_to_bool(corner_mask), total_chunk_count=total_chunk_count,
+            thread_count=thread_count,
+        )
         for level in self.levels:
             cont_gen.lines(level)

--- a/benchmarks/benchmarks/util_bench.py
+++ b/benchmarks/benchmarks/util_bench.py
@@ -1,30 +1,39 @@
+from __future__ import annotations
+
 from contourpy import FillType, LineType, max_threads
 
 
-def corner_masks():
+def corner_mask_to_bool(corner_mask: str | bool) -> bool:
+    if isinstance(corner_mask, bool):
+        return corner_mask
+    else:
+        return False
+
+
+def corner_masks() -> list[str | bool]:
     return ["no mask", False, True]
 
 
-def datasets():
+def datasets() -> list[str]:
     return ["simple", "random"]
 
 
-def fill_types():
+def fill_types() -> list[FillType]:
     return list(FillType.__members__.values())
 
 
-def line_types():
+def line_types() -> list[LineType]:
     return list(LineType.__members__.values())
 
 
-def problem_sizes():
+def problem_sizes() -> list[int]:
     return [10, 30, 100, 300, 1000]
 
 
-def thread_counts():
+def thread_counts() -> list[int]:
     thread_counts = [1, 2, 4, 6, 8]
     return list(filter(lambda n: n <= max(max_threads(), 1), thread_counts))
 
 
-def total_chunk_counts():
+def total_chunk_counts() -> list[int]:
     return [4, 12, 40, 120]

--- a/benchmarks/loader.py
+++ b/benchmarks/loader.py
@@ -1,16 +1,25 @@
+from __future__ import annotations
+
 from copy import deepcopy
 from datetime import datetime
+from typing import Any
 
+from asv.benchmark import Benchmark
 from asv.benchmarks import Benchmarks
 from asv.config import Config
-from asv.results import iter_results_for_machine
+from asv.results import Results, iter_results_for_machine
 from asv.statistics import get_err
 
 from contourpy import FillType, LineType
 
 
 class Loader:
-    def __init__(self, machine=None):
+    _config: Config
+    _benchmarks: Benchmarks
+    _machine: str
+    _results: Results
+
+    def __init__(self, machine: str | None = None) -> None:
         self._config = Config.load()
         self._benchmarks = Benchmarks.load(self._config)
 
@@ -29,17 +38,17 @@ class Loader:
         self._results = latest_results
         self._machine = machine
 
-    def _find_benchmark_by_name(self, name):
+    def _find_benchmark_by_name(self, name: str) -> Benchmark:
         for k, v in self._benchmarks.items():
             if k.endswith(name):
                 return v
         raise RuntimeError(f"Cannot find benchmark with name {name}")
 
     @property
-    def commit(self):
-        return self._results.commit_hash
+    def commit(self) -> str:
+        return self._results.commit_hash  # type: ignore[no-any-return]
 
-    def get(self, benchmark_name, **kwargs):
+    def get(self, benchmark_name: str, **kwargs: Any) -> dict[str, Any]:
         benchmark = self._find_benchmark_by_name(benchmark_name)
         param_names = benchmark["param_names"]
         params = deepcopy(benchmark["params"])
@@ -85,5 +94,5 @@ class Loader:
         return ret
 
     @property
-    def machine(self):
+    def machine(self) -> str:
         return self._machine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ profile = "hug"
 skip_gitignore = true
 
 [tool.mypy]
-files = ["lib/contourpy", "tests"]
+files = ["lib/contourpy", "benchmarks", "tests"]
 python_version = "3.8"
 
 check_untyped_defs = true
@@ -101,6 +101,7 @@ warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
 module = [
+    "asv.*",
     "matplotlib",
     "matplotlib.*",
 ]


### PR DESCRIPTION
Adding type annotations for the `benchmarks` directory, following on from #199 and #200.