### PR TITLE
Remove typehints from API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,8 @@ extensions = [
     "plot_directive",
 ]
 
+autodoc_typehints = "none"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
The presence of typehints in the API docs make them hard to understand and is unnecessary given the human-readable types in the docstrings. This PR removes them from the API docs.