### PR TITLE
Bump required setuptools version to 61

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
     "pybind11>=2.6",
-    "setuptools>=42",
+    "setuptools>=61",
 ]
 
 [project]


### PR DESCRIPTION
This is required to support pyproject.toml-based installs. 

Thanks to @hroncok for pointing this out at https://github.com/contourpy/contourpy/pull/181#discussion_r1071996338