### PR TITLE
don't require ninja to come from PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "mesonpy"
 requires = [
-    "meson[ninja] >= 1.2.0",
+    "meson >= 1.2.0",
     "meson-python >= 0.13.1",
     "pybind11 >= 2.10.4",
 ]


### PR DESCRIPTION
In pyproject.toml, the baseline requirements for building are supposed to be listed.

Many end users have a recent enough system-provided ninja, and don't need to install a new copy into every contourpy isolated build virtual environment. This is handled inside meson-python itself, which dynamically adds an additional build requirement on ninja via the backend hook `get_requires_for_build_sdist`, but only if a suitable system version is not found.

This is especially helpful on systems where an OS ninja is installed, but the platform is obscure enough that there are no PyPI "ninja" wheels, thus forcing `pip install contourpy` to download an additional copy of the ninja source code and build it via cmake before beginning to install contourpy itself. This is not guaranteed to work...

The ninja entry in build_requirements.txt is left alone because it's opt-in and used for CI. In CI pipelines, it may make sense to be fairly specific about which providers you want to use for any given dependency, and that's a workflow preference encoded as a workflow build command. Since it doesn't prevent people from using the baseline install command, this commit makes no value judgment regarding it.