### PR TITLE
Always use LineType.ChunkCombinedNan for lines in Bokeh

### DIFF
--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -196,8 +196,8 @@ class BokehRenderer(Renderer):
         fig = self._get_figure(ax)
         color = self._convert_color(color)
         xs, ys = lines_to_bokeh(lines, line_type)
-        if len(xs) > 0:
-            fig.multi_line(xs, ys, line_color=color, line_alpha=alpha, line_width=linewidth)
+        if xs is not None:
+            fig.line(xs, ys, line_color=color, line_alpha=alpha, line_width=linewidth)
 
     def mask(
         self,


### PR DESCRIPTION
Now that we have `LineType.ChunkCombinedNan`, always use it to render lines in `BokehRenderer`. Whatever lines are passed to`BokehRenderer.lines` are converted via `convert_line_type` and `dechunk_lines` to give a single NaN-separate points array which is used to create a Bokeh `line` glyph rather than the `multi_line` glyph used previously here.