### PR TITLE
Remove support for CPython 3.8 and PyPy 3.8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ linux_aarch64_test_task:
 
   matrix:
     - env:
-        PYTHON_VERSION: "3.8"
+        PYTHON_VERSION: "3.9"
     - env:
         PYTHON_VERSION: "3.11"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         name: ["Test"]
         include:
           # Debug build including Python and C++ coverage.
@@ -101,10 +101,6 @@ jobs:
             name: "Test C++11"
             extra-install-args: "-C setup-args=-Dcpp_std=c++11"
           # PyPy only tested on ubuntu for speed, without image tests.
-          - os: ubuntu-latest
-            python-version: "pypy3.8"
-            name: "Test"
-            test-no-images: true
           - os: ubuntu-latest
             python-version: "pypy3.9"
             name: "Test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -35,7 +34,7 @@ dynamic = ["version"]
 license = {file = "LICENSE"}
 name = "contourpy"
 readme = "README_simple.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 
 [project.optional-dependencies]
 docs = [
@@ -89,14 +88,14 @@ setup = [
 
 [tool.cibuildwheel]
 build-frontend = "build"
-build = "cp38-* cp39-* cp310-* cp311-* cp312-* pp38-* pp39-*"
+build = "cp39-* cp310-* cp311-* cp312-* pp39-*"
 skip = "*-musllinux_aarch64 *-musllinux_ppc64le *-musllinux_s390x pp*_aarch64 pp*_ppc64le pp*_s390x"
 test-command = [
     'python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"',
     'python -c "import contourpy as c; print(c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9))"',
 ]
 # Only test combinations for which a numpy wheel exists to avoid compiling numpy from source.
-test-skip = "*-musllinux_* pp38-* *_ppc64le *_s390x"
+test-skip = "*-musllinux_* *_ppc64le *_s390x"
 
 [tool.cibuildwheel.windows]
 before-build = [


### PR DESCRIPTION
Remove support for CPython 3.8 and PyPy 3.8, in line with NumPy and Matplotlib.