### PR TITLE
Use absolute imports

### DIFF
--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from ._contourpy import (
+from contourpy._contourpy import (
     ContourGenerator, FillType, LineType, Mpl2005ContourGenerator, Mpl2014ContourGenerator,
     SerialContourGenerator, ThreadedContourGenerator, ZInterp, max_threads,
 )
-from ._version import __version__
-from .chunk import calc_chunk_sizes
-from .enum_util import as_fill_type, as_line_type, as_z_interp
+from contourpy._version import __version__
+from contourpy.chunk import calc_chunk_sizes
+from contourpy.enum_util import as_fill_type, as_line_type, as_z_interp
 
 if TYPE_CHECKING:
     from typing import Any, Type

--- a/lib/contourpy/_contourpy.pyi
+++ b/lib/contourpy/_contourpy.pyi
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.typing as npt
 from typing_extensions import TypeAlias
 
-from . import _contourpy as cpy
+import contourpy._contourpy as cpy
 
 # Input numpy array types, the same as in common.h
 CoordinateArray: TypeAlias = npt.NDArray[np.float64]

--- a/lib/contourpy/enum_util.py
+++ b/lib/contourpy/enum_util.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ._contourpy import FillType, LineType, ZInterp
+from contourpy._contourpy import FillType, LineType, ZInterp
 
 
 def as_fill_type(fill_type: FillType | str) -> FillType:

--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -11,16 +11,16 @@ from bokeh.palettes import Category10
 from bokeh.plotting import figure
 import numpy as np
 
-from .. import FillType, LineType
-from .bokeh_util import filled_to_bokeh, lines_to_bokeh
-from .renderer import Renderer
+from contourpy import FillType, LineType
+from contourpy.util.bokeh_util import filled_to_bokeh, lines_to_bokeh
+from contourpy.util.renderer import Renderer
 
 if TYPE_CHECKING:
     from bokeh.models import GridPlot
     from bokeh.palettes import Palette
     from numpy.typing import ArrayLike
 
-    from .._contourpy import FillReturn, LineReturn
+    from contourpy._contourpy import FillReturn, LineReturn
 
 
 class BokehRenderer(Renderer):

--- a/lib/contourpy/util/bokeh_util.py
+++ b/lib/contourpy/util/bokeh_util.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from .. import FillType, LineType
-from .mpl_util import mpl_codes_to_offsets
+from contourpy import FillType, LineType
+from contourpy.util.mpl_util import mpl_codes_to_offsets
 
 if TYPE_CHECKING:
-    from .._contourpy import (
+    from contourpy._contourpy import (
         CoordinateArray, FillReturn, LineReturn, LineReturn_Separate, LineReturn_SeparateCode,
     )
 

--- a/lib/contourpy/util/data.py
+++ b/lib/contourpy/util/data.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 if TYPE_CHECKING:
-    from .._contourpy import CoordinateArray
+    from contourpy._contourpy import CoordinateArray
 
 
 def simple(

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -7,16 +7,16 @@ import matplotlib.collections as mcollections
 import matplotlib.pyplot as plt
 import numpy as np
 
-from .. import FillType, LineType
-from .mpl_util import filled_to_mpl_paths, lines_to_mpl_paths, mpl_codes_to_offsets
-from .renderer import Renderer
+from contourpy import FillType, LineType
+from contourpy.util.mpl_util import filled_to_mpl_paths, lines_to_mpl_paths, mpl_codes_to_offsets
+from contourpy.util.renderer import Renderer
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
     from numpy.typing import ArrayLike
 
-    from .. import _contourpy as cpy
+    import contourpy._contourpy as cpy
 
 
 class MplRenderer(Renderer):

--- a/lib/contourpy/util/mpl_util.py
+++ b/lib/contourpy/util/mpl_util.py
@@ -5,10 +5,12 @@ from typing import TYPE_CHECKING, cast
 import matplotlib.path as mpath
 import numpy as np
 
-from .. import FillType, LineType
+from contourpy import FillType, LineType
 
 if TYPE_CHECKING:
-    from .._contourpy import CodeArray, FillReturn, LineReturn, LineReturn_Separate, OffsetArray
+    from contourpy._contourpy import (
+        CodeArray, FillReturn, LineReturn, LineReturn_Separate, OffsetArray,
+    )
 
 
 def filled_to_mpl_paths(filled: FillReturn, fill_type: FillType) -> list[mpath.Path]:

--- a/lib/contourpy/util/renderer.py
+++ b/lib/contourpy/util/renderer.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
     from numpy.typing import ArrayLike
 
-    from .._contourpy import CoordinateArray, FillReturn, FillType, LineReturn, LineType
+    from contourpy._contourpy import CoordinateArray, FillReturn, FillType, LineReturn, LineType
 
 
 class Renderer(ABC):


### PR DESCRIPTION
Following the recommendation in PEP8, this changes the python imports to absolute rather than relative.