### PR TITLE
Remove ninja build requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,7 +186,7 @@ jobs:
           if [[ "${{ matrix.debug }}" != "" ]] || [[ "${{ matrix.coverage-files }}" != "" ]]
           then
             # Install requirements when not using build isolation.
-            python -m pip install -r build_requirements.txt
+            python -m pip install -r build_requirements.txt ninja
           fi
           python -m pip list
 

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,4 +1,4 @@
 # These are the requirements from the build-system section of pyproject.toml
-meson[ninja] >= 1.2.0
+meson >= 1.2.0
 meson-python >= 0.13.1
 pybind11 >= 2.10.4

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,7 +78,10 @@ html_theme_options = {
 
 rst_epilog = """
 .. _Bokeh: https://bokeh.org/
+.. _Clang: https://clang.llvm.org/
+.. _GCC: https://gcc.gnu.org/
 .. _Matplotlib: https://matplotlib.org/
+.. _MSVC: https://visualstudio.microsoft.com/
 .. _NumPy: https://numpy.org/
 .. _PyPI: https://pypi.org/project/contourpy/
 .. _conda: https://conda.io/
@@ -87,6 +90,7 @@ rst_epilog = """
 .. _github: https://www.github.com/contourpy/contourpy/
 .. _meson: https://mesonbuild.com/
 .. _meson-python: https://meson-python.readthedocs.io/
+.. _ninja: https://ninja-build.org/
 .. _pre-commit: https://pre-commit.com/
 .. _pybind11: https://pybind11.readthedocs.io/
 .. _pyenv: https://github.com/pyenv/pyenv/

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -3,6 +3,12 @@
 Developer guide
 ===============
 
+C++ compiler
+------------
+
+To build ContourPy you will need a C++ compiler. This is usually `GCC`_ on Linux, `Clang`_ on
+macOS, or `MSVC`_ on Windows. You will also need `ninja`_ installed.
+
 Installing from source
 ----------------------
 

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -7,7 +7,8 @@ C++ compiler
 ------------
 
 To build ContourPy you will need a C++ compiler. This is usually `GCC`_ on Linux, `Clang`_ on
-macOS, or `MSVC`_ on Windows. You will also need `ninja`_ installed.
+macOS, or `MSVC`_ on Windows. You will also need `ninja`_, binary wheels are available for many
+platforms that can be installed using ``pip``.
 
 Installing from source
 ----------------------


### PR DESCRIPTION
This removes the explicit `ninja` requirement in `build_requirements.txt` to keep it in line with the `[build-system]` `requires` section of `pyproject.toml`. See #260 for the change in `pyproject.toml`, and some discussion.

Also added minimal developer docs about needing a C++ compiler, etc.