### PR TITLE
Add new LineType ChunkCombinedNan

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,7 @@ rst_epilog = """
 .. _Bokeh: https://bokeh.org/
 .. _Clang: https://clang.llvm.org/
 .. _GCC: https://gcc.gnu.org/
+.. _HoloViews: https://holoviews.org/
 .. _Matplotlib: https://matplotlib.org/
 .. _MSVC: https://visualstudio.microsoft.com/
 .. _NumPy: https://numpy.org/

--- a/docs/user_guide/line_type.rst
+++ b/docs/user_guide/line_type.rst
@@ -24,6 +24,7 @@ Enum members are a combination of the following words:
 - **Chunk**: each chunk is separate, and is ``None`` if the chunk has no lines.
 - **Code**: includes `Matplotlib`_ kind codes for the previous line array.
 - **Offset**: individual lines are identified via offsets into the previous line array.
+- **Nan**: individual lines are separated by NaN (Not a Number).
 
 The format of data returned by :func:`~contourpy.ContourGenerator.lines` for each of the
 possible :class:`~contourpy.LineType` members is best illustrated through an example.
@@ -130,6 +131,23 @@ For chunk ``j`` the combined points are ``lines[0][j]`` and the combined offsets
 ``lines[1][j]``. An empty chunk has ``None`` for each. In this example the first line corresponds
 to point indices ``0:5`` and the second to ``5:7``. The length of the offset array is one more than
 the number of lines.
+
+ChunkCombinedNan
+^^^^^^^^^^^^^^^^^
+   >>> cont_gen = contour_generator(z=z, line_type=LineType.ChunkCombinedNan)
+   >>> lines = cont_gen.lines(2)
+   >>> lines
+   ([array([[0.58, 1.], [1., 0.44], [1.38, 1.], [1., 1.36], [0.58, 1.], [nan, nan], [2.6, 2.], [3., 1.57]])])
+
+This returns a tuple of a single list. The list contains a 2D ``np.float64`` array for each chunk
+containing the combined points for all lines in that chunk, with ``numpy.nan`` used as separators
+between adjacent lines. A tuple is used here for consistency with all of the other ``ChunkCombined``
+line types.
+
+For chunk ``j`` the combined nan-separated points are in ``lines[0][j]``. An empty chunk has
+``None`` instead.
+
+This is the line type used internally by `Bokeh`_ and `HoloViews`_.
 
 How to choose which line type to use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/contourpy/_contourpy.pyi
+++ b/lib/contourpy/_contourpy.pyi
@@ -32,7 +32,8 @@ LineReturn_Separate: TypeAlias = list[PointArray]
 LineReturn_SeparateCode: TypeAlias = tuple[list[PointArray], list[CodeArray]]
 LineReturn_ChunkCombinedCode: TypeAlias = tuple[list[PointArray | None], list[CodeArray | None]]
 LineReturn_ChunkCombinedOffset: TypeAlias = tuple[list[PointArray | None], list[OffsetArray | None]]
-LineReturn_Chunk: TypeAlias = LineReturn_ChunkCombinedCode | LineReturn_ChunkCombinedOffset
+LineReturn_ChunkCombinedNan: TypeAlias = tuple[list[PointArray | None]]
+LineReturn_Chunk: TypeAlias = LineReturn_ChunkCombinedCode | LineReturn_ChunkCombinedOffset | LineReturn_ChunkCombinedNan
 LineReturn: TypeAlias = LineReturn_Separate | LineReturn_SeparateCode | LineReturn_Chunk
 
 
@@ -63,6 +64,7 @@ class FillType:
 
 class LineType:
     ChunkCombinedCode: ClassVar[cpy.LineType]
+    ChunkCombinedNan: ClassVar[cpy.LineType]
     ChunkCombinedOffset: ClassVar[cpy.LineType]
     Separate: ClassVar[cpy.LineType]
     SeparateCode: ClassVar[cpy.LineType]

--- a/lib/contourpy/util/bokeh_util.py
+++ b/lib/contourpy/util/bokeh_util.py
@@ -84,6 +84,12 @@ def lines_to_bokeh(
                 line = points[offsets[i]:offsets[i+1]]
                 xs.append(line[:, 0])
                 ys.append(line[:, 1])
+    elif line_type == LineType.ChunkCombinedNan:
+        for points in lines[0]:
+            if points is None:
+                continue
+            xs.append(points[:, 0])
+            ys.append(points[:, 1])
     else:
         raise RuntimeError(f"Conversion of LineType {line_type} to Bokeh is not implemented")
 

--- a/lib/contourpy/util/mpl_util.py
+++ b/lib/contourpy/util/mpl_util.py
@@ -60,6 +60,18 @@ def lines_to_mpl_paths(lines: LineReturn, line_type: LineType) -> list[mpath.Pat
                 line = points[offsets[i]:offsets[i+1]]
                 closed = line[0, 0] == line[-1, 0] and line[0, 1] == line[-1, 1]
                 paths.append(mpath.Path(line, closed=closed))
+    elif line_type == LineType.ChunkCombinedNan:
+        paths = []
+        for points in lines[0]:
+            if points is None:
+                continue
+            nan_offsets = np.nonzero(np.isnan(points[:, 0]))[0]
+            nan_offsets = \
+                np.concatenate(([-1], nan_offsets, [len(points)]))  # type: ignore[arg-type]
+            for s, e in zip(nan_offsets[:-1], nan_offsets[1:]):
+                line = points[s+1:e]
+                closed = line[0, 0] == line[-1, 0] and line[0, 1] == line[-1, 1]
+                paths.append(mpath.Path(line, closed=closed))
     else:
         raise RuntimeError(f"Conversion of LineType {line_type} to MPL Paths is not implemented")
     return paths

--- a/src/base.h
+++ b/src/base.h
@@ -202,6 +202,7 @@ private:
     bool _direct_line_offsets;        // Whether line offsets array is written direct to Python.
     bool _direct_outer_offsets;       // Whether outer offsets array is written direct to Python.
     bool _outer_offsets_into_points;  // Otherwise into line offsets.  Only used if _identify_holes.
+    bool _nan_separated;              // Whether adjacent lines' points are separated by nans.
     unsigned int _return_list_count;
 };
 

--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -3,6 +3,7 @@
 
 #include "base.h"
 #include "converter.h"
+#include "util.h"
 #include <iostream>
 
 namespace contourpy {
@@ -121,6 +122,7 @@ BaseContourGenerator<Derived>::BaseContourGenerator(
       _direct_line_offsets(false),
       _direct_outer_offsets(false),
       _outer_offsets_into_points(false),
+      _nan_separated(false),
       _return_list_count(0)
 {
     if (_x.ndim() != 2 || _y.ndim() != 2 || _z.ndim() != 2)
@@ -367,6 +369,7 @@ py::sequence BaseContourGenerator<Derived>::filled(double lower_level, double up
     _direct_outer_offsets = (_fill_type == FillType::ChunkCombinedCodeOffset ||
                              _fill_type == FillType::ChunkCombinedOffsetOffset);
     _outer_offsets_into_points = (_fill_type == FillType::ChunkCombinedCodeOffset);
+    _nan_separated = false;
     _return_list_count = (_fill_type == FillType::ChunkCombinedCodeOffset ||
                           _fill_type == FillType::ChunkCombinedOffsetOffset) ? 3 : 2;
 
@@ -1911,6 +1914,12 @@ void BaseContourGenerator<Derived>::line(const Location& start_location, ChunkLo
     Location location = start_location;
     count_t point_count = 0;
 
+    // Insert nan if required before start of new line.
+    if (_nan_separated and local.pass > 0 && local.line_count > 0) {
+        *local.points.current++ = Util::nan;
+        *local.points.current++ = Util::nan;
+    }
+
     // finished == true indicates closed line loop.
     bool finished = follow_interior(location, start_location, local, point_count);
 
@@ -1942,7 +1951,12 @@ py::sequence BaseContourGenerator<Derived>::lines(double level)
     _direct_line_offsets = (_line_type == LineType::ChunkCombinedOffset);
     _direct_outer_offsets = false;
     _outer_offsets_into_points = false;
-    _return_list_count = (_line_type == LineType::Separate) ? 1 : 2;
+    _return_list_count = (_line_type == LineType::Separate ||
+                          _line_type == LineType::ChunkCombinedNan) ? 1 : 2;
+    _nan_separated = (_line_type == LineType::ChunkCombinedNan);
+
+    if (_nan_separated)
+        Util::ensure_nan_loaded();
 
     return march_wrapper();
 }
@@ -2073,6 +2087,14 @@ void BaseContourGenerator<Derived>::march_chunk(
         if (j_final_start < local.jend)
             _cache[local.istart + (j_final_start+1)*_nx] |= MASK_NO_MORE_STARTS;
 
+        if (_nan_separated && local.line_count > 1) {
+            // If _nan_separated, each line after the first has an extra nan to separate it from the
+            // previous line's points. If we were returning line offsets to the caller then this
+            // would need to occur in line() where the line_count is incremented. But as we are not
+            // returning line offsets it is faster just to add the extra here all at once.
+            local.total_point_count += local.line_count - 1;
+        }
+
         if (local.pass == 0) {
             if (local.total_point_count == 0) {
                 local.points.clear();
@@ -2169,8 +2191,13 @@ py::sequence BaseContourGenerator<Derived>::march_wrapper()
 
     // Return to python objects.
     if (_return_list_count == 1) {
-        assert(!_filled && _line_type == LineType::Separate);
-        return return_lists[0];
+        assert(!_filled);
+        if (_line_type == LineType::Separate)
+            return return_lists[0];
+        else {
+            assert(_line_type == LineType::ChunkCombinedNan);
+            return py::make_tuple(return_lists[0]);
+        }
     }
     else if (_return_list_count == 2)
         return py::make_tuple(return_lists[0], return_lists[1]);
@@ -2384,6 +2411,7 @@ bool BaseContourGenerator<Derived>::supports_line_type(LineType line_type)
         case LineType::SeparateCode:
         case LineType::ChunkCombinedCode:
         case LineType::ChunkCombinedOffset:
+        case LineType::ChunkCombinedNan:
             return true;
         default:
             return false;

--- a/src/chunk_local.h
+++ b/src/chunk_local.h
@@ -21,7 +21,7 @@ struct ChunkLocal
     int pass;
 
     // Data for whole pass.
-    count_t total_point_count;
+    count_t total_point_count;           // Includes nan separators if used.
     count_t line_count;                  // Count of all lines
     count_t hole_count;                  // Count of holes only.
 

--- a/src/line_type.cpp
+++ b/src/line_type.cpp
@@ -18,6 +18,9 @@ std::ostream &operator<<(std::ostream &os, const LineType& line_type)
         case LineType::ChunkCombinedOffset:
             os << "ChunkCombinedOffset";
             break;
+        case LineType::ChunkCombinedNan:
+            os << "ChunkCombinedNan";
+            break;
     }
     return os;
 }

--- a/src/line_type.h
+++ b/src/line_type.h
@@ -13,6 +13,7 @@ enum class LineType
     SeparateCode = 102,
     ChunkCombinedCode = 103,
     ChunkCombinedOffset = 104,
+    ChunkCombinedNan = 105,
 };
 
 std::ostream &operator<<(std::ostream &os, const LineType& line_type);

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -115,6 +115,10 @@ void SerialContourGenerator::export_lines(
             // return_lists[0][local.chunk] already contains points.
             // return_lists[1][local.chunk] already contains line offsets.
             break;
+        case LineType::ChunkCombinedNan:
+            assert(has_direct_points());
+            // return_lists[0][local.chunk] already contains points.
+            break;
     }
 }
 

--- a/src/threaded.cpp
+++ b/src/threaded.cpp
@@ -208,6 +208,10 @@ void ThreadedContourGenerator::export_lines(
             // return_lists[0][local.chunk] already contains points.
             // return_lists[1][local.chunk] already contains line offsets.
             break;
+        case LineType::ChunkCombinedNan:
+            assert(has_direct_points());
+            // return_lists[0][local.chunk] already contains points.
+            break;
     }
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,6 +3,19 @@
 
 namespace contourpy {
 
+bool Util::_nan_loaded = false;
+
+double Util::nan = 0.0;
+
+void Util::ensure_nan_loaded()
+{
+    if (!_nan_loaded) {
+        auto numpy = py::module_::import("numpy");
+        nan = numpy.attr("nan").cast<double>();
+        _nan_loaded = true;
+    }
+}
+
 index_t Util::get_max_threads()
 {
     return static_cast<index_t>(std::thread::hardware_concurrency());

--- a/src/util.h
+++ b/src/util.h
@@ -8,7 +8,20 @@ namespace contourpy {
 class Util
 {
 public:
+    static void ensure_nan_loaded();
+
     static index_t get_max_threads();
+
+    // This is the NaN used internally and returned to calling functions. The value is taken from
+    // numpy rather than the standard C++ approach so that it is guaranteed to work with
+    // numpy.isnan(). The value is actually the same for many platforms, but this approach
+    // guarantees it works for all platforms that numpy supports.
+    //
+    // ensure_nan_loaded() must be called before this value is read.
+    static double nan;
+
+private:
+    static bool _nan_loaded;
 };
 
 } // namespace contourpy

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -53,11 +53,13 @@ PYBIND11_MODULE(_contourpy, m) {
     py::enum_<contourpy::LineType>(m, "LineType",
         "Enum used for ``line_type`` keyword argument in :func:`~contourpy.contour_generator`.\n\n"
         "This controls the format of contour line data returned from "
-        ":meth:`~contourpy.ContourGenerator.lines`.")
+        ":meth:`~contourpy.ContourGenerator.lines`.\n\n"
+        "``LineType.ChunkCombinedNan`` added in version 1.2.0")
         .value("Separate", contourpy::LineType::Separate)
         .value("SeparateCode", contourpy::LineType::SeparateCode)
         .value("ChunkCombinedCode", contourpy::LineType::ChunkCombinedCode)
         .value("ChunkCombinedOffset", contourpy::LineType::ChunkCombinedOffset)
+        .value("ChunkCombinedNan", contourpy::LineType::ChunkCombinedNan)
         .export_values();
 
     py::enum_<contourpy::ZInterp>(m, "ZInterp",

--- a/tests/test_dechunk.py
+++ b/tests/test_dechunk.py
@@ -126,15 +126,26 @@ def test_dechunk_lines(z: cpy.CoordinateArray, line_type: LineType, chunk_size: 
         expected_codes = np.array([1, 2, 2, 1, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2, 2, 79])
         expected_offsets = np.array([0, 3, 6, 11, 16])
 
-        assert dechunked[0][0] is not None
-        assert_allclose(dechunked[0][0], expected_points)
-
         if line_type == LineType.ChunkCombinedCode:
+            if TYPE_CHECKING:
+                dechunked = cast(cpy.LineReturn_ChunkCombinedCode, dechunked)
+            assert dechunked[0][0] is not None
+            assert_allclose(dechunked[0][0], expected_points)
             assert dechunked[1][0] is not None
             assert_array_equal(dechunked[1][0], expected_codes)
         elif line_type == LineType.ChunkCombinedOffset:
+            if TYPE_CHECKING:
+                dechunked = cast(cpy.LineReturn_ChunkCombinedOffset, dechunked)
+            assert dechunked[0][0] is not None
+            assert_allclose(dechunked[0][0], expected_points)
             assert dechunked[1][0] is not None
             assert_array_equal(dechunked[1][0], expected_offsets)
+        elif line_type == LineType.ChunkCombinedNan:
+            if TYPE_CHECKING:
+                dechunked = cast(cpy.LineReturn_ChunkCombinedNan, dechunked)
+            assert dechunked[0][0] is not None
+            expected = np.insert(expected_points, expected_offsets[1:-1], [np.nan, np.nan], axis=0)
+            assert_allclose(dechunked[0][0], expected)
         else:
             raise RuntimeError(f"Unexpected line_type {line_type}")
 
@@ -154,5 +165,7 @@ def test_dechunk_lines_empty(z: cpy.CoordinateArray, line_type: LineType, chunk_
         assert dechunked == ([], [])
     elif line_type in (LineType.ChunkCombinedCode, LineType.ChunkCombinedOffset):
         assert dechunked == ([None], [None])
+    elif line_type == LineType.ChunkCombinedNan:
+        assert dechunked == ([None],)
     else:
         raise RuntimeError(f"Unexpected line_type {line_type}")

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -692,6 +692,14 @@ def test_return_by_line_type(
         assert offsets_or_none is not None
         assert points_or_none.shape == (7, 2)
         assert_array_equal(offsets_or_none, [0, 5, 7])
+    elif line_type == LineType.ChunkCombinedNan:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_ChunkCombinedNan, lines)
+        assert len(lines[0]) == 1  # Single chunk
+        points_or_none = lines[0][0]
+        assert points_or_none is not None
+        assert points_or_none.shape == (8, 2)
+        assert np.all(np.isnan(points_or_none[5, :]))
     else:
         raise RuntimeError(f"Unexpected line_type {line_type}")
 
@@ -769,6 +777,15 @@ def test_return_by_line_type_chunk(
             assert offsets_or_none is not None
             assert_allclose(points_or_none, expected[chunk])
             assert_array_equal(offsets_or_none, [0, len(expected[chunk])])
+    elif line_type == LineType.ChunkCombinedNan:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_ChunkCombinedNan, lines)
+        assert len(lines[0]) == 4
+        for chunk in range(4):
+            # Only a single line per chunk, so no nans here.
+            points_or_none = lines[0][chunk]
+            assert points_or_none is not None
+            assert_allclose(points_or_none, expected[chunk])
     else:
         raise RuntimeError(f"Unexpected line_type {line_type}")
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,13 +2,21 @@ from __future__ import annotations
 
 import numpy as np
 
-from contourpy import _remove_z_mask, max_threads
+from contourpy import _remove_z_mask, contour_generator, max_threads
 
 
 def test_max_threads() -> None:
     n = max_threads()
     # Assume testing on machine with 2 or more cores.
     assert n > 1
+
+
+def test_nan() -> None:
+    # Test that the nan used by contourpy is numpy.nan.
+    cont_gen = contour_generator(z=[[0, 1], [1, 0]], line_type="ChunkCombinedNan")
+    lines = cont_gen.lines(0.5)
+    assert lines[0][0] is not None
+    assert np.all(np.isnan(lines[0][0][2, :]))
 
 
 def test_remove_z_mask() -> None:


### PR DESCRIPTION
This adds a new `LineType` `ChunkCombinedNan` to the `serial` and `threaded` algorithms which returns a single numpy array per chunk containing the x, y coordinates of all the points in that chunk with lines separated by NaN. This is the internal format used in both Bokeh and HoloViews so it will simplify and improve the performance of those libraries for contour lines. Closes #289.

Example:
```python
from contourpy import contour_generator
z = [[0, 0], [1, 1], [0, 0]]
cont_gen = contour_generator(z=z, line_type="ChunkCombinedNan")
cont_gen.lines(0.5)
```
produces
```
([array([[0. , 0.5],
         [1. , 0.5],
         [nan, nan],
         [1. , 1.5],
         [0. , 1.5]])],)
```
The returned tuple only ever contains one list so strictly speaking the tuple is not required, but it is used here for consistency with all other `ChunkCombined` line and fill types.

The value of `nan` used is taken from `numpy` when first required rather than the standard C++ NaN value. These are nearly always the same, but this approach ensures that `np.isnan` will give the expected results on all platforms and compliers that numpy supports.

To do (in separate PRs):

1. Add to benchmarks.
2. Consider removing line offset calculation and storage for this line type. Currently they are always calculated and stored even though this is not necessary for `ChunkCombinedNan`. This needs investigating and the effect of performance measured.