### PR TITLE
Test contour levels that are +/-np.inf

### DIFF
--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -914,3 +914,28 @@ def test_filled_z_nonfinite(name: str, z: float, zlevel: float) -> None:
     cont_gen = contour_generator(z=[[z, z], [z, z]], name=name, fill_type=FillType.OuterCode)
     filled = cont_gen.filled(zlevel, zlevel)
     assert filled == ([], [])
+
+
+@pytest.mark.parametrize("name", util_test.all_names())
+def test_filled_infinite_level(name: str) -> None:
+    levels_all = [(0.5, np.inf), (-np.inf, 0.5), (-np.inf, np.inf)]
+    if name == "mpl2014":
+        expected_all = [
+            np.array([[1, 0.5], [1, 1], [0, 1], [0, 0.5], [1, 0.5]]),
+            np.array([[1, 0], [1, 0.5], [0, 0.5], [0, 0], [1, 0]]),
+            np.array([[1, 0], [1, 1], [0, 1], [0, 0], [1, 0]]),
+        ]
+    else:
+        expected_all = [
+            np.array([[0, 1], [0, 0.5], [1, 0.5], [1, 1], [0, 1]]),
+            np.array([[0, 0], [1, 0], [1, 0.5], [0, 0.5], [0, 0]]),
+            np.array([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
+        ]
+
+    cont_gen = contour_generator(z=[[0, 0], [1, 1]], name=name, fill_type=FillType.OuterCode)
+    for (lower_level, upper_level), expected in zip(levels_all, expected_all):
+        filled = cont_gen.filled(lower_level, upper_level)
+        assert len(filled[0]) == 1  # Single polygon
+        points = filled[0][0]
+        assert isinstance(points, np.ndarray)
+        assert_allclose(points, expected)

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -799,3 +799,11 @@ def test_lines_z_nonfinite(name: str, z: float, zlevel: float) -> None:
     cont_gen = contour_generator(z=[[z, z], [z, z]], name=name, line_type=LineType.SeparateCode)
     lines = cont_gen.lines(zlevel)
     assert lines == ([], [])
+
+
+@pytest.mark.parametrize("name", util_test.all_names())
+def test_lines_infinite_level(name: str) -> None:
+    cont_gen = contour_generator(z=[[0, 0], [1, 1]], name=name, line_type=LineType.SeparateCode)
+    for level in (-np.inf, np.inf):
+        lines = cont_gen.lines(level)
+        assert len(lines[0]) == 0  # No lines


### PR DESCRIPTION
Adding tests to confirm that contour levels of `-np.inf` and `np.inf` are valid on all platforms. These are useful, for example, to produce filled contours from a level `z` upwards which would be achieved using
```python
from contourpy import contour_generator
import numpy as np

cg = contour_generator(...)
filled = cg.filled(1.0, np.inf)
```

Doc update with examples to follow in a separate PR.