### PR TITLE
Add explicit sphinx docstrings for default_fill_type and default_line_type

### DIFF
--- a/docs/api/top.rst
+++ b/docs/api/top.rst
@@ -19,6 +19,16 @@ contourpy
    :members:
    :exclude-members: create_contour, create_filled_contour
 
+   .. property:: default_fill_type
+      :classmethod:
+
+      Return the default ``FillType`` used by this algorithm.
+
+   .. property:: default_line_type
+      :classmethod:
+
+      Return the default ``LineType`` used by this algorithm.
+
 .. autoclass:: Mpl2005ContourGenerator
    :show-inheritance:
 


### PR DESCRIPTION
The current sphinx documentation does not include `ContourGenerator.default_fill_type` or `default_line_type`, as `pybind11` does not deal with static property docstrings very well. This adds explicit entries in the docs for these two.