### PR TITLE
Switch from using python 3.12-dev to 3.12 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         name: ["Test"]
         include:
           # Debug build including Python and C++ coverage.
@@ -119,7 +119,7 @@ jobs:
             extra-install-args: "--only-binary Pillow"
           # Test against numpy nightly wheels.
           - os: ubuntu-latest
-            python-version: "3.12-dev"
+            python-version: "3.12"
             name: "Nightly wheels"
             nightly-wheels: true
 


### PR DESCRIPTION
Now that CPython 3.12 has been officially released, use `3.12` rather than `3.12-dev` with `setup-python` in CI.