### PR TITLE
Add simpler README for PyPI

### DIFF
--- a/README_simple.md
+++ b/README_simple.md
@@ -1,0 +1,15 @@
+<img alt="ContourPy" src="https://raw.githubusercontent.com/contourpy/contourpy/main/docs/_static/contourpy_logo_horiz.svg" height="90">
+
+ContourPy is a Python library for calculating contours of 2D quadrilateral grids.  It is written in C++11 and wrapped using pybind11.
+
+It contains the 2005 and 2014 algorithms used in Matplotlib as well as a newer algorithm that includes more features and is available in both serial and multithreaded versions.  It provides an easy way for Python libraries to use contouring algorithms without having to include Matplotlib as a dependency.
+
+  * **Documentation**: https://contourpy.readthedocs.io
+  * **Source code**: https://github.com/contourpy/contourpy
+
+| | |
+| --- | --- |
+| Latest release | [![PyPI version](https://img.shields.io/pypi/v/contourpy.svg?label=pypi&color=fdae61)](https://pypi.python.org/pypi/contourpy) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/contourpy.svg?label=conda-forge&color=a6d96a)](https://anaconda.org/conda-forge/contourpy) [![anaconda version](https://img.shields.io/conda/v/anaconda/contourpy.svg?label=anaconda&color=1a9641)](https://anaconda.org/anaconda/contourpy) |
+| Downloads | [![PyPi downloads](https://img.shields.io/pypi/dm/contourpy?label=pypi&style=flat&color=fdae61)](https://pepy.tech/project/contourpy) [![conda-forge downloads](https://raw.githubusercontent.com/contourpy/condabadges/main/cache/contourpy_conda-forge_monthly.svg)](https://anaconda.org/conda-forge/contourpy) [![anaconda downloads](https://raw.githubusercontent.com/contourpy/condabadges/main/cache/contourpy_anaconda_monthly.svg)](https://anaconda.org/anaconda/contourpy) |
+| Python version | [![Platforms](https://img.shields.io/pypi/pyversions/contourpy?color=fdae61)](https://pypi.org/project/contourpy/) |
+| Coverage | [![Codecov](https://img.shields.io/codecov/c/gh/contourpy/contourpy?color=fdae61&label=codecov)](https://app.codecov.io/gh/contourpy/contourpy) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ description = "Python library for calculating contours of 2D quadrilateral grids
 dynamic = ["version"]
 license = {text = "BSD-3-Clause"}
 name = "contourpy"
-readme = "README.md"
+readme = "README_simple.md"
 requires-python = ">= 3.8"
 
 [project.optional-dependencies]
@@ -67,8 +67,10 @@ test-no-images = [
 ]
 
 [project.urls]
-documentation = "https://contourpy.readthedocs.io"
-repository = "https://github.com/contourpy/contourpy"
+Homepage = "https://github.com/contourpy/contourpy"
+Changelog = "https://contourpy.readthedocs.io/en/latest/changelog.html"
+Documentation = "https://contourpy.readthedocs.io"
+Repository = "https://github.com/contourpy/contourpy"
 
 
 [tool.meson-python.args]


### PR DESCRIPTION
Workaround for #208.

PyPI does not render the `<picture>` tag that is used in the github README to support dark and light mode and it doesn't seem likely that this will supported in the short term. Hence this adds a new `README_simple.md` that is the same as the original `README.md` but with the `<picture>` tag removed.

Also added a couple more `project.urls` to the `pyproject.toml`. 