### PR TITLE
Replace mpl scatter call with plot instead

### DIFF
--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -155,7 +155,7 @@ class MplRenderer(Renderer):
                 np.stack((y[1:, :-1], ymid, y[:-1, 1:])).reshape((3, -1)),
                 **kwargs)
         if point_color is not None:
-            ax.scatter(x, y, color=point_color, alpha=alpha, marker='o')
+            ax.plot(x, y, color=point_color, alpha=alpha, marker='o', lw=0)
         ax._need_autoscale = True
 
     def lines(


### PR DESCRIPTION
A single-line change that replaces the one and only call of `matplotlib.Axes.scatter()` with `matplotlib.Axes.plot()` instead. Test images generated by `MplRenderer` are identical with this. This is a potential fix for a bug that occurs on `sparc64` hardware, see issue #196 for information.

Regardless of whether it fixes the `sparc64` bug or not, I would rather use `plot` than `scatter` anyway.