### PR TITLE
Use versionadded sphinx directive

### DIFF
--- a/lib/contourpy/util/_build_config.py.in
+++ b/lib/contourpy/util/_build_config.py.in
@@ -9,6 +9,8 @@ def build_config() -> dict[str, str]:
 
     All dictionary keys and values are strings, for example ``False`` is
     returned as ``"False"``.
+
+        .. versionadded:: 1.1.0
     """
     return dict(
         # Python settings

--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -239,6 +239,8 @@ class BokehRenderer(Renderer):
                 ``False``.
             webdriver (WebDriver, optional): Selenium WebDriver instance to use to create the image.
 
+                .. versionadded:: 1.1.1
+
         Warning:
             To output to SVG file, ``want_svg=True`` must have been passed to the constructor.
         """
@@ -257,6 +259,8 @@ class BokehRenderer(Renderer):
 
         Args:
             webdriver (WebDriver, optional): Selenium WebDriver instance to use to create the image.
+
+                .. versionadded:: 1.1.1
 
         Return:
             BytesIO: PNG image buffer.


### PR DESCRIPTION
Add `versionadded` sphinx directive to record the version at which new classes/functions/arguments were added. Initially used for:

- `_build_config` function (version added 1.1.0).
- `webdriver` argument to `BokehRenderer.save` and `save_to_buffer` functions (version added 1.1.1).