### PR TITLE
C++ docstring improvements

### DIFF
--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -68,82 +68,104 @@ PYBIND11_MODULE(_contourpy, m) {
         "This is the number of threads used by a multithreaded ContourGenerator if the kwarg "
         "``threads=0`` is passed to :func:`~contourpy.contour_generator`.");
 
+    const char* chunk_count_doc = "Return tuple of (y, x) chunk counts.";
+    const char* chunk_size_doc = "Return tuple of (y, x) chunk sizes.";
+    const char* corner_mask_doc = "Return whether ``corner_mask`` is set or not.";
+    const char* create_contour_doc =
+        "Synonym for :func:`~contourpy.ContourGenerator.lines` to provide backward compatibility "
+        "with Matplotlib.";
+    const char* create_filled_contour_doc =
+        "Synonym for :func:`~contourpy.ContourGenerator.filled` to provide backward compatibility "
+        "with Matplotlib.";
+    const char* default_fill_type_doc = "Return the default ``FillType`` used by this algorithm.";
+    const char* default_line_type_doc = "Return the default ``LineType`` used by this algorithm.";
+    const char* fill_type_doc = "Return the ``FillType``.";
+    const char* filled_doc =
+        "Calculate and return filled contours between two levels.\n\n"
+        "Args:\n"
+        "    lower_level (float): Lower z-level of the filled contours.\n"
+        "    upper_level (float): Upper z-level of the filled contours.\n"
+        "Return:\n"
+        "    Filled contour polygons as one or more sequences of numpy arrays. The exact format is "
+        "determined by the ``fill_type`` used by the ``ContourGenerator``.";
+    const char* line_type_doc = "Return the ``LineType``.";
+    const char* lines_doc =
+        "Calculate and return contour lines at a particular level.\n\n"
+        "Args:\n"
+        "    level (float): z-level to calculate contours at.\n\n"
+        "Return:\n"
+        "    Contour lines (open line strips and closed line loops) as one or more sequences of "
+        "numpy arrays. The exact format is determined by the ``line_type`` used by the "
+        "``ContourGenerator``.";
+    const char* quad_as_tri_doc = "Return whether ``quad_as_tri`` is set or not.";
+    const char* supports_corner_mask_doc =
+        "Return whether this algorithm supports ``corner_mask``.";
+    const char* supports_fill_type_doc =
+        "Return whether this algorithm supports a particular ``FillType``.";
+    const char* supports_line_type_doc =
+        "Return whether this algorithm supports a particular ``LineType``.";
+    const char* supports_quad_as_tri_doc =
+        "Return whether this algorithm supports ``quad_as_tri``.";
+    const char* supports_threads_doc =
+        "Return whether this algorithm supports the use of threads.";
+    const char* supports_z_interp_doc =
+        "Return whether this algorithm supports ``z_interp`` values other than ``ZInterp.Linear`` "
+        "which all support.";
+    const char* thread_count_doc = "Return the number of threads used.";
+    const char* z_interp_doc = "Return the ``ZInterp``.";
+
     py::class_<contourpy::ContourGenerator>(m, "ContourGenerator",
         "Abstract base class for contour generator classes, defining the interface that they all "
         "implement.")
-        .def("create_contour", [](double level) {return py::make_tuple();},
-            "Synonym for :func:`~contourpy.ContourGenerator.lines` to provide backward "
-            "compatibility with Matplotlib.")
+        .def("create_contour",
+            [](py::object /* self */, double level) {return py::make_tuple();},
+            py::arg("level"), create_contour_doc)
         .def("create_filled_contour",
-            [](double lower_level, double upper_level) {return py::make_tuple();},
-            "Synonym for :func:`~contourpy.ContourGenerator.filled` to provide backward "
-            "compatibility with Matplotlib.")
-        .def("filled", [](double lower_level, double upper_level) {return py::make_tuple();},
-            "Calculate and return filled contours between two levels.\n\n"
-            "Args:\n"
-            "    lower_level (float): Lower z-level of the filled contours.\n"
-            "    upper_level (float): Upper z-level of the filled contours.\n"
-            "Return:\n"
-            "    Filled contour polygons as one or more sequences of numpy arrays. The exact "
-            "format is determined by the ``fill_type`` used by the ``ContourGenerator``.")
-        .def("lines", [](double level) {return py::make_tuple();},
-            "Calculate and return contour lines at a particular level.\n\n"
-            "Args:\n"
-            "    level (float): z-level to calculate contours at.\n\n"
-            "Return:\n"
-            "    Contour lines (open line strips and closed line loops) as one or more sequences "
-            "of numpy arrays. The exact format is determined by the ``line_type`` used by the "
-            "``ContourGenerator``.")
+            [](py::object /* self */, double lower_level, double upper_level) {return py::make_tuple();},
+            py::arg("lower_level"), py::arg("upper_level"), create_filled_contour_doc)
+        .def("filled",
+            [](py::object /* self */, double lower_level, double upper_level) {return py::make_tuple();},
+            py::arg("lower_level"), py::arg("upper_level"), filled_doc)
+        .def("lines",
+            [](py::object /* self */, double level) {return py::make_tuple();},
+            py::arg("level"), lines_doc)
         .def_property_readonly(
             "chunk_count", [](py::object /* self */) {return py::make_tuple(1, 1);},
-            "Return tuple of (y, x) chunk counts.")
+            chunk_count_doc)
         .def_property_readonly(
-            "chunk_size", [](py::object /* self */) {return py::make_tuple(1, 1);},
-            "Return tuple of (y, x) chunk sizes.")
+            "chunk_size", [](py::object /* self */) {return py::make_tuple(1, 1);}, chunk_size_doc)
         .def_property_readonly(
-            "corner_mask", [](py::object /* self */) {return false;},
-            "Return whether ``corner_mask`` is set or not.")
+            "corner_mask", [](py::object /* self */) {return false;}, corner_mask_doc)
         .def_property_readonly(
             "fill_type", [](py::object /* self */) {return contourpy::FillType::OuterOffset;},
-            "Return the ``FillType``.")
+            fill_type_doc)
         .def_property_readonly(
             "line_type", [](py::object /* self */) {return contourpy::LineType::Separate;},
-            "Return the ``LineType``.")
+            line_type_doc)
         .def_property_readonly(
-            "quad_as_tri", [](py::object /* self */) {return false;},
-            "Return whether ``quad_as_tri`` is set or not.")
+            "quad_as_tri", [](py::object /* self */) {return false;}, quad_as_tri_doc)
         .def_property_readonly(
-            "thread_count", [](py::object /* self */) {return 1;},
-            "Return the number of threads used.")
+            "thread_count", [](py::object /* self */) {return 1;}, thread_count_doc)
         .def_property_readonly(
             "z_interp", [](py::object /* self */) {return contourpy::ZInterp::Linear;},
-            "Return the ``ZInterp``.")
+            z_interp_doc)
         .def_property_readonly_static(
             "default_fill_type",
             [](py::object /* self */) {return contourpy::FillType::OuterOffset;},
-            "Return the default ``FillType`` used by this algorithm.")
+            default_fill_type_doc)
         .def_property_readonly_static(
             "default_line_type", [](py::object /* self */) {return contourpy::LineType::Separate;},
-            "Return the default ``LineType`` used by this algorithm.")
-        .def_static(
-            "supports_corner_mask", []() {return false;},
-            "Return whether this algorithm supports ``corner_mask``.")
+            default_line_type_doc)
+        .def_static("supports_corner_mask", []() {return false;}, supports_corner_mask_doc)
         .def_static(
             "supports_fill_type", [](contourpy::FillType /* fill_type */) {return false;},
-            "Return whether this algorithm supports a particular ``FillType``.")
+            py::arg("fill_type"), supports_fill_type_doc)
         .def_static(
             "supports_line_type", [](contourpy::LineType /* line_type */) {return false;},
-            "Return whether this algorithm supports a particular ``LineType``.")
-        .def_static(
-            "supports_quad_as_tri", []() {return false;},
-            "Return whether this algorithm supports ``quad_as_tri``.")
-        .def_static(
-            "supports_threads", []() {return false;},
-            "Return whether this algorithm supports the use of threads.")
-        .def_static(
-            "supports_z_interp", []() {return false;},
-            "Return whether this algorithm supports ``z_interp`` values other than "
-            "``ZInterp.Linear`` which all support.");
+            py::arg("line_type"), supports_line_type_doc)
+        .def_static("supports_quad_as_tri", []() {return false;}, supports_quad_as_tri_doc)
+        .def_static("supports_threads", []() {return false;}, supports_threads_doc)
+        .def_static("supports_z_interp", []() {return false;}, supports_z_interp_doc);
 
     py::class_<contourpy::Mpl2005ContourGenerator, contourpy::ContourGenerator>(
         m, "Mpl2005ContourGenerator",
@@ -168,28 +190,33 @@ PYBIND11_MODULE(_contourpy, m) {
              py::kw_only(),
              py::arg("x_chunk_size") = 0,
              py::arg("y_chunk_size") = 0)
-        .def("create_contour", &contourpy::Mpl2005ContourGenerator::lines,
-            "Synonym for :func:`~contourpy.Mpl2005ContourGenerator.lines` to provide backward "
-            "compatibility with Matplotlib.")
+        .def("create_contour", &contourpy::Mpl2005ContourGenerator::lines, create_contour_doc)
         .def("create_filled_contour", &contourpy::Mpl2005ContourGenerator::filled,
-            "Synonym for :func:`~contourpy.Mpl2005ContourGenerator.filled` to provide backward "
-            "compatibility with Matplotlib.")
-        .def("filled", &contourpy::Mpl2005ContourGenerator::filled)
-        .def("lines", &contourpy::Mpl2005ContourGenerator::lines)
-        .def_property_readonly("chunk_count", &contourpy::Mpl2005ContourGenerator::get_chunk_count)
-        .def_property_readonly("chunk_size", &contourpy::Mpl2005ContourGenerator::get_chunk_size)
-        .def_property_readonly("fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
-        .def_property_readonly("line_type", [](py::object /* self */) {return mpl20xx_line_type;})
+            create_filled_contour_doc)
+        .def("filled", &contourpy::Mpl2005ContourGenerator::filled, filled_doc)
+        .def("lines", &contourpy::Mpl2005ContourGenerator::lines, lines_doc)
+        .def_property_readonly(
+            "chunk_count", &contourpy::Mpl2005ContourGenerator::get_chunk_count, chunk_count_doc)
+        .def_property_readonly(
+            "chunk_size", &contourpy::Mpl2005ContourGenerator::get_chunk_size, chunk_size_doc)
+        .def_property_readonly(
+            "fill_type", [](py::object /* self */) {return mpl20xx_fill_type;}, fill_type_doc)
+        .def_property_readonly(
+            "line_type", [](py::object /* self */) {return mpl20xx_line_type;}, line_type_doc)
         .def_property_readonly_static(
-            "default_fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
+            "default_fill_type", [](py::object /* self */) {return mpl20xx_fill_type;},
+            default_fill_type_doc)
         .def_property_readonly_static(
-            "default_line_type", [](py::object /* self */) {return mpl20xx_line_type;})
+            "default_line_type", [](py::object /* self */) {return mpl20xx_line_type;},
+            default_line_type_doc)
         .def_static(
             "supports_fill_type",
-            [](contourpy::FillType fill_type) {return fill_type == mpl20xx_fill_type;})
+            [](contourpy::FillType fill_type) {return fill_type == mpl20xx_fill_type;},
+            supports_fill_type_doc)
         .def_static(
             "supports_line_type",
-            [](contourpy::LineType line_type) {return line_type == mpl20xx_line_type;});
+            [](contourpy::LineType line_type) {return line_type == mpl20xx_line_type;},
+            supports_line_type_doc);
 
     py::class_<contourpy::mpl2014::Mpl2014ContourGenerator, contourpy::ContourGenerator>(
         m, "Mpl2014ContourGenerator",
@@ -219,32 +246,39 @@ PYBIND11_MODULE(_contourpy, m) {
              py::arg("x_chunk_size") = 0,
              py::arg("y_chunk_size") = 0)
         .def("create_contour", &contourpy::mpl2014::Mpl2014ContourGenerator::lines,
-            "Synonym for :func:`~contourpy.Mpl2014ContourGenerator.lines` to provide backward "
-            "compatibility with Matplotlib.")
+            create_contour_doc)
         .def("create_filled_contour", &contourpy::mpl2014::Mpl2014ContourGenerator::filled,
-            "Synonym for :func:`~contourpy.Mpl2014ContourGenerator.filled` to provide backward "
-            "compatibility with Matplotlib.")
-        .def("filled", &contourpy::mpl2014::Mpl2014ContourGenerator::filled)
-        .def("lines", &contourpy::mpl2014::Mpl2014ContourGenerator::lines)
+            create_filled_contour_doc)
+        .def("filled", &contourpy::mpl2014::Mpl2014ContourGenerator::filled, filled_doc)
+        .def("lines", &contourpy::mpl2014::Mpl2014ContourGenerator::lines, lines_doc)
         .def_property_readonly(
-            "chunk_count", &contourpy::mpl2014::Mpl2014ContourGenerator::get_chunk_count)
+            "chunk_count", &contourpy::mpl2014::Mpl2014ContourGenerator::get_chunk_count,
+            chunk_count_doc)
         .def_property_readonly(
-            "chunk_size", &contourpy::mpl2014::Mpl2014ContourGenerator::get_chunk_size)
+            "chunk_size", &contourpy::mpl2014::Mpl2014ContourGenerator::get_chunk_size,
+            chunk_size_doc)
         .def_property_readonly(
-            "corner_mask", &contourpy::mpl2014::Mpl2014ContourGenerator::get_corner_mask)
-        .def_property_readonly("fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
-        .def_property_readonly("line_type", [](py::object /* self */) {return mpl20xx_line_type;})
+            "corner_mask", &contourpy::mpl2014::Mpl2014ContourGenerator::get_corner_mask,
+            corner_mask_doc)
+        .def_property_readonly(
+            "fill_type", [](py::object /* self */) {return mpl20xx_fill_type;}, fill_type_doc)
+        .def_property_readonly(
+            "line_type", [](py::object /* self */) {return mpl20xx_line_type;}, line_type_doc)
         .def_property_readonly_static(
-            "default_fill_type", [](py::object /* self */) {return mpl20xx_fill_type;})
+            "default_fill_type", [](py::object /* self */) {return mpl20xx_fill_type;},
+            default_fill_type_doc)
         .def_property_readonly_static(
-            "default_line_type", [](py::object /* self */) {return mpl20xx_line_type;})
-        .def_static("supports_corner_mask", []() {return true;})
+            "default_line_type", [](py::object /* self */) {return mpl20xx_line_type;},
+            default_line_type_doc)
+        .def_static("supports_corner_mask", []() {return true;}, supports_corner_mask_doc)
         .def_static(
             "supports_fill_type",
-            [](contourpy::FillType fill_type) {return fill_type == mpl20xx_fill_type;})
+            [](contourpy::FillType fill_type) {return fill_type == mpl20xx_fill_type;},
+            supports_fill_type_doc)
         .def_static(
             "supports_line_type",
-            [](contourpy::LineType line_type) {return line_type == mpl20xx_line_type;});
+            [](contourpy::LineType line_type) {return line_type == mpl20xx_line_type;},
+            supports_line_type_doc);
 
     py::class_<contourpy::SerialContourGenerator, contourpy::ContourGenerator>(
         m, "SerialContourGenerator",
@@ -276,26 +310,41 @@ PYBIND11_MODULE(_contourpy, m) {
              py::arg("x_chunk_size") = 0,
              py::arg("y_chunk_size") = 0)
         .def("_write_cache", &contourpy::SerialContourGenerator::write_cache)
-        .def("create_contour", &contourpy::SerialContourGenerator::lines)
-        .def("create_filled_contour", &contourpy::SerialContourGenerator::filled)
-        .def("filled", &contourpy::SerialContourGenerator::filled)
-        .def("lines", &contourpy::SerialContourGenerator::lines)
-        .def_property_readonly("chunk_count", &contourpy::SerialContourGenerator::get_chunk_count)
-        .def_property_readonly("chunk_size", &contourpy::SerialContourGenerator::get_chunk_size)
-        .def_property_readonly("corner_mask", &contourpy::SerialContourGenerator::get_corner_mask)
-        .def_property_readonly("fill_type", &contourpy::SerialContourGenerator::get_fill_type)
-        .def_property_readonly("line_type", &contourpy::SerialContourGenerator::get_line_type)
-        .def_property_readonly("quad_as_tri", &contourpy::SerialContourGenerator::get_quad_as_tri)
-        .def_property_readonly("z_interp", &contourpy::SerialContourGenerator::get_z_interp)
-        .def_property_readonly_static("default_fill_type", [](py::object /* self */) {
-            return contourpy::SerialContourGenerator::default_fill_type();})
-        .def_property_readonly_static("default_line_type", [](py::object /* self */) {
-            return contourpy::SerialContourGenerator::default_line_type();})
-        .def_static("supports_corner_mask", []() {return true;})
-        .def_static("supports_fill_type", &contourpy::SerialContourGenerator::supports_fill_type)
-        .def_static("supports_line_type", &contourpy::SerialContourGenerator::supports_line_type)
-        .def_static("supports_quad_as_tri", []() {return true;})
-        .def_static("supports_z_interp", []() {return true;});
+        .def("create_contour", &contourpy::SerialContourGenerator::lines, create_contour_doc)
+        .def("create_filled_contour", &contourpy::SerialContourGenerator::filled,
+            create_filled_contour_doc)
+        .def("filled", &contourpy::SerialContourGenerator::filled, filled_doc)
+        .def("lines", &contourpy::SerialContourGenerator::lines, lines_doc)
+        .def_property_readonly(
+            "chunk_count", &contourpy::SerialContourGenerator::get_chunk_count, chunk_count_doc)
+        .def_property_readonly(
+            "chunk_size", &contourpy::SerialContourGenerator::get_chunk_size, chunk_size_doc)
+        .def_property_readonly(
+            "corner_mask", &contourpy::SerialContourGenerator::get_corner_mask, corner_mask_doc)
+        .def_property_readonly(
+            "fill_type", &contourpy::SerialContourGenerator::get_fill_type, fill_type_doc)
+        .def_property_readonly(
+            "line_type", &contourpy::SerialContourGenerator::get_line_type, line_type_doc)
+        .def_property_readonly(
+            "quad_as_tri", &contourpy::SerialContourGenerator::get_quad_as_tri, quad_as_tri_doc)
+        .def_property_readonly(
+            "z_interp", &contourpy::SerialContourGenerator::get_z_interp, z_interp_doc)
+        .def_property_readonly_static(
+            "default_fill_type",
+            [](py::object /* self */) {return contourpy::SerialContourGenerator::default_fill_type();},
+            default_fill_type_doc)
+        .def_property_readonly_static("default_line_type",
+            [](py::object /* self */) {return contourpy::SerialContourGenerator::default_line_type();},
+            default_line_type_doc)
+        .def_static("supports_corner_mask", []() {return true;}, supports_corner_mask_doc)
+        .def_static(
+            "supports_fill_type", &contourpy::SerialContourGenerator::supports_fill_type,
+            supports_fill_type_doc)
+        .def_static(
+            "supports_line_type", &contourpy::SerialContourGenerator::supports_line_type,
+            supports_line_type_doc)
+        .def_static("supports_quad_as_tri", []() {return true;}, supports_quad_as_tri_doc)
+        .def_static("supports_z_interp", []() {return true;}, supports_z_interp_doc);
 
     py::class_<contourpy::ThreadedContourGenerator, contourpy::ContourGenerator>(
         m, "ThreadedContourGenerator",
@@ -329,31 +378,44 @@ PYBIND11_MODULE(_contourpy, m) {
              py::arg("y_chunk_size") = 0,
              py::arg("thread_count") = 0)
         .def("_write_cache", &contourpy::ThreadedContourGenerator::write_cache)
-        .def("create_contour", &contourpy::ThreadedContourGenerator::lines,
-            "Synonym for :func:`~contourpy.ThreadedContourGenerator.lines` to provide backward "
-            "compatibility with Matplotlib.")
+        .def("create_contour", &contourpy::ThreadedContourGenerator::lines, create_contour_doc)
         .def("create_filled_contour", &contourpy::ThreadedContourGenerator::filled,
-            "Synonym for :func:`~contourpy.ThreadedContourGenerator.filled` to provide backward "
-            "compatibility with Matplotlib.")
-        .def("filled", &contourpy::ThreadedContourGenerator::filled)
-        .def("lines", &contourpy::ThreadedContourGenerator::lines)
-        .def_property_readonly("chunk_count", &contourpy::ThreadedContourGenerator::get_chunk_count)
-        .def_property_readonly("chunk_size", &contourpy::ThreadedContourGenerator::get_chunk_size)
-        .def_property_readonly("corner_mask", &contourpy::ThreadedContourGenerator::get_corner_mask)
-        .def_property_readonly("fill_type", &contourpy::ThreadedContourGenerator::get_fill_type)
-        .def_property_readonly("line_type", &contourpy::ThreadedContourGenerator::get_line_type)
-        .def_property_readonly("quad_as_tri", &contourpy::ThreadedContourGenerator::get_quad_as_tri)
+            create_filled_contour_doc)
+        .def("filled", &contourpy::ThreadedContourGenerator::filled, filled_doc)
+        .def("lines", &contourpy::ThreadedContourGenerator::lines, lines_doc)
         .def_property_readonly(
-            "thread_count", &contourpy::ThreadedContourGenerator::get_thread_count)
-        .def_property_readonly("z_interp", &contourpy::ThreadedContourGenerator::get_z_interp)
-        .def_property_readonly_static("default_fill_type", [](py::object /* self */) {
-            return contourpy::ThreadedContourGenerator::default_fill_type();})
-        .def_property_readonly_static("default_line_type", [](py::object /* self */) {
-            return contourpy::ThreadedContourGenerator::default_line_type();})
-        .def_static("supports_corner_mask", []() {return true;})
-        .def_static("supports_fill_type", &contourpy::ThreadedContourGenerator::supports_fill_type)
-        .def_static("supports_line_type", &contourpy::ThreadedContourGenerator::supports_line_type)
-        .def_static("supports_quad_as_tri", []() {return true;})
-        .def_static("supports_threads", []() {return true;})
-        .def_static("supports_z_interp", []() {return true;});
+            "chunk_count", &contourpy::ThreadedContourGenerator::get_chunk_count, chunk_count_doc)
+        .def_property_readonly(
+            "chunk_size", &contourpy::ThreadedContourGenerator::get_chunk_size, chunk_size_doc)
+        .def_property_readonly(
+            "corner_mask", &contourpy::ThreadedContourGenerator::get_corner_mask, corner_mask_doc)
+        .def_property_readonly(
+            "fill_type", &contourpy::ThreadedContourGenerator::get_fill_type, fill_type_doc)
+        .def_property_readonly(
+            "line_type", &contourpy::ThreadedContourGenerator::get_line_type, line_type_doc)
+        .def_property_readonly(
+            "quad_as_tri", &contourpy::ThreadedContourGenerator::get_quad_as_tri, quad_as_tri_doc)
+        .def_property_readonly(
+            "thread_count", &contourpy::ThreadedContourGenerator::get_thread_count,
+            thread_count_doc)
+        .def_property_readonly(
+            "z_interp", &contourpy::ThreadedContourGenerator::get_z_interp, z_interp_doc)
+        .def_property_readonly_static(
+            "default_fill_type",
+            [](py::object /* self */) {return contourpy::ThreadedContourGenerator::default_fill_type();},
+            default_fill_type_doc)
+        .def_property_readonly_static(
+            "default_line_type",
+            [](py::object /* self */) {return contourpy::ThreadedContourGenerator::default_line_type();},
+            default_line_type_doc)
+        .def_static("supports_corner_mask", []() {return true;}, supports_corner_mask_doc)
+        .def_static(
+            "supports_fill_type", &contourpy::ThreadedContourGenerator::supports_fill_type,
+            supports_fill_type_doc)
+        .def_static(
+            "supports_line_type", &contourpy::ThreadedContourGenerator::supports_line_type,
+            supports_line_type_doc)
+        .def_static("supports_quad_as_tri", []() {return true;}, supports_quad_as_tri_doc)
+        .def_static("supports_threads", []() {return true;}, supports_threads_doc)
+        .def_static("supports_z_interp", []() {return true;}, supports_z_interp_doc);
 }


### PR DESCRIPTION
Two sets of improvements to C++ docstrings:

- Explicit use of `py::arg` to clarify argument names
- Use the same docstrings for all the various `ContourGenerator` classes