### PR TITLE
Reenable bokeh tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,8 +158,6 @@ jobs:
             snap list chromium
             snap info chromium
           fi
-          # Creating symlink here isn't ideal :)
-          cd /snap/bin && sudo ln -s chromium.chromedriver chromedriver
           which chromium
           chromium --version
           which chromedriver
@@ -223,7 +221,7 @@ jobs:
           elif [[ "${{ matrix.test-text }}" != "" ]]
           then
             echo "Run normal and text tests with coverage"
-            python -m pytest -v --color=yes -rP tests/test_renderer.py --runtext --cov=lib --cov-report=lcov
+            python -m pytest -v --color=yes -rP tests/test_bokeh_renderer.py tests/test_renderer.py --runtext --cov=lib --cov-report=lcov
           elif [[ "${{ matrix.test-no-images }}" != "" ]]
           then
             echo "Run only tests that do not generate images"

--- a/tests/test_bokeh_renderer.py
+++ b/tests/test_bokeh_renderer.py
@@ -19,11 +19,15 @@ def driver() -> Iterator[WebDriver]:
     # Based on Bokeh's tests/support/plugins/selenium.py
     def chrome() -> WebDriver:
         from selenium.webdriver.chrome.options import Options
+        from selenium.webdriver.chrome.service import Service
         from selenium.webdriver.chrome.webdriver import WebDriver as Chrome
+
         options = Options()
         options.add_argument("--headless")  # type: ignore[no-untyped-call]
         options.add_argument("--no-sandbox")  # type: ignore[no-untyped-call]
-        return Chrome(options=options)
+
+        service = Service(executable_path="/snap/bin/chromium.chromedriver")
+        return Chrome(options=options, service=service)
 
     driver = chrome()
     driver.implicitly_wait(10)


### PR DESCRIPTION
This reenables the bokeh images tests in CI after the improvements of #261.

Chromedriver path is hardcoded which isn't ideal but will allow the CI to run and can be improved in future.