### PR TITLE
meson: simplify pybind11 dependency lookup

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,18 +21,7 @@ endif
 py_mod = import('python')
 py3 = py_mod.find_installation(pure: false)
 
-incdir_pybind11 = run_command(py3,
-  ['-c', 'import pybind11; print(pybind11.get_include())'],
-  check: true
-).stdout().strip()
-
-inc_pybind11 = include_directories(incdir_pybind11)
-
-pybind11_config = find_program('pybind11-config')
-pybind11_config_ret = run_command(pybind11_config, ['--includes'], check: true)
-pybind11_dep = declare_dependency(
-  include_directories: [pybind11_config_ret.stdout().split('-I')[-1].strip()],
-)
+pybind11_dep = dependency('pybind11')
 
 message('----- INFO -----')
 message(meson.backend())


### PR DESCRIPTION
Since meson 1.1.0 is required, it is simple to take advantage of the new-in-1.1.0 builtin dependency for pybind11. It will automatically handle the gory details of pybind11-config.