### PR TITLE
CI updates for CPython 3.12, PyPy 3.9 and musllinux

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ linux_aarch64_test_task:
     source venv/bin/activate
 
   install_contourpy_script: |
-    python -m pip install -v .[test] -C builddir=build
+    python -m pip install -v .[test] -Cbuilddir=build
     python -m pip list
     python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"
 
@@ -55,7 +55,7 @@ macos_arm64_test_task:
     source venv/bin/activate
 
   install_contourpy_script: |
-    python -m pip install -v .[test] -C builddir=build
+    python -m pip install -v .[test] -Cbuilddir=build
     python -m pip list
     python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -287,12 +287,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # musllinux: build numpy from source, run non-image tests only
+          # musllinux: run standard tests.
           - arch: x86_64
             manylinux_version: musllinux
             image: musllinux_1_1_x86_64
             venv: venv
-            test: test-no-images
+            test: test
           # ppc64le and s390x: dependencies are conda packages, run standard tests.
           - arch: ppc64le
             manylinux_version: manylinux2014

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,12 +100,10 @@ jobs:
             python-version: "3.11"
             name: "Test C++11"
             extra-install-args: "-C setup-args=-Dcpp_std=c++11"
-          # PyPy only tested on ubuntu for speed, without image tests.
+          # PyPy only tested on ubuntu for speed.
           - os: ubuntu-latest
             python-version: "pypy3.9"
             name: "Test"
-            build-numpy: true
-            test-no-images: true
           # Pre-release Python 3.12 without image tests.
           - os: ubuntu-latest
             python-version: "3.12-dev"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,12 +182,12 @@ jobs:
       - name: Build and install numpy from sdist
         if: matrix.build-numpy
         run: |
-          pip install -v --no-binary=numpy numpy -C setup-args="-Dallow-noblas=true"
+          python -m pip install -v --no-binary=numpy numpy -C setup-args="-Dallow-noblas=true"
 
       - name: Build and install numpy from sdist with debug asserts enabled
         if: matrix.build-numpy-debug
         run: |
-          CFLAGS=-UNDEBUG pip install -v --no-binary=numpy numpy -C setup-args="-Dallow-noblas=true"
+          python -m pip install -v --no-binary=numpy numpy -C setup-args="-Dallow-noblas=true" -C setup-args=-Dbuildtype=debug
 
       - name: Pre-install Python dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12-dev"]
         name: ["Test"]
         include:
           # Debug build including Python and C++ coverage.
@@ -104,19 +104,6 @@ jobs:
           - os: ubuntu-latest
             python-version: "pypy3.9"
             name: "Test"
-          # Pre-release Python 3.12 without image tests.
-          - os: ubuntu-latest
-            python-version: "3.12-dev"
-            name: "Test"
-            test-no-images: true
-          - os: macos-latest
-            python-version: "3.12-dev"
-            name: "Test"
-            test-no-images: true
-          - os: windows-latest
-            python-version: "3.12-dev"
-            name: "Test"
-            test-no-images: true
           # Win32 test.
           - os: windows-latest
             python-version: "3.11"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,12 +182,12 @@ jobs:
       - name: Build and install numpy from sdist
         if: matrix.build-numpy
         run: |
-          pip install -v --no-binary=numpy numpy
+          pip install -v --no-binary=numpy numpy -C setup-args="-Dallow-noblas=true"
 
       - name: Build and install numpy from sdist with debug asserts enabled
         if: matrix.build-numpy-debug
         run: |
-          CFLAGS=-UNDEBUG pip install -v --no-binary=numpy numpy
+          CFLAGS=-UNDEBUG pip install -v --no-binary=numpy numpy -C setup-args="-Dallow-noblas=true"
 
       - name: Pre-install Python dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.11"
             name: "Test C++11"
-            extra-install-args: "-C setup-args=-Dcpp_std=c++11"
+            extra-install-args: "-Csetup-args=-Dcpp_std=c++11"
           # PyPy only tested on ubuntu for speed.
           - os: ubuntu-latest
             python-version: "pypy3.9"
@@ -182,12 +182,12 @@ jobs:
       - name: Build and install numpy from sdist
         if: matrix.build-numpy
         run: |
-          python -m pip install -v --no-binary=numpy numpy -C setup-args="-Dallow-noblas=true"
+          python -m pip install -v --no-binary=numpy numpy -Csetup-args="-Dallow-noblas=true"
 
       - name: Build and install numpy from sdist with debug asserts enabled
         if: matrix.build-numpy-debug
         run: |
-          python -m pip install -v --no-binary=numpy numpy -C setup-args="-Dallow-noblas=true" -C setup-args=-Dbuildtype=debug
+          python -m pip install -v --no-binary=numpy numpy -Csetup-args="-Dallow-noblas=true" -Csetup-args=-Dbuildtype=debug
 
       - name: Pre-install Python dependencies
         run: |
@@ -204,11 +204,11 @@ jobs:
           if [[ "${{ matrix.debug }}" != "" ]]
           then
             echo "Install contourpy in debug editable mode with coverage"
-            python -m pip install -ve .[test] --no-build-isolation -C setup-args=-Dbuildtype=debug -C setup-args=-Db_coverage=true -C builddir=build
+            python -m pip install -ve .[test] --no-build-isolation -Csetup-args=-Dbuildtype=debug -Csetup-args=-Db_coverage=true -Cbuilddir=build
           elif [[ "${{ matrix.coverage-files }}" != "" ]]
           then
             echo "Install contourpy in editable mode with bokeh dependencies"
-            python -m pip install -ve .[bokeh,test] --no-build-isolation -C builddir=build
+            python -m pip install -ve .[bokeh,test] --no-build-isolation -Cbuilddir=build
           elif [[ "${{ matrix.test-no-images }}" != "" ]]
           then
             echo "Install contourpy with non-image-generating test dependencies"

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -77,7 +77,7 @@ as follows:
 
 .. code-block:: console
 
-   $ python -m pip install -ve . --no-build-isolation -C editable-verbose=true
+   $ python -m pip install -ve . --no-build-isolation -Ceditable-verbose=true
 
 
 Install configuration options
@@ -100,7 +100,7 @@ use:
 
 .. code-block:: console
 
-   $ python -m pip install -v .  -C setup-args=-Dbuildtype=debug -C builddir=build
+   $ python -m pip install -v . -Csetup-args=-Dbuildtype=debug -Cbuilddir=build
 
 or the editable mode equivalent.
 
@@ -108,12 +108,12 @@ C++ standard
 ^^^^^^^^^^^^
 
 Although ContourPy is C++11 compliant the default C++ standard used to build is C++17.
-To change the C++ standard to, for example C++14, append ``-C setup-args=-Dcpp_std=c++14`` to the
+To change the C++ standard to, for example C++14, append ``-Csetup-args=-Dcpp_std=c++14`` to the
 ``pip install`` command. For example:
 
 .. code-block:: console
 
-   $ python -m pip install -v . -C setup-args=-Dcpp_std=c++14
+   $ python -m pip install -v . -Csetup-args=-Dcpp_std=c++14
 
 
 Running tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "numpy >= 1.16, < 2.0; python_version <= '3.11'",
-    "numpy >= 1.26.0rc1, < 2.0; python_version >= '3.12'",
+    "numpy >= 1.16, < 2.0",
 ]
 description = "Python library for calculating contours of 2D quadrilateral grids"
 dynamic = ["version"]


### PR DESCRIPTION
Various CI updates now that it is possible to test using numpy, matplotlib and pillow wheels for CPython 3.12, PyPy 3.9 and musllinux.

- Allow `noblas` when compiling numpy from source.
- Correctly set debug option when compiling numpy from source.
- Use image tests for:
    - CPython 3.12
    - PyPy 3.9
    - musllinux