### PR TITLE
Remove threaded experimental warnings

### DIFF
--- a/docs/benchmarks/threads.rst
+++ b/docs/benchmarks/threads.rst
@@ -51,10 +51,3 @@ before they can allocate arrays.
    only needed for rendering using the `Matplotlib`_ Agg renderer, then for complicated problems the
    rendering time usually far exceeds the calculation time so a reduction in calculation time may
    not be of much real-world benefit.
-
-.. warning::
-
-   The threaded algorithm is work in progress and should be considered experimental.  It works fine
-   in an isolated environment using the ``contourpy`` tests and benchmarks, but needs to be
-   rigorously tested in real-world environments that that include mixed Python/C++ code and multiple
-   threads before it can be considered production quality.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Advantages of the new algorithm compared to Matplotlib's default algorithm of 20
 #. Supports treating quads a four triangles for more detailed contours (see :ref:`quad_as_tri`).
 #. Supports alternative forms of interpolation of z-values (currently only logarithmic) (see
    :ref:`z_interp`).
-#. Multithreaded option (this should be considered experimental) (see :ref:`threads`).
+#. Multithreaded option (see :ref:`threads`).
 
 .. toctree::
    :maxdepth: 1

--- a/docs/user_guide/name.rst
+++ b/docs/user_guide/name.rst
@@ -59,10 +59,3 @@ into chunks.  It shares the majority of its code with ``serial`` except:
 
 #. High-level processing of chunks occurs in parallel using a thread pool.
 #. Creation of `NumPy`_ arrays is limited to a single thread at a time.
-
-.. warning::
-
-   This algorithm is work in progress and should be considered experimental.  It works fine
-   in an isolated environment using the ``contourpy`` tests and benchmarks, but needs to be
-   rigorously tested in real-world environments that that include mixed Python/C++ code and multiple
-   threads before it can be considered production quality.

--- a/docs/user_guide/threads.rst
+++ b/docs/user_guide/threads.rst
@@ -8,13 +8,6 @@ The ``threaded`` algorithm supports the use of multiple threads.
 .. name_supports::
    :filter: threads
 
-.. warning::
-
-   The threaded algorithm is work in progress and should be considered experimental.  It works fine
-   in an isolated environment using the ``contourpy`` tests and benchmarks, but needs to be
-   rigorously tested in real-world environments that that include mixed Python/C++ code and multiple
-   threads before it can be considered production quality.
-
 ``threaded`` shares most of its code with ``serial`` except for the high-level processing of chunks
 which it performs in parallel using a thread pool, and the creation of `NumPy`_ arrays is limited to
 a single thread at a time.


### PR DESCRIPTION
Removing warnings that the `threaded` algorithm is experimental. It has been around for long enough and used enough to demonstrate that there is nothing fundamentally wrong with the approach.