### PR TITLE
Minor improvement to get_boundary_start_point

### DIFF
--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -883,7 +883,7 @@ index_t BaseContourGenerator<Derived>::get_boundary_start_point(const Location& 
             start_point = quad-_nx-1;
         }
     }
-    else if (forward < 0) {
+    else {  // forward < 0
         if (forward == -_nx) {
             assert(left == 1);
             start_point = quad-1;


### PR DESCRIPTION
This removes an unnecessary `else if` statement, replacing it with an `else`.