### PR TITLE
Add Windows 32-bit testing to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,12 @@ jobs:
             python-version: "3.12-dev"
             name: "Test"
             test-no-images: true
+          # Win32 test.
+          - os: windows-latest
+            python-version: "3.11"
+            name: "Win32"
+            win32: true
+            extra-install-args: "--only-binary Pillow"
 
     steps:
       - name: Checkout source
@@ -129,10 +135,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Python ${{ matrix.python-version }}
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.win32 && 'x86' || 'x64' }}
+
+      - name: Setup MSVC (32-bit)
+        if: matrix.win32
+        uses: bus1/cabuild/action/msdevshell@v1
+        with:
+          architecture: 'x86'
+
+      - name: Fix PATH on win32
+        # Avoid this in GHA: "ERROR: Found GNU link.exe instead of MSVC link.exe"
+        if: matrix.win32
+        run: |
+          rm /c/Program\ Files/Git/usr/bin/link.EXE
 
       - name: Install OS dependencies
         if: matrix.debug


### PR DESCRIPTION
Add Windows 32-bit testing to CI. I am deleting the GNU linker so that it cannot be confused with the MSVC one, which I am not proud of, but if it is good enough for numpy then I am happy to do the same:

https://github.com/numpy/numpy/blob/34d6693b6e763c42ffa09ad050cce7f429e15ec0/tools/wheels/cibw_test_command.sh#L21-L24