### PR TITLE
Add build_config to store and show build configuration info

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,6 +25,7 @@ linux_aarch64_test_task:
   install_contourpy_script: |
     python -m pip install -v .[test] -C builddir=build
     python -m pip list
+    python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"
 
   run_tests_script: |
     python -m pytest -v tests/
@@ -56,6 +57,7 @@ macos_arm64_test_task:
   install_contourpy_script: |
     python -m pip install -v .[test] -C builddir=build
     python -m pip list
+    python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"
 
   run_tests_script: |
     python -m pytest -v tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,10 +103,11 @@ jobs:
             chromium --version
             echo "Install contourpy in debug mode with test and bokeh dependencies"
             # Also -Ddebug=true?
-            python -m pip install -v .[bokeh,test] -C setup-args=-Dbuildtype=debug -C builddir=build
+            python -m pip install -v .[bokeh,test] -C setup-args=-Dbuildtype=debug -C setup-args=-Dcpp_std=c++11 -C builddir=build
           fi
           python -m pip list
-          python -c "import contourpy._contourpy as c; print('CONTOURPY_DEBUG', c.CONTOURPY_DEBUG)"
+          python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"
+          python -c "import contourpy as c; print('NDEBUG', c._contourpy.NDEBUG)"
 
       - name: Install cppcheck
         if: runner.os == 'Linux'

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ wheelhouse/
 generated/
 benchmarks/*.png
 benchmarks/*.svg
+build_config.py

--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -8,6 +8,8 @@ Please feel free to use them to experiment with ``contourpy``, but you should no
 downstream projects as they are liable to change at short notice without a formal deprecation
 period.
 
+.. autofunction:: build_config
+
 .. automodule:: contourpy.util.data
    :members:
 

--- a/lib/contourpy/_contourpy.pyi
+++ b/lib/contourpy/_contourpy.pyi
@@ -34,8 +34,7 @@ LineReturn_ChunkCombinedOffset: TypeAlias = tuple[list[PointArray | None], list[
 LineReturn: TypeAlias = LineReturn_Separate | LineReturn_SeparateCode | LineReturn_ChunkCombinedCode | LineReturn_ChunkCombinedOffset
 
 
-CONTOURPY_CXX11: int
-CONTOURPY_DEBUG: int
+CONTOURPY_NDEBUG: int
 __version__: str
 
 class FillType:

--- a/lib/contourpy/util/__init__.py
+++ b/lib/contourpy/util/__init__.py
@@ -1,0 +1,3 @@
+from contourpy.util._build_config import build_config
+
+__all__ = ["build_config"]

--- a/lib/contourpy/util/_build_config.py.in
+++ b/lib/contourpy/util/_build_config.py.in
@@ -1,0 +1,58 @@
+# _build_config.py.in is converted into _build_config.py during the meson build process.
+
+from __future__ import annotations
+
+
+def build_config() -> dict[str, str]:
+    """
+    Return a dictionary containing build configuration settings.
+
+    All dictionary keys and values are strings, for example ``False`` is
+    returned as ``"False"``.
+    """
+    return dict(
+        # Python settings
+        python_version="@python_version@",
+        python_install_dir=r"@python_install_dir@",
+        python_path=r"@python_path@",
+
+        # Package versions
+        contourpy_version="@contourpy_version@",
+        meson_version="@meson_version@",
+        mesonpy_version="@mesonpy_version@",
+        pybind11_version="@pybind11_version@",
+
+        # Misc meson settings
+        meson_backend="@meson_backend@",
+        build_dir="@build_dir@",
+        source_dir="@source_dir@",
+        cross_build="@cross_build@",
+
+        # Build options
+        build_options="@build_options@",
+        buildtype="@buildtype@",
+        cpp_std="@cpp_std@",
+        debug="@debug@",
+        optimization="@optimization@",
+        vsenv="@vsenv@",
+        b_ndebug="@b_ndebug@",
+        b_vscrt="@b_vscrt@",
+
+        # C++ compiler
+        compiler_name="@compiler_name@",
+        compiler_version="@compiler_version@",
+        linker_id="@linker_id@",
+        compile_command="@compile_command@",
+
+        # Host machine
+        host_cpu="@host_cpu@",
+        host_cpu_family="@host_cpu_family@",
+        host_cpu_endian="@host_cpu_endian@",
+        host_cpu_system="@host_cpu_system@",
+
+        # Build machine, same as host machine if not a cross_build
+        build_cpu="@build_cpu@",
+        build_cpu_family="@build_cpu_family@",
+        build_cpu_endian="@build_cpu_endian@",
+        build_cpu_system="@build_cpu_system@",
+    )

--- a/lib/contourpy/util/_build_config.py.in
+++ b/lib/contourpy/util/_build_config.py.in
@@ -24,12 +24,12 @@ def build_config() -> dict[str, str]:
 
         # Misc meson settings
         meson_backend="@meson_backend@",
-        build_dir="@build_dir@",
-        source_dir="@source_dir@",
+        build_dir=r"@build_dir@",
+        source_dir=r"@source_dir@",
         cross_build="@cross_build@",
 
         # Build options
-        build_options="@build_options@",
+        build_options=r"@build_options@",
         buildtype="@buildtype@",
         cpp_std="@cpp_std@",
         debug="@debug@",

--- a/lib/contourpy/util/meson.build
+++ b/lib/contourpy/util/meson.build
@@ -19,8 +19,8 @@ conf_data = configuration_data()
 
 # Python settings
 conf_data.set('python_version', py3.language_version())
-conf_data.set('python_install_dir', py3.get_install_dir())
-conf_data.set('python_path', py3.full_path())
+conf_data.set('python_install_dir', py3.get_install_dir().replace('\\', '/'))
+conf_data.set('python_path', py3.full_path().replace('\\', '/'))
 
 # package versions
 conf_data.set('contourpy_version', meson.project_version())
@@ -36,12 +36,12 @@ conf_data.set('pybind11_version', pybind11_dep.version())
 
 # Misc meson settings
 conf_data.set('meson_backend', meson.backend())
-conf_data.set('build_dir', meson.current_build_dir())
-conf_data.set('source_dir', meson.current_source_dir())
+conf_data.set('build_dir', meson.current_build_dir().replace('\\', '/'))
+conf_data.set('source_dir', meson.current_source_dir().replace('\\', '/'))
 conf_data.set('cross_build', meson.is_cross_build())
 
 # Build options
-conf_data.set('build_options', meson.build_options())
+conf_data.set('build_options', meson.build_options().replace('\\', '/'))
 options = [
   'b_ndebug',
   'b_vscrt',

--- a/lib/contourpy/util/meson.build
+++ b/lib/contourpy/util/meson.build
@@ -12,3 +12,72 @@ py3.install_sources(
   python_sources,
   subdir: 'contourpy/util',
 )
+
+
+# Build config data
+conf_data = configuration_data()
+
+# Python settings
+conf_data.set('python_version', py3.language_version())
+conf_data.set('python_install_dir', py3.get_install_dir())
+conf_data.set('python_path', py3.full_path())
+
+# package versions
+conf_data.set('contourpy_version', meson.project_version())
+conf_data.set('meson_version', meson.version())
+conf_data.set('mesonpy_version',
+  run_command(
+    py3,
+    ['-c', 'import mesonpy; print(mesonpy.__version__)'],
+    check: true
+  ).stdout().strip()
+)
+conf_data.set('pybind11_version', pybind11_dep.version())
+
+# Misc meson settings
+conf_data.set('meson_backend', meson.backend())
+conf_data.set('build_dir', meson.current_build_dir())
+conf_data.set('source_dir', meson.current_source_dir())
+conf_data.set('cross_build', meson.is_cross_build())
+
+# Build options
+conf_data.set('build_options', meson.build_options())
+options = [
+  'b_ndebug',
+  'b_vscrt',
+  'buildtype',
+  'cpp_std',
+  'debug',
+  'optimization',
+  'vsenv',
+]
+foreach option : options
+  conf_data.set(option, get_option(option))
+endforeach
+
+# C++ compiler
+cpp = meson.get_compiler('cpp')
+conf_data.set('compiler_name', cpp.get_id())
+conf_data.set('compiler_version', cpp.version())
+conf_data.set('linker_id', cpp.get_linker_id())
+conf_data.set('compile_command', ' '.join(cpp.cmd_array()))
+
+# Host and build machines
+machines = {
+  'host': host_machine,
+  'build': build_machine,
+}
+foreach name, machine : machines
+  conf_data.set(name + '_cpu', machine.cpu())
+  conf_data.set(name + '_cpu_family', machine.cpu_family())
+  conf_data.set(name + '_cpu_endian', machine.endian())
+  conf_data.set(name + '_cpu_system', machine.system())
+endforeach
+
+# Write build config to python file
+configure_file(
+  input: '_build_config.py.in',
+  output: '_build_config.py',
+  configuration: conf_data,
+  install_dir: py3.get_install_dir() / 'contourpy' / 'util',
+)

--- a/meson.build
+++ b/meson.build
@@ -20,27 +20,7 @@ endif
 
 py_mod = import('python')
 py3 = py_mod.find_installation(pure: false)
-
 pybind11_dep = dependency('pybind11')
-
-message('----- INFO -----')
-message(meson.backend())
-message(meson.version())
-cpp = meson.get_compiler('cpp')
-message(cpp.get_id())
-message(cpp.version())
-message(cpp.get_linker_id())
-message(cpp.cmd_array())
-message(host_machine.cpu())
-message(host_machine.cpu_family())
-message(host_machine.system())
-message(meson.project_source_root())
-message(py3.get_install_dir())
-message(py3.language_version())
-message('----------------')
-message(pybind11_dep.version())
-message(pybind11_dep.type_name())
-message('----------------')
 
 subdir('lib/contourpy')
 subdir('src')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ mypy = [
     # Requirements to run mypy to check type annotations.
     "contourpy[bokeh]",
     "docutils-stubs",
-    "mypy ==0.991",
+    "mypy == 0.991",
     "types-Pillow",
 ]
 test = [

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,4 @@
 cpp_args = [
-  # CONTOURPY_DEBUG derived from NDEBUG in wrap.cpp
-  '-DCONTOURPY_CXX11=0',  # only for information purposes.
   '-DCONTOURPY_VERSION=@0@'.format(version),
 ]
 

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -28,14 +28,15 @@ PYBIND11_MODULE(_contourpy, m) {
         ":class:`~contourpy.ZInterp`) and :func:`contourpy.max_threads` function are all available "
         "in the :mod:`contourpy` module.";
 
-    m.attr("CONTOURPY_DEBUG") =
-#ifdef NDEBUG
-        0;
-#else
-        1;
-#endif
-    m.attr("CONTOURPY_CXX11") = CONTOURPY_CXX11;  // Currently ignored
     m.attr("__version__") = MACRO_STRINGIFY(CONTOURPY_VERSION);
+
+    // asserts are enabled if NDEBUG is 0.
+    m.attr("NDEBUG") =
+#ifdef NDEBUG
+        1;
+#else
+        0;
+#endif
 
     py::enum_<contourpy::FillType>(m, "FillType",
         "Enum used for ``fill_type`` keyword argument in :func:`~contourpy.contour_generator`.\n\n"

--- a/tests/test_build_config.py
+++ b/tests/test_build_config.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from contourpy.util import build_config
+
+
+@pytest.fixture
+def all_keys() -> list[str]:
+    return [
+        "b_ndebug",
+        "b_vscrt",
+        "build_cpu_endian",
+        "build_cpu_family",
+        "build_cpu_system",
+        "build_cpu",
+        "build_dir",
+        "build_options",
+        "buildtype",
+        "compile_command",
+        "compiler_name",
+        "compiler_version",
+        "contourpy_version",
+        "cpp_std",
+        "cross_build",
+        "debug",
+        "host_cpu_endian",
+        "host_cpu_family",
+        "host_cpu_system",
+        "host_cpu",
+        "linker_id",
+        "meson_backend",
+        "meson_version",
+        "mesonpy_version",
+        "optimization",
+        "pybind11_version",
+        "python_install_dir",
+        "python_path",
+        "python_version",
+        "source_dir",
+        "vsenv",
+    ]
+
+
+def test_build_config(all_keys: list[str]) -> None:
+    config = build_config()
+
+    for key in all_keys:
+        # key exists and its value is a non-empty string
+        value = config.pop(key)
+        assert isinstance(value, str) and len(value) > 0
+
+    # assert no keys left
+    assert len(config) == 0


### PR DESCRIPTION
Fixes the 4th and 5th items of issue #224.

This PR saves build configuration determined at build time in a Python file so that it is available at runtime via `contourpy.util.build_config`, e.g.
```python
from contourpy.util import build_config
print(build_config())
```
Example output (pretty printed with simplified directories):
```
{'b_ndebug': 'if-release',
 'b_vscrt': 'from_buildtype',
 'build_cpu': 'aarch64',
 'build_cpu_endian': 'little',
 'build_cpu_family': 'aarch64',
 'build_cpu_system': 'darwin',
 'build_dir': '/somedir/.mesonpy-l7paevlc/build/lib/contourpy/util',
 'build_options': '-Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md '
                  '-Doptimization=3 -Dvsenv=True '
                  '--native-file=/somedir/.mesonpy-l7paevlc/build/meson-python-native-file.ini',
 'buildtype': 'release',
 'compile_command': 'c++',
 'compiler_name': 'clang',
 'compiler_version': '14.0.0',
 'contourpy_version': '1.0.8.dev1',
 'cpp_std': 'c++17',
 'cross_build': 'False',
 'debug': 'False',
 'host_cpu': 'aarch64',
 'host_cpu_endian': 'little',
 'host_cpu_family': 'aarch64',
 'host_cpu_system': 'darwin',
 'linker_id': 'ld64',
 'meson_backend': 'ninja',
 'meson_version': '1.1.0',
 'mesonpy_version': '0.13.0',
 'optimization': '3',
 'pybind11_version': '2.10.4',
 'python_install_dir': '/usr/local/lib/python3.10/site-packages/',
 'python_path': '/somedir/envs/contourpy3.10/bin/python',
 'python_version': '3.10',
 'source_dir': '/somedir/lib/contourpy/util',
 'vsenv': 'True'}
```

Also removed  the attributes `CONTOURPY_DEBUG` and `CONTOURPY_CXX11` from the C++ extension and added the `NDEBUG` attribute instead, to help check that the build process is correctly enabling/disabling asserts.