### PR TITLE
Add --driver-path pytest option to specify chrome driver path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,7 @@ jobs:
           elif [[ "${{ matrix.test-text }}" != "" ]]
           then
             echo "Run normal and text tests with coverage"
-            python -m pytest -v --color=yes -rP tests/test_bokeh_renderer.py tests/test_renderer.py --runtext --cov=lib --cov-report=lcov
+            python -m pytest -v --color=yes -rP tests/test_bokeh_renderer.py tests/test_renderer.py --runtext --driver-path=/snap/bin/chromium.chromedriver --cov=lib --cov-report=lcov
           elif [[ "${{ matrix.test-no-images }}" != "" ]]
           then
             echo "Run only tests that do not generate images"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 import pytest
+
+if TYPE_CHECKING:
+    from _pytest.fixtures import SubRequest
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -11,6 +14,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
     parser.addoption(
         "--runtext", action="store_true", default=False, help="run tests with text output",
+    )
+    parser.addoption(
+        "--driver-path", type=str, action="store", default="", help="path to chrome driver",
     )
 
 
@@ -33,3 +39,8 @@ def pytest_collection_modifyitems(config: pytest.Config, items: Sequence[Any]) -
         for item in items:
             if "text" in item.keywords and item.callspec.getparam("show_text"):
                 item.add_marker(skip_text)
+
+
+@pytest.fixture(scope="session")
+def driver_path(request: SubRequest) -> Any:
+    return request.config.getoption("--driver-path")

--- a/tests/test_bokeh_renderer.py
+++ b/tests/test_bokeh_renderer.py
@@ -15,19 +15,22 @@ bokeh_renderer = pytest.importorskip("contourpy.util.bokeh_renderer")
 
 
 @pytest.fixture(scope="session")
-def driver() -> Iterator[WebDriver]:
+def driver(driver_path: str) -> Iterator[WebDriver]:
     # Based on Bokeh's tests/support/plugins/selenium.py
     def chrome() -> WebDriver:
         from selenium.webdriver.chrome.options import Options
-        from selenium.webdriver.chrome.service import Service
         from selenium.webdriver.chrome.webdriver import WebDriver as Chrome
 
         options = Options()
         options.add_argument("--headless")  # type: ignore[no-untyped-call]
         options.add_argument("--no-sandbox")  # type: ignore[no-untyped-call]
 
-        service = Service(executable_path="/snap/bin/chromium.chromedriver")
-        return Chrome(options=options, service=service)
+        if driver_path:
+            from selenium.webdriver.chrome.service import Service
+            service = Service(executable_path=driver_path)
+            return Chrome(options=options, service=service)
+        else:
+            return Chrome(options=options)
 
     driver = chrome()
     driver.implicitly_wait(10)


### PR DESCRIPTION
This adds a new `--driver-path` pytest option to override the path to the chrome driver that is used for Bokeh renderer tests. By default this is unset and selenium will follow its normal process for determining the path. For usage see `.github/workflows/test.yml` which sets it to `/snap/bin/chromium.chromedriver` in the appropriate github action run which has many browsers installed and we want to ensure the tests use the correct one.