### PR TITLE
Set default meson build type

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -27,6 +27,10 @@
     //     "python setup.py build",
     //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     // ],
+    "build_command": [
+        "python -m pip install --upgrade build pip",
+        "python -m build --wheel -o {build_cache_dir} {build_dir}"
+    ],
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
@@ -71,8 +75,7 @@
     // followed by the pip installed packages).
     "matrix": {
         "matplotlib": [],
-        "numpy": [],
-        "pybind11": [],
+        "numpy": []
     },
 
     // Combinations of libraries/python versions can be excluded/included

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ compile = [
 dist = []
 install = []
 setup = [
-    "-Doptimization=3",
     "--vsenv",  # Force use of MSVC on Windows, ignored on other platforms
 ]
 
@@ -97,6 +96,9 @@ archs = "auto aarch64"
 
 [tool.cibuildwheel.macos]
 archs = "x86_64 arm64"
+
+[tool.cibuildwheel.windows]
+archs = "AMD64"  # Temporarily exclude x86
 
 
 [tool.isort]

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,5 @@
 cpp_args = [
-  '-DCONTOURPY_VERSION=@0@'.format(version),
+  '-DCONTOURPY_VERSION=' + version
 ]
 
 ext = py3.extension_module(
@@ -19,8 +19,8 @@ ext = py3.extension_module(
     'wrap.cpp',
     'z_interp.cpp',
   ],
-  cpp_args: [cpp_args],
-  dependencies : [pybind11_dep],
+  cpp_args: cpp_args,
+  dependencies: [pybind11_dep],
   gnu_symbol_visibility: 'hidden',
   install: true,
   subdir: 'contourpy',


### PR DESCRIPTION
Using the default `meson-python` `buildtype` of `release`. This gives `-O3` optimisation by default and excludes debug information which is what is has historically been the case for `contourpy` PyPI wheels. For development and coverage purposes a `buildtype` of `debug` will probably be used, as illustrated in GHA `test.yml`.

Not yet adding any specific extra compiler flags, most of which are extra warning detections.

Also updated the `asv` config to run benchmarks and confirmed that there are no statistically-significant reductions in performance when running the benchmark suite. Updated timings to follow.

FIxes the first two items of issue #224.