### PR TITLE
Add python 3.12-dev to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,19 @@ jobs:
             name: "Test"
             build-numpy: true
             test-no-images: true
+          # Pre-release Python 3.12 without image tests.
+          - os: ubuntu-latest
+            python-version: "3.12-dev"
+            name: "Test"
+            test-no-images: true
+          - os: macos-latest
+            python-version: "3.12-dev"
+            name: "Test"
+            test-no-images: true
+          - os: windows-latest
+            python-version: "3.12-dev"
+            name: "Test"
+            test-no-images: true
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
Add python 3.12-dev to CI. Not using image tests as do not want to compile matplotlib from source.