### PR TITLE
Cast offsets to np.int64 before calling np.insert

### DIFF
--- a/lib/contourpy/array.py
+++ b/lib/contourpy/array.py
@@ -131,7 +131,8 @@ def insert_nan_at_offsets(points: cpy.PointArray, offsets: cpy.OffsetArray) -> c
         return points
     else:
         nan_spacer = np.array([np.nan, np.nan], dtype=point_dtype)
-        return np.insert(points, offsets[1:-1], nan_spacer, axis=0)
+        # Convert offsets to int64 to avoid numpy error when mixing signed and unsigned ints.
+        return np.insert(points, offsets[1:-1].astype(np.int64), nan_spacer, axis=0)
 
 
 def offsets_from_codes(codes: cpy.CodeArray) -> cpy.OffsetArray:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -18,16 +18,26 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def z() -> cpy.CoordinateArray:
-    return np.array([[0, 1, 0, 0, 0],
-                     [0, 1, 0, 0, 0],
-                     [0, 1, 0, 0, 0],
-                     [0, 2, 0, 1, 0],
-                     [0, 0, 0, 0, 0]], dtype=np.float64)
+    # Care needed with test data as although arbitrary z produces identical results for lines
+    # regardless of line_type, this is not the case for filled as the order that polygons are
+    # produced is different depending on whether the relationship between outer and inner
+    # boundaries is calculated. If it is then inner boundaries directly follow their outer boundary,
+    # if not then the boundaries are returned in the order they are found.
+    # This test data is chosen so that filled results are always the same.
+    return np.array([
+        [1, 0, 0, 0, 0, 0, 0],
+        [0, 0, 2, 0, 0, 0, 0],
+        [0, 2, 0, 0, 0, 0, 0],
+        [0, 1, 1, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 1],
+        [0, 2, 2, 0, 0, 0, 0],
+        [0, 0, 0, 0, 1, 0, 1],
+    ], dtype=np.float64)
 
 
 @pytest.mark.parametrize("fill_type_to", FillType.__members__.values())
 @pytest.mark.parametrize("fill_type_from", FillType.__members__.values())
-@pytest.mark.parametrize("chunk_size", (0, 2))
+@pytest.mark.parametrize("chunk_size", (0, 3))
 @pytest.mark.parametrize("empty", (False, True))
 def test_convert_fill_type(
     z: cpy.CoordinateArray,
@@ -69,7 +79,7 @@ def test_convert_fill_type(
 
 @pytest.mark.parametrize("line_type_to", LineType.__members__.values())
 @pytest.mark.parametrize("line_type_from", LineType.__members__.values())
-@pytest.mark.parametrize("chunk_size", (0, 2))
+@pytest.mark.parametrize("chunk_size", (0, 3))
 @pytest.mark.parametrize("empty", (False, True))
 def test_convert_line_type(
     z: cpy.CoordinateArray,

--- a/tests/test_dechunk.py
+++ b/tests/test_dechunk.py
@@ -144,7 +144,9 @@ def test_dechunk_lines(z: cpy.CoordinateArray, line_type: LineType, chunk_size: 
             if TYPE_CHECKING:
                 dechunked = cast(cpy.LineReturn_ChunkCombinedNan, dechunked)
             assert dechunked[0][0] is not None
-            expected = np.insert(expected_points, expected_offsets[1:-1], [np.nan, np.nan], axis=0)
+            # Convert offsets to int64 to avoid numpy error when mixing signed and unsigned ints.
+            expected = np.insert(expected_points, expected_offsets[1:-1].astype(np.int64),
+                                 [np.nan, np.nan], axis=0)
             assert_allclose(dechunked[0][0], expected)
         else:
             raise RuntimeError(f"Unexpected line_type {line_type}")


### PR DESCRIPTION
Cast offsets to `np.int64` before calling `np.insert` to avoid mixing signed and unsigned ints that causes UFunc error. Also improved tests for `convert` functions to avoid future regression.

Fixes #299.