### PR TITLE
Add new functions dechunk_lines and dechunk_filled

### DIFF
--- a/docs/api/top.rst
+++ b/docs/api/top.rst
@@ -12,6 +12,10 @@ contourpy
 
 .. autofunction:: contour_generator
 
+.. autofunction:: dechunk_filled
+
+.. autofunction:: dechunk_lines
+
 .. autofunction:: max_threads
 
 

--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -10,6 +10,7 @@ from contourpy._contourpy import (
 )
 from contourpy._version import __version__
 from contourpy.chunk import calc_chunk_sizes
+from contourpy.dechunk import dechunk_filled, dechunk_lines
 from contourpy.enum_util import as_fill_type, as_line_type, as_z_interp
 
 if TYPE_CHECKING:
@@ -22,6 +23,8 @@ if TYPE_CHECKING:
 __all__ = [
     "__version__",
     "contour_generator",
+    "dechunk_filled",
+    "dechunk_lines",
     "max_threads",
     "FillType",
     "LineType",

--- a/lib/contourpy/_contourpy.pyi
+++ b/lib/contourpy/_contourpy.pyi
@@ -24,14 +24,16 @@ FillReturn_ChunkCombinedCode: TypeAlias = tuple[list[PointArray | None], list[Co
 FillReturn_ChunkCombinedOffset: TypeAlias = tuple[list[PointArray | None], list[OffsetArray | None]]
 FillReturn_ChunkCombinedCodeOffset: TypeAlias = tuple[list[PointArray | None], list[CodeArray | None], list[OffsetArray | None]]
 FillReturn_ChunkCombinedOffsetOffset: TypeAlias = tuple[list[PointArray | None], list[OffsetArray | None], list[OffsetArray | None]]
-FillReturn: TypeAlias = FillReturn_OuterCode | FillReturn_OuterOffset | FillReturn_ChunkCombinedCode | FillReturn_ChunkCombinedOffset | FillReturn_ChunkCombinedCodeOffset | FillReturn_ChunkCombinedOffsetOffset
+FillReturn_Chunk: TypeAlias = FillReturn_ChunkCombinedCode | FillReturn_ChunkCombinedOffset | FillReturn_ChunkCombinedCodeOffset | FillReturn_ChunkCombinedOffsetOffset
+FillReturn: TypeAlias = FillReturn_OuterCode | FillReturn_OuterOffset | FillReturn_Chunk
 
 # Types returned from lines()
 LineReturn_Separate: TypeAlias = list[PointArray]
 LineReturn_SeparateCode: TypeAlias = tuple[list[PointArray], list[CodeArray]]
 LineReturn_ChunkCombinedCode: TypeAlias = tuple[list[PointArray | None], list[CodeArray | None]]
 LineReturn_ChunkCombinedOffset: TypeAlias = tuple[list[PointArray | None], list[OffsetArray | None]]
-LineReturn: TypeAlias = LineReturn_Separate | LineReturn_SeparateCode | LineReturn_ChunkCombinedCode | LineReturn_ChunkCombinedOffset
+LineReturn_Chunk: TypeAlias = LineReturn_ChunkCombinedCode | LineReturn_ChunkCombinedOffset
+LineReturn: TypeAlias = LineReturn_Separate | LineReturn_SeparateCode | LineReturn_Chunk
 
 
 NDEBUG: int

--- a/lib/contourpy/dechunk.py
+++ b/lib/contourpy/dechunk.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+
+from contourpy import FillType, LineType
+from contourpy.enum_util import as_fill_type, as_line_type
+
+if TYPE_CHECKING:
+    import contourpy._contourpy as cpy
+
+
+def _concat_codes(chunk_codes_or_none: list[cpy.CodeArray | None]) -> cpy.CodeArray | None:
+    chunk_codes = [chunk for chunk in chunk_codes_or_none if chunk is not None]
+    if not chunk_codes:
+        return None
+    return np.concatenate(chunk_codes)
+
+
+def _concat_offsets(chunk_offsets_or_none: list[cpy.OffsetArray | None]) -> cpy.OffsetArray | None:
+    chunk_offsets = [chunk for chunk in chunk_offsets_or_none if chunk is not None]
+    if not chunk_offsets:
+        return None
+    nchunks = len(chunk_offsets)
+    cumulative_offsets = np.cumsum([offsets[-1] for offsets in chunk_offsets])
+    ret: cpy.OffsetArray = np.concatenate(
+        (chunk_offsets[0],
+         *(chunk_offsets[i+1][1:] + cumulative_offsets[i] for i in range(nchunks-1)))
+    )
+    return ret
+
+
+def _concat_points(chunk_points_or_none: list[cpy.PointArray | None]) -> cpy.PointArray | None:
+    chunk_points = [chunk for chunk in chunk_points_or_none if chunk is not None]
+    if not chunk_points:
+        return None
+    return np.concatenate(chunk_points)
+
+
+def dechunk_filled(filled: cpy.FillReturn, fill_type: FillType | str) -> cpy.FillReturn:
+    """Return the specified filled contours with all chunked data moved into the first chunk.
+
+    Filled contours that are not chunked (``FillType.OuterCode`` and ``FillType.OuterOffset``) and
+    those that are but only contain a single chunk are returned unmodified. Individual polygons are
+    unchanged, they are not geometrically combined.
+
+    Args:
+        filled (sequence of arrays): Filled contour data as returned by
+            :func:`~contourpy.ContourGenerator.filled`.
+        fill_type (FillType or str): Type of ``filled`` as enum or string equivalent.
+
+    Return:
+        Filled contours in a single chunk.
+
+    .. versionadded:: 1.1.2
+    """
+    fill_type = as_fill_type(fill_type)
+
+    if fill_type in (FillType.OuterCode, FillType.OuterOffset) or len(filled[0]) < 2:
+        # No-op if fill_type is not chunked or there is just one chunk.
+        return filled
+
+    if TYPE_CHECKING:
+        filled = cast(cpy.FillReturn_Chunk, filled)
+    points = _concat_points(filled[0])
+
+    if fill_type == FillType.ChunkCombinedCode:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedCode, filled)
+        if points is None:
+            ret1: cpy.FillReturn_ChunkCombinedCode = ([None], [None])
+        else:
+            ret1 = ([points], [_concat_codes(filled[1])])
+        return ret1
+    elif fill_type == FillType.ChunkCombinedOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedOffset, filled)
+        if points is None:
+            ret2: cpy.FillReturn_ChunkCombinedOffset = ([None], [None])
+        else:
+            ret2 = ([points], [_concat_offsets(filled[1])])
+        return ret2
+    elif fill_type == FillType.ChunkCombinedCodeOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedCodeOffset, filled)
+        if points is None:
+            ret3: cpy.FillReturn_ChunkCombinedCodeOffset = ([None], [None], [None])
+        else:
+            ret3 = ([points], [_concat_codes(filled[1])], [_concat_offsets(filled[2])])
+        return ret3
+    elif fill_type == FillType.ChunkCombinedOffsetOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedOffsetOffset, filled)
+        if points is None:
+            ret4: cpy.FillReturn_ChunkCombinedOffsetOffset = ([None], [None], [None])
+        else:
+            ret4 = ([points], [_concat_offsets(filled[1])], [_concat_offsets(filled[2])])
+        return ret4
+    else:
+        raise ValueError(f"Invalid FillType {fill_type}")
+
+
+def dechunk_lines(lines: cpy.LineReturn, line_type: LineType | str) -> cpy.LineReturn:
+    """Return the specified contour lines with all chunked data moved into the first chunk.
+
+    Contour lines that are not chunked (``LineType.Separate`` and ``LineType.SeparateCode``) and
+    those that are but only contain a single chunk are returned unmodified. Individual lines are
+    unchanged, they are not geometrically combined.
+
+    Args:
+        lines (sequence of arrays): Contour line data as returned by
+            :func:`~contourpy.ContourGenerator.lines`.
+        line_type (LineType or str): Type of ``lines`` as enum or string equivalent.
+
+    Return:
+        Contour lines in a single chunk.
+
+    .. versionadded:: 1.1.2
+    """
+    line_type = as_line_type(line_type)
+
+    if line_type in (LineType.Separate, LineType.SeparateCode) or len(lines[0]) < 2:
+        # No-op if line_type is not chunked or there is just one chunk.
+        return lines
+
+    if TYPE_CHECKING:
+        lines = cast(cpy.LineReturn_Chunk, lines)
+    points = _concat_points(lines[0])
+
+    if line_type == LineType.ChunkCombinedCode:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_ChunkCombinedCode, lines)
+        if points is None:
+            ret1: cpy.LineReturn_ChunkCombinedCode = ([None], [None])
+        else:
+            ret1 = ([points], [_concat_codes(lines[1])])
+        return ret1
+    elif line_type == LineType.ChunkCombinedOffset:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_ChunkCombinedOffset, lines)
+        if points is None:
+            ret2: cpy.LineReturn_ChunkCombinedOffset = ([None], [None])
+        else:
+            ret2 = ([points], [_concat_offsets(lines[1])])
+        return ret2
+    else:
+        raise ValueError(f"Invalid LineType {line_type}")

--- a/lib/contourpy/meson.build
+++ b/lib/contourpy/meson.build
@@ -2,6 +2,7 @@ python_sources = [
   '__init__.py',
   '_version.py',
   'chunk.py',
+  'dechunk.py',
   'enum_util.py',
   '_contourpy.pyi',
   'py.typed',

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -98,7 +98,7 @@ class MplRenderer(Renderer):
             filled (sequence of arrays): Filled contour data as returned by
                 :func:`~contourpy.ContourGenerator.filled`.
             fill_type (FillType or str): Type of ``filled`` data as returned by
-                :attr:`~contourpy.ContourGenerator.fill_type`, or a string equivalent
+                :attr:`~contourpy.ContourGenerator.fill_type`, or string equivalent
             ax (int or Maplotlib Axes, optional): Which axes to plot on, default ``0``.
             color (str, optional): Color to plot with. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the
@@ -175,7 +175,7 @@ class MplRenderer(Renderer):
             lines (sequence of arrays): Contour line data as returned by
                 :func:`~contourpy.ContourGenerator.lines`.
             line_type (LineType or str): Type of ``lines`` data as returned by
-                :attr:`~contourpy.ContourGenerator.line_type`, or a strin equivalent.
+                :attr:`~contourpy.ContourGenerator.line_type`, or string equivalent.
             ax (int or Matplotlib Axes, optional): Which Axes to plot on, default ``0``.
             color (str, optional): Color to plot lines. May be a string color or the letter ``"C"``
                 followed by an integer in the range ``"C0"`` to ``"C9"`` to use a color from the

--- a/src/fill_type.h
+++ b/src/fill_type.h
@@ -9,10 +9,10 @@ namespace contourpy {
 // C++11 scoped enum, must be fully qualified to use.
 enum class FillType
 {
-    OuterCode= 201,
+    OuterCode = 201,
     OuterOffset = 202,
     ChunkCombinedCode = 203,
-    ChunkCombinedOffset= 204,
+    ChunkCombinedOffset = 204,
     ChunkCombinedCodeOffset = 205,
     ChunkCombinedOffsetOffset = 206,
 };

--- a/src/line_type.h
+++ b/src/line_type.h
@@ -12,7 +12,7 @@ enum class LineType
     Separate = 101,
     SeparateCode = 102,
     ChunkCombinedCode = 103,
-    ChunkCombinedOffset= 104,
+    ChunkCombinedOffset = 104,
 };
 
 std::ostream &operator<<(std::ostream &os, const LineType& line_type);

--- a/tests/test_dechunk.py
+++ b/tests/test_dechunk.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
+import pytest
+
+from contourpy import FillType, LineType, contour_generator, dechunk_filled, dechunk_lines
+
+from . import util_test
+
+if TYPE_CHECKING:
+    import contourpy._contourpy as cpy
+
+
+@pytest.fixture
+def z() -> cpy.CoordinateArray:
+    return np.array([[0, 1, 0, 0, 0],
+                     [0, 1, 0, 0, 0],
+                     [0, 1, 0, 0, 0],
+                     [0, 2, 0, 1, 0],
+                     [0, 0, 0, 0, 0]], dtype=np.float64)
+
+
+@pytest.mark.parametrize("fill_type", FillType.__members__.values())
+@pytest.mark.parametrize("chunk_size", (0, 2))
+def test_dechunk_filled(z: cpy.CoordinateArray, fill_type: FillType, chunk_size: int) -> None:
+    cont_gen = contour_generator(z=z, fill_type=fill_type, chunk_size=chunk_size)
+    assert cont_gen.chunk_count == ((2, 2) if chunk_size==2 else (1, 1))
+    filled = cont_gen.filled(0.5, 1.5)
+
+    dechunked = dechunk_filled(filled, fill_type)
+    util_test.assert_filled(dechunked, fill_type)
+
+    if chunk_size == 0 or fill_type in (FillType.OuterCode, FillType.OuterOffset):
+        # Dechunking is a no-op for non-chunked fill types.
+        assert dechunked == filled
+    else:
+        nchunks = len(dechunked[0])
+        assert nchunks == 1
+
+        # Note it is important that this contains a polygon with a hole,
+        # and using chunk_size=2 there is an empty chunk.
+        expected_points = np.array([
+            [0.5, 0], [1, 0], [1.5, 0], [1.5, 1], [1.5, 2], [1, 2], [0.5, 2], [0.5, 1], [0.5, 0],
+            [0.5, 2], [1, 2], [1.5, 2], [1.75, 3], [1, 3.75], [0.25, 3], [0.5, 2], [1, 2.5],
+            [0.75, 3], [1, 3.25], [1.25, 3], [1, 2.5], [2.5, 3], [3, 2.5], [3.5, 3], [3, 3.5],
+            [2.5, 3]])
+        expected_codes = np.array([1, 2, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79,
+                                   1, 2, 2, 2, 79])
+        expected_offsets = np.array([0, 9, 16, 21, 26])
+
+        assert dechunked[0][0] is not None
+        assert_allclose(dechunked[0][0], expected_points)
+
+        if fill_type == FillType.ChunkCombinedCode:
+            if TYPE_CHECKING:
+                dechunked = cast(cpy.FillReturn_ChunkCombinedCode, dechunked)
+            assert dechunked[1][0] is not None
+            assert_array_equal(dechunked[1][0], expected_codes)
+        elif fill_type == FillType.ChunkCombinedOffset:
+            if TYPE_CHECKING:
+                dechunked = cast(cpy.FillReturn_ChunkCombinedOffset, dechunked)
+            assert dechunked[1][0] is not None
+            assert_array_equal(dechunked[1][0], expected_offsets)
+        elif fill_type == FillType.ChunkCombinedCodeOffset:
+            if TYPE_CHECKING:
+                dechunked = cast(cpy.FillReturn_ChunkCombinedCodeOffset, dechunked)
+            assert dechunked[1][0] is not None
+            assert_array_equal(dechunked[1][0], expected_codes)
+            assert dechunked[2][0] is not None
+            assert_array_equal(dechunked[2][0], [0, 9, 21, 26])
+        elif fill_type == FillType.ChunkCombinedOffsetOffset:
+            if TYPE_CHECKING:
+                dechunked = cast(cpy.FillReturn_ChunkCombinedOffsetOffset, dechunked)
+            assert dechunked[1][0] is not None
+            assert_array_equal(dechunked[1][0], expected_offsets)
+            assert dechunked[2][0] is not None
+            assert_array_equal(dechunked[2][0], [0, 1, 3, 4])
+        else:
+            raise RuntimeError(f"Unexpected fill_type {fill_type}")
+
+
+@pytest.mark.parametrize("fill_type", FillType.__members__.values())
+@pytest.mark.parametrize("chunk_size", (0, 1))
+def test_dechunk_filled_empty(z: cpy.CoordinateArray, fill_type: FillType, chunk_size: int) -> None:
+    cont_gen = contour_generator(z=z, fill_type=fill_type, chunk_size=chunk_size)
+    filled = cont_gen.filled(3, 4)
+
+    dechunked = dechunk_filled(filled, fill_type)
+    util_test.assert_filled(dechunked, fill_type)
+
+    if fill_type in (FillType.OuterCode, FillType.OuterOffset):
+        assert dechunked == ([], [])
+    elif fill_type in (FillType.ChunkCombinedCode, FillType.ChunkCombinedOffset):
+        assert dechunked == ([None], [None])
+    elif fill_type in (FillType.ChunkCombinedCodeOffset, FillType.ChunkCombinedOffsetOffset):
+        assert dechunked == ([None], [None], [None])
+    else:
+        raise RuntimeError(f"Unexpected fill_type {fill_type}")
+
+
+@pytest.mark.parametrize("line_type", LineType.__members__.values())
+@pytest.mark.parametrize("chunk_size", (0, 2))
+def test_dechunk_lines(z: cpy.CoordinateArray, line_type: LineType, chunk_size: int) -> None:
+    cont_gen = contour_generator(z=z, line_type=line_type, chunk_size=chunk_size)
+    assert cont_gen.chunk_count == ((2, 2) if chunk_size==2 else (1, 1))
+    lines = cont_gen.lines(0.5)
+
+    dechunked = dechunk_lines(lines, line_type)
+    util_test.assert_lines(dechunked, line_type)
+
+    if chunk_size == 0 or line_type in (LineType.Separate, LineType.SeparateCode):
+        # Dechunking is a no-op for non-chunked line types.
+        assert dechunked == lines
+    else:
+        nchunks = len(dechunked[0])
+        assert nchunks == 1
+
+        # Note it is important that this contains a closed line loop as well as open line strips,
+        # and using chunk_size=2 there is an empty chunk.
+        expected_points = np.array([
+            [1.5, 0], [1.5, 1], [1.5, 2], [0.5, 2], [0.5, 1], [0.5, 0], [1.5, 2], [1.75, 3],
+            [1, 3.75], [0.25, 3], [0.5, 2], [2.5, 3], [3, 2.5], [3.5, 3], [3, 3.5], [2.5, 3]])
+        expected_codes = np.array([1, 2, 2, 1, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2, 2, 79])
+        expected_offsets = np.array([ 0, 3, 6, 11, 16])
+
+        assert dechunked[0][0] is not None
+        assert_allclose(dechunked[0][0], expected_points)
+
+        if line_type == LineType.ChunkCombinedCode:
+            assert dechunked[1][0] is not None
+            assert_array_equal(dechunked[1][0], expected_codes)
+        elif line_type == LineType.ChunkCombinedOffset:
+            assert dechunked[1][0] is not None
+            assert_array_equal(dechunked[1][0], expected_offsets)
+        else:
+            raise RuntimeError(f"Unexpected line_type {line_type}")
+
+
+@pytest.mark.parametrize("line_type", LineType.__members__.values())
+@pytest.mark.parametrize("chunk_size", (0, 1))
+def test_dechunk_lines_empty(z: cpy.CoordinateArray, line_type: LineType, chunk_size: int) -> None:
+    cont_gen = contour_generator(z=z, line_type=line_type, chunk_size=chunk_size)
+    lines = cont_gen.lines(4)
+
+    dechunked = dechunk_lines(lines, line_type)
+    util_test.assert_lines(dechunked, line_type)
+
+    if line_type == LineType.Separate:
+        assert dechunked == []
+    elif line_type == LineType.SeparateCode:
+        assert dechunked == ([], [])
+    elif line_type in (LineType.ChunkCombinedCode, LineType.ChunkCombinedOffset):
+        assert dechunked == ([None], [None])
+    else:
+        raise RuntimeError(f"Unexpected line_type {line_type}")


### PR DESCRIPTION
Adding two new functions `dechunk_lines` and `dechunk_filled`, which accept any `lines` or `filled` respectively and move the 2nd and subsequent chunks, if present, into the first chunk. These will be useful for upcoming examples of using ContourPy output with other libraries.

User guide docs will follow in a separate PR.