### PR TITLE
Move array manipulation functions into separate file

### DIFF
--- a/lib/contourpy/array.py
+++ b/lib/contourpy/array.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from itertools import chain
+from typing import TYPE_CHECKING, TypeVar
+
+import numpy as np
+
+from contourpy.types import CLOSEPOLY, LINETO, MOVETO, code_dtype, offset_dtype, point_dtype
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    import contourpy._contourpy as cpy
+
+    T = TypeVar("T", bound=np.generic)  # Type for generic np.ndarray
+
+
+def codes_from_offsets(offsets: cpy.OffsetArray) -> cpy.CodeArray:
+    """Determine codes from offsets, assuming they all correspond to closed polygons.
+    """
+    n = offsets[-1]
+    codes = np.full(n, LINETO, dtype=code_dtype)
+    codes[offsets[:-1]] = MOVETO
+    codes[offsets[1:] - 1] = CLOSEPOLY
+    return codes
+
+
+def codes_from_offsets_and_points(
+    offsets: cpy.OffsetArray,
+    points: cpy.PointArray,
+) -> cpy.CodeArray:
+    """Determine codes from offsets and points, using the equality of the start and end points of
+    each line to determine if lines are closed or not.
+    """
+    codes = np.full(len(points), LINETO, dtype=code_dtype)
+    codes[offsets[:-1]] = MOVETO
+
+    end_offsets = offsets[1:] - 1
+    closed = np.all(points[offsets[:-1]] == points[end_offsets], axis=1)
+    codes[end_offsets[closed]] = CLOSEPOLY
+
+    return codes
+
+
+def codes_from_points(points: cpy.PointArray) -> cpy.CodeArray:
+    """Determine codes for a single line, using the equality of the start and end points to
+    determine if the line is closed or not.
+    """
+    n = len(points)
+    codes = np.full(n, LINETO, dtype=code_dtype)
+    codes[0] = MOVETO
+    if np.all(points[0] == points[-1]):
+        codes[-1] = CLOSEPOLY
+    return codes
+
+
+def concat_codes_or_none(list_of_codes_or_none: list[cpy.CodeArray | None]) -> cpy.CodeArray | None:
+    """Concatenate a list of codes or None into a single code array or None.
+    """
+    list_of_codes = [codes for codes in list_of_codes_or_none if codes is not None]
+    if list_of_codes:
+        return np.concatenate(list_of_codes)
+    else:
+        return None
+
+
+def concat_offsets(list_of_offsets: list[cpy.OffsetArray]) -> cpy.OffsetArray:
+    """Concatenate a list of offsets into a single offset array.
+    """
+    n = len(list_of_offsets)
+    cumulative = np.cumsum([offsets[-1] for offsets in list_of_offsets])
+    ret: cpy.OffsetArray = np.concatenate(
+        (list_of_offsets[0], *(list_of_offsets[i+1][1:] + cumulative[i] for i in range(n-1)))
+    )
+    return ret
+
+
+def concat_offsets_or_none(
+    list_of_offsets_or_none: list[cpy.OffsetArray | None],
+) -> cpy.OffsetArray | None:
+    """Concatenate a list of offsets or None into a single offset array or None.
+    """
+    list_of_offsets = [offsets for offsets in list_of_offsets_or_none if offsets is not None]
+    if list_of_offsets:
+        return concat_offsets(list_of_offsets)
+    else:
+        return None
+
+
+def concat_points_or_none(
+    list_of_points_or_none: list[cpy.PointArray | None],
+) -> cpy.PointArray | None:
+    """Concatenate a list of points or None into a single point array or None.
+    """
+    list_of_points = [points for points in list_of_points_or_none if points is not None]
+    if list_of_points:
+        return np.concatenate(list_of_points)
+    else:
+        return None
+
+
+def concat_points_or_none_with_nan(
+    list_of_points_or_none: list[cpy.PointArray | None],
+) -> cpy.PointArray | None:
+    """Concatenate a list of points or None into a single point array or None, with NaNs used to
+    separate each line.
+    """
+    list_of_points = [points for points in list_of_points_or_none if points is not None]
+    if list_of_points:
+        return concat_points_with_nan(list_of_points)
+    else:
+        return None
+
+
+def concat_points_with_nan(list_of_points: list[cpy.PointArray],) -> cpy.PointArray:
+    """Concatenate a list of points into a single point array with NaNs used to separate each line.
+    """
+    if len(list_of_points) == 1:
+        return list_of_points[0]
+    else:
+        nan_spacer = np.full((1, 2), np.nan, dtype=point_dtype)
+        list_of_points = [list_of_points[0],
+                          *list(chain(*((nan_spacer, x) for x in list_of_points[1:])))]
+        return np.concatenate(list_of_points)
+
+
+def insert_nan_at_offsets(points: cpy.PointArray, offsets: cpy.OffsetArray) -> cpy.PointArray:
+    """Insert NaNs into a point array at locations specified by an offset array.
+    """
+    if len(offsets) <= 2:
+        return points
+    else:
+        nan_spacer = np.array([np.nan, np.nan], dtype=point_dtype)
+        return np.insert(points, offsets[1:-1], nan_spacer, axis=0)
+
+
+def offsets_from_codes(codes: cpy.CodeArray) -> cpy.OffsetArray:
+    """Determine offsets from codes using locations of MOVETO codes.
+    """
+    return np.append(np.nonzero(codes == MOVETO)[0], len(codes)).astype(offset_dtype)
+
+
+def offsets_from_lengths(seq: list[cpy.PointArray]) -> cpy.OffsetArray:
+    """Determine offsets from lengths of point arrays.
+    """
+    return np.cumsum([0] + [len(line) for line in seq], dtype=offset_dtype)
+
+
+def outer_offsets_from_list_of_codes(seq: list[cpy.CodeArray]) -> cpy.OffsetArray:
+    """Determine outer offsets from codes using locations of MOVETO codes.
+    """
+    return np.cumsum([0] + [np.count_nonzero(codes == MOVETO) for codes in seq], dtype=offset_dtype)
+
+
+def outer_offsets_from_list_of_offsets(seq: list[cpy.OffsetArray]) -> cpy.OffsetArray:
+    """Determine outer offsets from a list of offsets.
+    """
+    return np.cumsum([0] + [len(offsets)-1 for offsets in seq], dtype=offset_dtype)
+
+
+def remove_nan(points: cpy.PointArray) -> tuple[cpy.PointArray, cpy.OffsetArray]:
+    """Remove NaN from a points array, also return the offsets corresponding to the NaN removed.
+    """
+    nan_offsets = np.nonzero(np.isnan(points[:, 0]))[0]
+    if len(nan_offsets) == 0:
+        return points, np.array([0, len(points)], dtype=offset_dtype)
+    else:
+        points = np.delete(points, nan_offsets, axis=0)
+        nan_offsets -= np.arange(len(nan_offsets))
+        offsets = np.concatenate(
+            ([0], nan_offsets, [len(points)])).astype(offset_dtype)  # type: ignore[arg-type]
+        return points, offsets
+
+
+def split_by_offsets(array: npt.NDArray[T], offsets: cpy.OffsetArray) -> list[npt.NDArray[T]]:
+    """Split an array at locations specified by an offset array.
+    """
+    if len(offsets) > 2:
+        return np.split(array, offsets[1:-1])
+    else:
+        return [array]
+
+
+def split_points_at_nan(points: cpy.PointArray) -> list[cpy.PointArray]:
+    """Split a points array at NaNs into a list of point arrays.
+    """
+    nan_offsets = np.nonzero(np.isnan(points[:, 0]))[0]
+    if len(nan_offsets) == 0:
+        return [points]
+    else:
+        nan_offsets = np.concatenate(([-1], nan_offsets, [len(points)]))  # type: ignore[arg-type]
+        return [points[s+1:e] for s, e in zip(nan_offsets[:-1], nan_offsets[1:])]

--- a/lib/contourpy/meson.build
+++ b/lib/contourpy/meson.build
@@ -1,6 +1,7 @@
 python_sources = [
   '__init__.py',
   '_version.py',
+  'array.py',
   'chunk.py',
   'convert.py',
   'dechunk.py',

--- a/lib/contourpy/util/bokeh_util.py
+++ b/lib/contourpy/util/bokeh_util.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 from contourpy import FillType, LineType
-from contourpy.convert import _offsets_from_codes
+from contourpy.array import offsets_from_codes
 
 if TYPE_CHECKING:
     from contourpy._contourpy import (
@@ -25,7 +25,7 @@ def filled_to_bokeh(
             if points is None:
                 continue
             if have_codes:
-                offsets = _offsets_from_codes(offsets)
+                offsets = offsets_from_codes(offsets)
             xs.append([])  # New outer with zero or more holes.
             ys.append([])
             for i in range(len(offsets)-1):
@@ -39,7 +39,7 @@ def filled_to_bokeh(
             for j in range(len(outer_offsets)-1):
                 if fill_type == FillType.ChunkCombinedCodeOffset:
                     codes = codes_or_offsets[outer_offsets[j]:outer_offsets[j+1]]
-                    offsets = _offsets_from_codes(codes) + outer_offsets[j]
+                    offsets = offsets_from_codes(codes) + outer_offsets[j]
                 else:
                     offsets = codes_or_offsets[outer_offsets[j]:outer_offsets[j+1]+1]
                 xs.append([])  # New outer with zero or more holes.
@@ -78,7 +78,7 @@ def lines_to_bokeh(
             if points is None:
                 continue
             if line_type == LineType.ChunkCombinedCode:
-                offsets = _offsets_from_codes(offsets)
+                offsets = offsets_from_codes(offsets)
 
             for i in range(len(offsets)-1):
                 line = points[offsets[i]:offsets[i+1]]

--- a/lib/contourpy/util/mpl_util.py
+++ b/lib/contourpy/util/mpl_util.py
@@ -6,7 +6,7 @@ import matplotlib.path as mpath
 import numpy as np
 
 from contourpy import FillType, LineType
-from contourpy.convert import _codes_from_offsets
+from contourpy.array import codes_from_offsets
 
 if TYPE_CHECKING:
     from contourpy._contourpy import FillReturn, LineReturn, LineReturn_Separate
@@ -16,7 +16,7 @@ def filled_to_mpl_paths(filled: FillReturn, fill_type: FillType) -> list[mpath.P
     if fill_type in (FillType.OuterCode, FillType.ChunkCombinedCode):
         paths = [mpath.Path(points, codes) for points, codes in zip(*filled) if points is not None]
     elif fill_type in (FillType.OuterOffset, FillType.ChunkCombinedOffset):
-        paths = [mpath.Path(points, _codes_from_offsets(offsets))
+        paths = [mpath.Path(points, codes_from_offsets(offsets))
                  for points, offsets in zip(*filled) if points is not None]
     elif fill_type == FillType.ChunkCombinedCodeOffset:
         paths = []
@@ -34,7 +34,7 @@ def filled_to_mpl_paths(filled: FillReturn, fill_type: FillType) -> list[mpath.P
             for i in range(len(outer_offsets)-1):
                 offs = offsets[outer_offsets[i]:outer_offsets[i+1]+1]
                 pts = points[offs[0]:offs[-1]]
-                paths += [mpath.Path(pts, _codes_from_offsets(offs - offs[0]))]
+                paths += [mpath.Path(pts, codes_from_offsets(offs - offs[0]))]
     else:
         raise RuntimeError(f"Conversion of FillType {fill_type} to MPL Paths is not implemented")
     return paths


### PR DESCRIPTION
There are various point/code/offset array manipulation functions in `convert.py` and `dechunk.py`. This PR moves them out into a separate file `array.py` and gives them more consistent function and argument names. These are only intended to be used internally within ContourPy so they are not exported from the top-level module.