### PR TITLE
Update wheel building using meson

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -8,12 +8,33 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: ${{ matrix.arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    #env:
+      #MACOSX_DEPLOYMENT_TARGET: "10.9"
 
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-11]
+        include:
+          - os: ubuntu-20.04
+            arch: aarch64
+          - os: ubuntu-20.04
+            arch: ppc64le
+          - os: ubuntu-20.04
+            arch: s390x
+          - os: ubuntu-20.04
+            arch: x86_64
+
+          - os: macOS-11
+            arch: arm64
+            # Temporary fix for cross-compiling on macos until meson 1.2.0 is released.
+            config-settings: setup-args=--cross-file="$PWD/meson-cross.ini"
+          - os: macOS-11
+            arch: x86_64
+
+          - os: windows-2019
+            arch: AMD64
 
     steps:
       - name: Checkout source
@@ -28,7 +49,10 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.3
+        uses: pypa/cibuildwheel@v2.13.0
+        env:
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_CONFIG_SETTINGS: ${{ matrix.config-settings }}
 
       - uses: actions/upload-artifact@v3
         with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-recursive-include src *.h
-recursive-include tests *.png *.py
-recursive-include docs Makefile make.bat *.ico *.rst *.png *.py *.svg
-include lib/contourpy/py.typed

--- a/lib/contourpy/meson.build
+++ b/lib/contourpy/meson.build
@@ -3,6 +3,8 @@ python_sources = [
   '_version.py',
   'chunk.py',
   'enum_util.py',
+  '_contourpy.pyi',
+  'py.typed',
 ]
 
 py3.install_sources(

--- a/meson-cross.ini
+++ b/meson-cross.ini
@@ -1,0 +1,3 @@
+# Temporary fix for cross-compiling on macos until meson 1.2.0 is released.
+[binaries]
+pybind11-config = 'pybind11-config'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,22 +86,14 @@ setup = [
 
 [tool.cibuildwheel]
 build-frontend = "build"
-build = "cp38-* cp39-* cp310-* cp311-* pp38-* pp39-*"
-test-command = 'python -c "import contourpy as c; c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9)"'
-# Only test combinations for which a numpy wheel exists
-test-skip = "pp38-*-aarch64 pp39-* *musllinux* *-macosx_arm64"
-
-[tool.cibuildwheel.config-settings]
-compile-args = "-v"
-
-[tool.cibuildwheel.linux]
-archs = "auto aarch64"
-
-[tool.cibuildwheel.macos]
-archs = "x86_64 arm64"
-
-[tool.cibuildwheel.windows]
-archs = "AMD64"  # Temporarily exclude x86
+build = "cp38-* cp39-* cp310-* cp311-* pp38-*_x86_64 pp38-* pp39-*"
+skip = "*-musllinux_aarch64 *-musllinux_ppc64le *-musllinux_s390x pp*_aarch64 pp*_ppc64le pp*_s390x"
+test-command = [
+    'python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"',
+    'python -c "import contourpy as c; c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9)"',
+]
+# Only test combinations for which a numpy wheel exists to avoid compiling numpy from source.
+test-skip = "pp38-*_aarch64 pp39-* *-musllinux_* *_ppc64le *_s390x"
 
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 ]
 description = "Python library for calculating contours of 2D quadrilateral grids"
 dynamic = ["version"]
-license = {text = "BSD-3-Clause"}
+license = {file = "LICENSE"}
 name = "contourpy"
 readme = "README_simple.md"
 requires-python = ">= 3.8"


### PR DESCRIPTION
Update to wheel building github action that uses `cibuildwheel` in line with switch to `meson` build system.

Changes:

1. No longer building any 32-bit wheels, in line with what `numpy` and `matplotlib` are planning.
2. Added building of `ppc64le` and `s390x` wheels, on `manylinux` only.
3. Cross-building of `aarch64` macos wheels on `x86_64` is obtained using a workaround to find `pybind11-config` that won't be needed when `meson` 1.2.0 is reieased, which should be soon.
4. Printing `build_config` as part of post-build tests to confirm cross-build and so are working as expected.
5. Still building `musllinux` wheels on `x86_64` only. 