### PR TITLE
Prepare for 1.1.1rc1

### DIFF
--- a/lib/contourpy/_version.py
+++ b/lib/contourpy/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.1.dev1"
+__version__ = "1.1.1rc1"

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
   ],
   license: 'BSD-3-Clause',
   meson_version: '>= 1.2.0',
-  version: '1.1.1.dev1',
+  version: '1.1.1rc1',
 )
 
 # Check meson project version is the same as in _version.py


### PR DESCRIPTION
Prepare for 1.1.1rc1 which supports Python 3.12. Changelog not updated yet, will be done in the actual release.