### PR TITLE
Use better names for enums when reporting parameterised tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 import pytest
 
+from contourpy import FillType, LineType, ZInterp
+
 if TYPE_CHECKING:
     from _pytest.fixtures import SubRequest
 
@@ -39,6 +41,13 @@ def pytest_collection_modifyitems(config: pytest.Config, items: Sequence[Any]) -
         for item in items:
             if "text" in item.keywords and item.callspec.getparam("show_text"):
                 item.add_marker(skip_text)
+
+
+def pytest_make_parametrize_id(config: pytest.Config, val: Any, argname: str) -> str | None:
+    # Override names used for enums in tests.
+    if isinstance(val, (FillType, LineType, ZInterp)):
+        return val.name
+    return None
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Use better names for enums when reporting parameterised tests via a `pytest_make_parametrize_id` function in `conftest.py`.

Example before:
```
$ pytest -v tests/test_dechunk.py::test_dechunk_lines
tests/test_dechunk.py::test_dechunk_lines[0-line_type0]
tests/test_dechunk.py::test_dechunk_lines[0-line_type1]
tests/test_dechunk.py::test_dechunk_lines[0-line_type2]
tests/test_dechunk.py::test_dechunk_lines[0-line_type3]
tests/test_dechunk.py::test_dechunk_lines[2-line_type0]
tests/test_dechunk.py::test_dechunk_lines[2-line_type1]
tests/test_dechunk.py::test_dechunk_lines[2-line_type2]
tests/test_dechunk.py::test_dechunk_lines[2-line_type3]
```

and after:
```
$ pytest -v tests/test_dechunk.py::test_dechunk_lines
tests/test_dechunk.py::test_dechunk_lines[0-Separate]
tests/test_dechunk.py::test_dechunk_lines[0-SeparateCode]
tests/test_dechunk.py::test_dechunk_lines[0-ChunkCombinedCode]
tests/test_dechunk.py::test_dechunk_lines[0-ChunkCombinedOffset]
tests/test_dechunk.py::test_dechunk_lines[2-Separate]
tests/test_dechunk.py::test_dechunk_lines[2-SeparateCode]
tests/test_dechunk.py::test_dechunk_lines[2-ChunkCombinedCode]
tests/test_dechunk.py::test_dechunk_lines[2-ChunkCombinedOffset]
```