### PR TITLE
Support strings instead of enums in renderer functions

### DIFF
--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -96,12 +96,12 @@ def contour_generator(
             If ``True``, only the triangular corners of quads nearest these points are always masked
             out, other triangular corners comprising three unmasked points are contoured as usual.
             If not specified, uses the default provided by the algorithm ``name``.
-        line_type (LineType, optional): The format of contour line data returned from calls to
-            :meth:`~contourpy.ContourGenerator.lines`. If not specified, uses the default provided
-            by the algorithm ``name``.
-        fill_type (FillType, optional): The format of filled contour data returned from calls to
-            :meth:`~contourpy.ContourGenerator.filled`. If not specified, uses the default provided
-            by the algorithm ``name``.
+        line_type (LineType or str, optional): The format of contour line data returned from calls
+            to :meth:`~contourpy.ContourGenerator.lines`. If not specified, uses the default
+            provided by the algorithm ``name``.
+        fill_type (FillType or str, optional): The format of filled contour data returned from calls
+            to :meth:`~contourpy.ContourGenerator.filled`. If not specified, uses the default
+            provided by the algorithm ``name``.
         chunk_size (int or tuple(int, int), optional): Chunk size in (y, x) directions, or the same
             size in both directions if only one value is specified.
         chunk_count (int or tuple(int, int), optional): Chunk count in (y, x) directions, or the

--- a/lib/contourpy/enum_util.py
+++ b/lib/contourpy/enum_util.py
@@ -13,7 +13,10 @@ def as_fill_type(fill_type: FillType | str) -> FillType:
         FillType: Converted value.
     """
     if isinstance(fill_type, str):
-        return FillType.__members__[fill_type]
+        try:
+            return FillType.__members__[fill_type]
+        except KeyError:
+            raise ValueError(f"'{fill_type}' is not a valid FillType")
     else:
         return fill_type
 
@@ -28,7 +31,10 @@ def as_line_type(line_type: LineType | str) -> LineType:
         LineType: Converted value.
     """
     if isinstance(line_type, str):
-        return LineType.__members__[line_type]
+        try:
+            return LineType.__members__[line_type]
+        except KeyError:
+            raise ValueError(f"'{line_type}' is not a valid LineType")
     else:
         return line_type
 
@@ -43,6 +49,9 @@ def as_z_interp(z_interp: ZInterp | str) -> ZInterp:
         ZInterp: Converted value.
     """
     if isinstance(z_interp, str):
-        return ZInterp.__members__[z_interp]
+        try:
+            return ZInterp.__members__[z_interp]
+        except KeyError:
+            raise ValueError(f"'{z_interp}' is not a valid ZInterp")
     else:
         return z_interp

--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -12,6 +12,7 @@ from bokeh.plotting import figure
 import numpy as np
 
 from contourpy import FillType, LineType
+from contourpy.enum_util import as_fill_type, as_line_type
 from contourpy.util.bokeh_util import filled_to_bokeh, lines_to_bokeh
 from contourpy.util.renderer import Renderer
 
@@ -89,7 +90,7 @@ class BokehRenderer(Renderer):
     def filled(
         self,
         filled: FillReturn,
-        fill_type: FillType,
+        fill_type: FillType | str,
         ax: figure | int = 0,
         color: str = "C0",
         alpha: float = 0.7,
@@ -99,14 +100,15 @@ class BokehRenderer(Renderer):
         Args:
             filled (sequence of arrays): Filled contour data as returned by
                 :func:`~contourpy.ContourGenerator.filled`.
-            fill_type (FillType): Type of ``filled`` data, as returned by
-                :attr:`~contourpy.ContourGenerator.fill_type`.
+            fill_type (FillType or str): Type of ``filled`` data as returned by
+                :attr:`~contourpy.ContourGenerator.fill_type`, or a string equivalent.
             ax (int or Bokeh Figure, optional): Which plot to use, default ``0``.
             color (str, optional): Color to plot with. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the
                 ``Category10`` palette. Default ``"C0"``.
             alpha (float, optional): Opacity to plot with, default ``0.7``.
         """
+        fill_type = as_fill_type(fill_type)
         fig = self._get_figure(ax)
         color = self._convert_color(color)
         xs, ys = filled_to_bokeh(filled, fill_type)
@@ -167,7 +169,7 @@ class BokehRenderer(Renderer):
     def lines(
         self,
         lines: LineReturn,
-        line_type: LineType,
+        line_type: LineType | str,
         ax: figure | int = 0,
         color: str = "C0",
         alpha: float = 1.0,
@@ -178,8 +180,8 @@ class BokehRenderer(Renderer):
         Args:
             lines (sequence of arrays): Contour line data as returned by
                 :func:`~contourpy.ContourGenerator.lines`.
-            line_type (LineType): Type of ``lines`` data, as returned by
-                :attr:`~contourpy.ContourGenerator.line_type`.
+            line_type (LineType or str): Type of ``lines`` data as returned by
+                :attr:`~contourpy.ContourGenerator.line_type`, or a string equivalent.
             ax (int or Bokeh Figure, optional): Which plot to use, default ``0``.
             color (str, optional): Color to plot lines. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the
@@ -190,6 +192,7 @@ class BokehRenderer(Renderer):
         Note:
             Assumes all lines are open line strips not closed line loops.
         """
+        line_type = as_line_type(line_type)
         fig = self._get_figure(ax)
         color = self._convert_color(color)
         xs, ys = lines_to_bokeh(lines, line_type)

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from contourpy import FillType, LineType
+from contourpy.enum_util import as_fill_type, as_line_type
 from contourpy.util.mpl_util import filled_to_mpl_paths, lines_to_mpl_paths, mpl_codes_to_offsets
 from contourpy.util.renderer import Renderer
 
@@ -86,7 +87,7 @@ class MplRenderer(Renderer):
     def filled(
         self,
         filled: cpy.FillReturn,
-        fill_type: FillType,
+        fill_type: FillType | str,
         ax: Axes | int = 0,
         color: str = "C0",
         alpha: float = 0.7,
@@ -96,14 +97,15 @@ class MplRenderer(Renderer):
         Args:
             filled (sequence of arrays): Filled contour data as returned by
                 :func:`~contourpy.ContourGenerator.filled`.
-            fill_type (FillType): Type of ``filled`` data, as returned by
-                :attr:`~contourpy.ContourGenerator.fill_type`.
+            fill_type (FillType or str): Type of ``filled`` data as returned by
+                :attr:`~contourpy.ContourGenerator.fill_type`, or a string equivalent
             ax (int or Maplotlib Axes, optional): Which axes to plot on, default ``0``.
             color (str, optional): Color to plot with. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the
                 ``tab10`` colormap. Default ``"C0"``.
             alpha (float, optional): Opacity to plot with, default ``0.7``.
         """
+        fill_type = as_fill_type(fill_type)
         ax = self._get_ax(ax)
         paths = filled_to_mpl_paths(filled, fill_type)
         collection = mcollections.PathCollection(
@@ -161,7 +163,7 @@ class MplRenderer(Renderer):
     def lines(
         self,
         lines: cpy.LineReturn,
-        line_type: LineType,
+        line_type: LineType | str,
         ax: Axes | int = 0,
         color: str = "C0",
         alpha: float = 1.0,
@@ -172,8 +174,8 @@ class MplRenderer(Renderer):
         Args:
             lines (sequence of arrays): Contour line data as returned by
                 :func:`~contourpy.ContourGenerator.lines`.
-            line_type (LineType): Type of ``lines`` data, as returned by
-                :attr:`~contourpy.ContourGenerator.line_type`.
+            line_type (LineType or str): Type of ``lines`` data as returned by
+                :attr:`~contourpy.ContourGenerator.line_type`, or a strin equivalent.
             ax (int or Matplotlib Axes, optional): Which Axes to plot on, default ``0``.
             color (str, optional): Color to plot lines. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the
@@ -181,6 +183,7 @@ class MplRenderer(Renderer):
             alpha (float, optional): Opacity to plot lines with, default ``1.0``.
             linewidth (float, optional): Width of lines, default ``1``.
         """
+        line_type = as_line_type(line_type)
         ax = self._get_ax(ax)
         paths = lines_to_mpl_paths(lines, line_type)
         collection = mcollections.PathCollection(
@@ -467,7 +470,7 @@ class MplDebugRenderer(MplRenderer):
     def filled(
         self,
         filled: cpy.FillReturn,
-        fill_type: FillType,
+        fill_type: FillType | str,
         ax: Axes | int = 0,
         color: str = "C1",
         alpha: float = 0.7,
@@ -477,6 +480,7 @@ class MplDebugRenderer(MplRenderer):
         start_point_color: str = "red",
         arrow_size: float = 0.1,
     ) -> None:
+        fill_type = as_fill_type(fill_type)
         super().filled(filled, fill_type, ax, color, alpha)
 
         if line_color is None and point_color is None:
@@ -515,7 +519,7 @@ class MplDebugRenderer(MplRenderer):
     def lines(
         self,
         lines: cpy.LineReturn,
-        line_type: LineType,
+        line_type: LineType | str,
         ax: Axes | int = 0,
         color: str = "C0",
         alpha: float = 1.0,
@@ -524,6 +528,7 @@ class MplDebugRenderer(MplRenderer):
         start_point_color: str = "red",
         arrow_size: float = 0.1,
     ) -> None:
+        line_type = as_line_type(line_type)
         super().lines(lines, line_type, ax, color, alpha, linewidth)
 
         if arrow_size == 0.0 and point_color is None:

--- a/lib/contourpy/util/renderer.py
+++ b/lib/contourpy/util/renderer.py
@@ -33,7 +33,7 @@ class Renderer(ABC):
     def filled(
         self,
         filled: FillReturn,
-        fill_type: FillType,
+        fill_type: FillType | str,
         ax: Any = 0,
         color: str = "C0",
         alpha: float = 0.7,
@@ -57,7 +57,7 @@ class Renderer(ABC):
     def lines(
         self,
         lines: LineReturn,
-        line_type: LineType,
+        line_type: LineType | str,
         ax: Any = 0,
         color: str = "C0",
         alpha: float = 1.0,

--- a/tests/test_bokeh_renderer.py
+++ b/tests/test_bokeh_renderer.py
@@ -54,7 +54,7 @@ def test_chrome_version(driver: WebDriver) -> None:
 @pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
-@pytest.mark.parametrize("fill_type", FillType.__members__.values())
+@pytest.mark.parametrize("fill_type", [*FillType.__members__.values(), "OuterCode"])
 def test_renderer_filled_bokeh(show_text: bool, fill_type: FillType, driver: WebDriver) -> None:
     from .image_comparison import compare_images
 
@@ -91,7 +91,7 @@ def test_renderer_filled_bokeh(show_text: bool, fill_type: FillType, driver: Web
 @pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
-@pytest.mark.parametrize("line_type", LineType.__members__.values())
+@pytest.mark.parametrize("line_type", [*LineType.__members__.values(), "Separate"])
 def test_renderer_lines_bokeh(show_text: bool, line_type: LineType, driver: WebDriver) -> None:
     from .image_comparison import compare_images
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -60,6 +60,6 @@ def test_string_to_enum(
         line_type = from_string_function(name)
         assert line_type == enum
 
-    msg = "'unknown'"
-    with pytest.raises(KeyError, match=msg):
+    msg = "'unknown' is not a valid"
+    with pytest.raises(ValueError, match=msg):
         _ = from_string_function("unknown")

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
 @pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
-@pytest.mark.parametrize("fill_type", FillType.__members__.values())
-def test_debug_renderer_filled(show_text: bool, fill_type: FillType) -> None:
+@pytest.mark.parametrize("fill_type", [*FillType.__members__.values(), "OuterCode"])
+def test_debug_renderer_filled(show_text: bool, fill_type: FillType | str) -> None:
     from contourpy.util.mpl_renderer import MplDebugRenderer
 
     from .image_comparison import compare_images
@@ -43,7 +43,7 @@ def test_debug_renderer_filled(show_text: bool, fill_type: FillType) -> None:
 @pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
-@pytest.mark.parametrize("line_type", LineType.__members__.values())
+@pytest.mark.parametrize("line_type", [*LineType.__members__.values(), "Separate"])
 def test_debug_renderer_lines(show_text: bool, line_type: LineType) -> None:
     from contourpy.util.mpl_renderer import MplDebugRenderer
 
@@ -71,7 +71,7 @@ def test_debug_renderer_lines(show_text: bool, line_type: LineType) -> None:
 @pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
-@pytest.mark.parametrize("fill_type", FillType.__members__.values())
+@pytest.mark.parametrize("fill_type", [*FillType.__members__.values(), "OuterCode"])
 def test_renderer_filled(show_text: bool, fill_type: FillType) -> None:
     from contourpy.util.mpl_renderer import MplRenderer
 
@@ -108,7 +108,7 @@ def test_renderer_filled(show_text: bool, fill_type: FillType) -> None:
 @pytest.mark.image
 @pytest.mark.text
 @pytest.mark.parametrize("show_text", [False, True])
-@pytest.mark.parametrize("line_type", LineType.__members__.values())
+@pytest.mark.parametrize("line_type", [*LineType.__members__.values(), "Separate"])
 def test_renderer_lines(show_text: bool, line_type: LineType) -> None:
     from contourpy.util.mpl_renderer import MplRenderer
 


### PR DESCRIPTION
Support the use of strings instead of enums in `Renderer` functions `filled()` and `lines()`.

Also improved error messages when converting strings to enums.