### PR TITLE
Update meson to 1.2.0

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,8 +28,6 @@ jobs:
 
           - os: macOS-11
             arch: arm64
-            # Temporary fix for cross-compiling on macos until meson 1.2.0 is released.
-            config-settings: setup-args=--cross-file="$PWD/meson-cross.ini"
           - os: macOS-11
             arch: x86_64
 

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,4 +1,4 @@
 # These are the requirements from the build-system section of pyproject.toml
-meson[ninja] >= 1.1.0
+meson[ninja] >= 1.2.0
 meson-python >= 0.13.1
 pybind11 >= 2.10.4

--- a/meson-cross.ini
+++ b/meson-cross.ini
@@ -1,3 +1,0 @@
-# Temporary fix for cross-compiling on macos until meson 1.2.0 is released.
-[binaries]
-pybind11-config = 'pybind11-config'

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project(
     'werror=true',
   ],
   license: 'BSD-3-Clause',
-  meson_version: '>= 1.1.0',
+  meson_version: '>= 1.2.0',
   version: '1.1.1.dev1',
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "mesonpy"
 requires = [
-    "meson[ninja] >= 1.1.0",
+    "meson[ninja] >= 1.2.0",
     "meson-python >= 0.13.1",
     "pybind11 >= 2.10.4",
 ]


### PR DESCRIPTION
Update `meson` to `1.2.0` which handles `pybind11` correctly when cross-compiling so no longer need to use our own `meson-cross.ini`.