### PR TITLE
Add meson-specific build docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,7 +178,7 @@ jobs:
           if [[ "${{ matrix.debug }}" != "" ]] || [[ "${{ matrix.coverage-files }}" != "" ]]
           then
             # Install requirements when not using build isolation.
-            python -m pip install "meson[ninja] >= 1.1.0" "meson-python >= 0.13.1" "pybind11 >= 2.10.4"
+            python -m pip install -r build_requirements.txt
           fi
           python -m pip list
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ benchmarks/*.png
 benchmarks/*.svg
 build_config.py
 .coverage
+docs/_build/

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,0 +1,4 @@
+# These are the requirements from the build-system section of pyproject.toml
+meson[ninja] >= 1.1.0
+meson-python >= 0.13.1
+pybind11 >= 2.10.4

--- a/docs/benchmarks/index.rst
+++ b/docs/benchmarks/index.rst
@@ -3,7 +3,7 @@
 Benchmarks
 ==========
 
-``contourpy`` uses ``asv`` (`airspeed velocity <https://asv.readthedocs.io>`_) for benchmarking.
+ContourPy uses ``asv`` (`airspeed velocity <https://asv.readthedocs.io>`_) for benchmarking.
 
 To run the entire benchmarking suite:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,11 +78,16 @@ rst_epilog = """
 .. _Matplotlib: https://matplotlib.org/
 .. _NumPy: https://numpy.org/
 .. _PyPI: https://pypi.org/project/contourpy/
+.. _conda: https://conda.io/
 .. _conda-forge: https://anaconda.org/conda-forge/contourpy/
 .. _default: https://anaconda.org/anaconda/contourpy/
 .. _github: https://www.github.com/contourpy/contourpy/
+.. _meson: https://mesonbuild.com/
+.. _meson-python: https://meson-python.readthedocs.io/
 .. _pre-commit: https://pre-commit.com/
 .. _pybind11: https://pybind11.readthedocs.io/
+.. _pyenv: https://github.com/pyenv/pyenv/
+.. _virtualenv: https://virtualenv.pypa.io/en/latest/
 """
 
 extlinks = {

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -1,0 +1,196 @@
+.. _developer_guide:
+
+Developer guide
+===============
+
+Installing from source
+----------------------
+
+The source code for ContourPy is available from `github`_.
+Either ``git clone`` it directly, or fork and ``git clone`` it from your fork, as usual.
+It is recommended to install ContourPy from source into a new virtual environment using
+`conda`_, `pyenv`_ or `virtualenv`_ for example, rather than using your system Python.
+
+.. note::
+
+   To use all of the installation features described below you will need a recent version of
+   ``pip >= 23.1``. You can upgrade your installed ``pip`` using:
+
+   .. code-block:: console
+
+      $ python -m pip install --upgrade pip
+
+From the base directory of your local ``contourpy`` git repository, build and install it using:
+
+.. code-block:: console
+
+   $ python -m pip install -v .
+
+This is the simplest approach and uses a temporarily isolated environment to build ContourPy
+and then installs the built package into the current environment. If you make any changes to the
+source code (Python or C++) you will need to rerun this command to rebuild and reinstall.
+
+
+Installing using editable mode
+------------------------------
+
+To develop ContourPy source code, the recommended approach is to install in editable mode without
+using build isolation. Using this approach avoids the need to manually rebuild after making changes
+to the source code (Python or C++) as ContourPy is rebuilt automatically whenever it is imported.
+
+Firstly install the build requirements into your working environment:
+
+.. code-block:: console
+
+   $ python -m pip install -r build_requirements.txt
+
+then build ``contourpy`` in editable mode without build isolation:
+
+.. code-block:: console
+
+   $ python -m pip install -ve . --no-build-isolation
+
+Now whenever you ``import contourpy`` it will automatically rebuild if any source code files have
+changed. No specific indication is given when this occurs, but the ``import`` will take longer.
+If you wish to have visible confirmation of the rebuild then either set the environment variable
+``MESONPY_EDITABLE_VERBOSE=1`` or pass an extra configuration flag to your ``pip install`` command
+as follows:
+
+.. code-block:: console
+
+   $ python -m pip install -ve . --no-build-isolation -C editable-verbose=true
+
+
+Install configuration options
+-----------------------------
+
+Configuration options can be passed to ``pip install`` to control aspects of the build process.
+Some of the most commonly used are described below.
+Others are documented on the websites of the build tools `meson`_ and `meson-python`_.
+
+Debug build
+^^^^^^^^^^^
+
+The default build type for ContourPy is ``release`` which means it is built with performance
+optimisations and without debug symbols. This ensures that the code runs quickly and the binaries
+are small, which is what most end-users want.
+
+For development purposes it can help to build in ``debug`` mode. This adds debug symbols, enables
+C++ ``assert`` statements, and disables performance optimisations. To produce a ``debug`` build
+use:
+
+.. code-block:: console
+
+   $ python -m pip install -v .  -C setup-args=-Dbuildtype=debug -C builddir=build
+
+or the editable mode equivalent.
+
+C++ standard
+^^^^^^^^^^^^
+
+Although ContourPy is C++11 compliant the default C++ standard used to build is C++17.
+To change the C++ standard to, for example C++14, append ``-C setup-args=-Dcpp_std=c++14`` to the
+``pip install`` command. For example:
+
+.. code-block:: console
+
+   $ python -m pip install -v . -C setup-args=-Dcpp_std=c++14
+
+
+Running tests
+-------------
+
+To run the test suite, first ensure that the required dependencies are installed when building
+ContourPy and then run the tests using ``pytest``:
+
+.. code-block:: console
+
+   $ python -m pip install -ve .[test]
+   $ pytest -v
+
+It is possible to exclude certain tests. To exclude image comparison tests, for example if you do
+not have Matplotlib or Pillow installed:
+
+.. code-block:: console
+
+   $ pytest -k "not image"
+
+To exclude threaded tests:
+
+.. code-block:: console
+
+   $ pytest -k "not threads"
+
+Other tests are excluded by default but can be manually enabled. To include tests that generate text
+output:
+
+.. code-block:: console
+
+  $ pytest --runtext
+
+.. warning::
+
+   The ContourPy baseline images used for Matplotlib tests assume that the installed Matplotlib was
+   built with the version of FreeType that it vendors. If you have built Matplotlib yourself using a
+   different version of FreeType, as is usually the case for Linux distro packagers, you should not
+   run text tests as the generated images will be different even if everything is working as
+   expected.
+
+To include tests that take a long time to run:
+
+.. code-block:: console
+
+  $ pytest --runslow
+
+.. note::
+
+   :class:`~contourpy.util.bokeh_renderer.BokehRenderer` tests will be run if Bokeh is installed,
+   otherwise they will be skipped. The generated images for Bokeh tests are sensitive to the version
+   of the browser and the Operating System used to generate them, so unless you have experience in
+   this area you are advised to leave the generation and testing of Bokeh images to the ContourPy
+   Continuous Integration tests.
+
+
+Building the documentation
+--------------------------
+
+To build the documentation:
+
+.. code-block:: console
+
+   $ python -m pip install -v .[docs]
+   $ cd docs
+   $ make html
+
+and the top-level generated HTML file is ``docs/_build/html/index.html`` relate to the root of your
+github repository.
+
+
+Pre-commit hooks
+----------------
+
+Contributors are recommended to install `pre-commit`_ hooks which will automatically run various
+checks whenever ``git commit`` is run. First install ``pre-commit`` using either
+
+.. code-block:: bash
+
+   $ pip install pre-commit
+
+or
+
+.. code-block:: bash
+
+   $ conda install -c conda-forge pre-commit
+
+and then install the hooks using
+
+.. code-block:: bash
+
+   $ pre-commit install
+
+The hooks will then be run on each ``git commit``. You can manually run the hooks outside of a
+```git commit`` using
+
+.. code-block:: bash
+
+   $ pre-commit run --all-files

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ Advantages of the new algorithm compared to Matplotlib's default algorithm of 20
    :maxdepth: 1
    :caption: Extra Information
 
+   developer_guide
    benchmarks/index
    description
    config

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 Installing from prepackaged binaries
 ------------------------------------
 
-Stable releases of ``contourpy`` are available from `PyPI`_, `conda-forge`_, and Anaconda
+Stable releases of ContourPy are available from `PyPI`_, `conda-forge`_, and Anaconda
 `default`_ channels for Linux, macOS and Windows.
 
 #. To install from `PyPI`_:
@@ -27,134 +27,10 @@ Stable releases of ``contourpy`` are available from `PyPI`_, `conda-forge`_, and
 
 The only compulsory runtime dependency is `NumPy`_.
 
-If you want to make use of one of contourpy's utility renderers in the :mod:`contourpy.util` module
+If you want to make use of one of ContourPy's utility renderers in the :mod:`contourpy.util` module
 you will also have to install either `Matplotlib`_ or `Bokeh`_.
 
 Installing from source
 ----------------------
 
-The source code for ``contourpy`` is available from `github`_.
-Either ``git clone`` it directly, or fork and ``git clone`` it from your fork, as usual.
-
-.. note::
-
-   You should install ``contourpy`` from source into a new virtual environment using ``conda`` or
-   ``venv`` for example.
-   To use ``venv`` to create a new virtual environment in a directory called ``.venv/contourpy``
-   and activate it:
-
-   .. code-block:: console
-
-      $ python -m venv ~/.venv/contourpy
-      $ . ~/.venv/contourpy/bin/activate
-
-From the base directory of your local ``contourpy`` git repo, build and install it in editable mode
-using:
-
-.. code-block:: console
-
-   $ pip install -ve .
-
-
-To build in debug mode, which enables ``assert`` statements in the C++ code, use the
-``CONTOURPY_DEBUG`` environment variable:
-
-.. code-block:: console
-
-   $ CONTOURPY_DEBUG=1 pip install -ve .
-
-
-Running tests
--------------
-
-To run the test suite, first ensure that the required dependencies are installed and then run the
-tests using ``pytest``:
-
-.. code-block:: console
-
-   $ pip install -ve .[test]
-   $ pytest
-
-It is possible to exclude certain tests. To exclude image comparison tests, for example if you do
-not have ``matplotlib`` installed:
-
-.. code-block:: console
-
-   $ pytest -k "not image"
-
-To exclude threaded tests:
-
-.. code-block:: console
-
-   $ pytest -k "not threads"
-
-Other tests are excluded by default but can be manually enabled. To include tests that generate text
-output:
-
-.. code-block:: console
-
-  $ pytest --runtext
-
-but note that the output depends on the version of ``freetype`` that ``matplotlib`` is compiled
-against. To include tests that take a long time to run:
-
-.. code-block:: console
-
-  $ pytest --runslow
-
-:class:`~contourpy.util.bokeh_renderer.BokehRenderer` tests will be run if ``bokeh`` is installed,
-otherwise they will be skipped.
-
-
-Building the documentation
---------------------------
-
-To build the documentation:
-
-.. code-block:: console
-
-   $ pip install -ve .[docs]
-   $ cd docs
-   $ make html
-
-.. warning::
-
-   If you modify some of the C++ source code and wish to ensure a completely clean build, you can
-   first use:
-
-   .. code-block:: console
-
-      $ git clean -fxd
-
-   although use this with care as it will also delete any new files that you have created that have
-   not been added to ``git`` and are not mentioned in the ``.gitignore`` file.
-
-
-Notes for contributors
-----------------------
-
-Contributors are recommended to install `pre-commit`_ hooks which will automatically run various
-checks whenever ``git commit`` is run. First install ``pre-commit`` using either
-
-.. code-block:: bash
-
-   $ pip install pre-commit
-
-or
-
-.. code-block:: bash
-
-   $ conda install -c conda-forge pre-commit
-
-and then install the hooks using
-
-.. code-block:: bash
-
-   $ pre-commit install
-
-The hooks will then be run on each ``git commit``. You can manually run the hooks outside of a
-```git commit`` using
-
-.. code-block:: bash
-
-   $ pre-commit run --all-files
+If you wish to install from source code, see the :ref:`developer_guide`.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,7 +1,7 @@
 Usage
 =====
 
-The standard approach to use ``contourpy`` is to:
+The standard approach to use ContourPy is to:
 
 #. Call :func:`~contourpy.contour_generator` passing your 2D ``z`` array and optional ``x`` and ``y``
    arrays as arguments to return a :class:`~contourpy.ContourGenerator` object, such as the default

--- a/docs/user_guide/name.rst
+++ b/docs/user_guide/name.rst
@@ -22,7 +22,7 @@ respectively.
 mpl2005
 ^^^^^^^
 
-The original 2005 Matplotlib algorithm, modified to conform to the ``contourpy`` API and so that it
+The original 2005 Matplotlib algorithm, modified to conform to the ContourPy API and so that it
 can be wrapped using `pybind11`_. Does not support any of ``corner_mask``, ``quad_as_tri``,
 ``threads`` or ``z_interp``.
 
@@ -35,7 +35,7 @@ mpl2014
 ^^^^^^^
 
 The 2014 Matplotlib algorithm, a replacement of the original 2005 algorithm that added
-``corner_mask`` and made the code easier to understand.  Modified to conform to the ``contourpy``
+``corner_mask`` and made the code easier to understand.  Modified to conform to the ContourPy
 API and so that it can be wrapped using `pybind11`_.  Does not support ``quad_as_tri``, ``threads``
 or ``z_interp``.
 
@@ -47,7 +47,7 @@ or ``z_interp``.
 serial
 ^^^^^^
 
-The default algorithm for ``contourpy``, released in 2022, which supports all of the optional
+The default algorithm for ContourPy, released in 2022, which supports all of the optional
 features except for ``threads``. It combines lessons learnt from both of the previous algorithms as
 well as adding new features and performance improvements.
 


### PR DESCRIPTION
Add "Developer guide" page to docs containing meson-specific info.