### PR TITLE
Test and build wheels for python 3.12 using numpy RC

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.13.0
+        uses: pypa/cibuildwheel@v2.15.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_CONFIG_SETTINGS: ${{ matrix.config-settings }}
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
     name: pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
       - uses: pre-commit/action@v3.0.0
 
   codebase:
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -113,22 +113,19 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.12-dev"
             name: "Test"
-            build-numpy-no-isolation: true
             test-no-images: true
           - os: macos-latest
             python-version: "3.12-dev"
             name: "Test"
-            build-numpy-no-isolation: true
             test-no-images: true
           - os: windows-latest
             python-version: "3.12-dev"
             name: "Test"
-            build-numpy-no-isolation: true
             test-no-images: true
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -290,7 +287,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,10 +38,5 @@ repos:
     hooks:
       - id: pyupgrade
 
-  - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.13
-    hooks:
-      - id: validate-pyproject
-
 ci:
   autofix_prs: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,14 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "numpy >= 1.16, < 2.0",
+    "numpy >= 1.16, < 2.0; python_version <= '3.11'",
+    "numpy >= 1.26.0rc1, < 2.0; python_version >= '3.12'",
 ]
 description = "Python library for calculating contours of 2D quadrilateral grids"
 dynamic = ["version"]
@@ -87,14 +89,14 @@ setup = [
 
 [tool.cibuildwheel]
 build-frontend = "build"
-build = "cp38-* cp39-* cp310-* cp311-* pp38-*_x86_64 pp38-* pp39-*"
+build = "cp38-* cp39-* cp310-* cp311-* cp312-* pp38-* pp39-*"
 skip = "*-musllinux_aarch64 *-musllinux_ppc64le *-musllinux_s390x pp*_aarch64 pp*_ppc64le pp*_s390x"
 test-command = [
     'python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"',
-    'python -c "import contourpy as c; c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9)"',
+    'python -c "import contourpy as c; print(c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9))"',
 ]
 # Only test combinations for which a numpy wheel exists to avoid compiling numpy from source.
-test-skip = "pp38-*_aarch64 pp39-* *-musllinux_* *_ppc64le *_s390x"
+test-skip = "*-musllinux_* pp38-* *_ppc64le *_s390x"
 
 
 [tool.codespell]


### PR DESCRIPTION
Use numpy `1.26.0rc1` that supports Python 3.12 for tests and wheel building. Also update some github actions.