### PR TITLE
Temporarily disable python 3.12 tests [skip ci]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,18 +110,18 @@ jobs:
             build-numpy: true
             test-no-images: true
           # Pre-release Python 3.12 without image tests.
-          - os: ubuntu-latest
-            python-version: "3.12-dev"
-            name: "Test"
-            test-no-images: true
-          - os: macos-latest
-            python-version: "3.12-dev"
-            name: "Test"
-            test-no-images: true
-          - os: windows-latest
-            python-version: "3.12-dev"
-            name: "Test"
-            test-no-images: true
+          #- os: ubuntu-latest
+          #  python-version: "3.12-dev"
+          #  name: "Test"
+          #  test-no-images: true
+          #- os: macos-latest
+          #  python-version: "3.12-dev"
+          #  name: "Test"
+          #  test-no-images: true
+          #- os: windows-latest
+          #  python-version: "3.12-dev"
+          #  name: "Test"
+          #  test-no-images: true
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
Temporarily disable python 3.12-dev tests in CI. They were working last week but not this, and there is no rush.