### PR TITLE
Complete mypy configuration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include src *.h
 recursive-include tests *.png *.py
 recursive-include docs Makefile make.bat *.ico *.rst *.png *.py *.svg
+include lib/contourpy/py.typed

--- a/docs/sphinxext/name_supports.py
+++ b/docs/sphinxext/name_supports.py
@@ -29,9 +29,12 @@ class NameSupports(Directive):
             "supports_z_interp",
         ]
 
-        filter_ = self.options.get("filter")
-        if filter_ is not None:
-            function_names = list(filter(lambda str: filter_ in str, function_names))
+        filter_string = self.options.get("filter")
+        if filter_string is not None:
+            function_name = f"supports_{filter_string}"
+            if function_name not in function_names:
+                raise ValueError(f"Invalid filter string '{filter_string}'")
+            function_names = [function_name]
 
         table = Table(1 + len(names))
         table.add_header([""] + names)

--- a/docs/sphinxext/plot_directive.py
+++ b/docs/sphinxext/plot_directive.py
@@ -66,7 +66,7 @@ class PlotDirective(CodeBlock):
             exec(self._mpl_mode_header(mode) + combined_source)
         setattr(MplRenderer, "show", old_show)
 
-        images = []
+        images: list[nodes.Node] = []
         for i, svg_filename in enumerate(svg_filenames):
             image = nodes.image(uri=svg_filename)
             if using_modes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,13 @@ bokeh = [
     "chromedriver",
     "selenium",
 ]
+mypy = [
+    # Requirements to run mypy to check type annotations.
+    "contourpy[bokeh]",
+    "docutils-stubs",
+    "mypy ==0.991",
+    "types-Pillow",
+]
 test = [
     # Standard test dependencies.
     "matplotlib",


### PR DESCRIPTION
This completes the `mypy` configuration to allow checking of type annotations.

`mypy` is not in `pre-commit` yet, but is run manually from the command line using:

```
pip install -ve .[mypy]
mypy
```
The `mypy` dependencies also pull in the `bokeh` ones.