### PR TITLE
Pin numpy < 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "numpy >=1.16",
+    "numpy >= 1.16, < 2.0",
 ]
 description = "Python library for calculating contours of 2D quadrilateral grids"
 dynamic = ["version"]


### PR DESCRIPTION
Pinning numpy to `< 2.0` as recommended in numpy/numpy#24300 for packages that use the NumPy C API, as done here via `pybind11`.

Leaving CI without numpy version pins, will address problems if/when they come up.