### PR TITLE
Correct authors section in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ requires = [
 
 [project]
 authors = [
-    {name = "Ian Thomas"},
-    {email = "ianthomas23@gmail.com"},
+    {name = "Ian Thomas", email = "ianthomas23@gmail.com"},
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Use a single author in the `authors` section of `pyproject.toml`, as recommended by @QuLogic in https://github.com/contourpy/contourpy/pull/181#discussion_r1166083245.