### PR TITLE
Print config summary during build process

### DIFF
--- a/lib/contourpy/util/meson.build
+++ b/lib/contourpy/util/meson.build
@@ -81,3 +81,8 @@ configure_file(
   configuration: conf_data,
   install_dir: py3.get_install_dir() / 'contourpy' / 'util',
 )
+
+# Print summary of important build config
+foreach key : ['host_cpu', 'build_cpu', 'cross_build', 'optimization']
+  summary({key: conf_data.get(key)}, section: 'Build config')
+endforeach


### PR DESCRIPTION
It has been awkward checking cross-compilation settings when building wheels for PyPI and conda packages, so this prints some key build configuration settings earlier in the build process in the meson summary section.