### PR TITLE
Bump meson-python to 0.13.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "mesonpy"
 requires = [
     "meson >= 1.1.0",
-    "meson-python >= 0.13.0",
+    "meson-python >= 0.13.1",
     "pybind11 >= 2.10.4",
 ]
 


### PR DESCRIPTION
Bump meson-python to 0.13.1. This picks up the `$ARCHFLAGS` fix to allow cross-compilation on macOS (mesonbuild/meson-python#407).