### PR TITLE
Run mypy in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,9 +101,9 @@ jobs:
             fi
           else
             chromium --version
-            echo "Install contourpy in debug mode with test and bokeh dependencies"
+            echo "Install contourpy in debug mode with test, bokeh and mypy dependencies"
             # Also -Ddebug=true?
-            python -m pip install -v .[bokeh,test] -C setup-args=-Dbuildtype=debug -C setup-args=-Dcpp_std=c++11 -C builddir=build
+            python -m pip install -v .[bokeh,mypy,test] -C setup-args=-Dbuildtype=debug -C setup-args=-Dcpp_std=c++11 -C builddir=build
           fi
           python -m pip list
           python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ bokeh = [
 ]
 mypy = [
     # Requirements to run mypy to check type annotations.
-    "contourpy[bokeh]",
+    "contourpy[bokeh,docs]",
     "docutils-stubs",
     "mypy == 1.2.0",
     "types-Pillow",

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -38,6 +38,19 @@ def test_cppcheck() -> None:
     assert proc.returncode == 0, f"cppcheck issues:\n{proc.stderr.decode('utf-8')}"
 
 
+def test_mypy() -> None:
+    # Skip test if mypy is not installed.
+    cmd = ["mypy", "--version"]
+    try:
+        proc = run(cmd, capture_output=True)
+    except FileNotFoundError:
+        pytest.skip()
+
+    cmd = ["mypy"]
+    proc = run(cmd, capture_output=True)
+    assert proc.returncode == 0, print(f"mypy issues:\n{proc.stdout.decode('utf-8')}")
+
+
 def test_version() -> None:
     version_python = contourpy.__version__
     assert version_is_canonical(version_python)


### PR DESCRIPTION
Run `mypy` in CI. Added it to `test_codebase` rather than in `pre-commit` so that it runs in the development virtual environment rather than the `pre-commit` one. If `mypy` is not installed the test is skipped.

It runs in the `debug` CI run as that already has the `bokeh` dependencies installed, so just need to add the extra `mypy` ones.