### PR TITLE
Test and build wheels for musllinux aarch64

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,19 +1,31 @@
 linux_aarch64_test_task:
-  name: "Cirrus linux aarch64 ${PYTHON_VERSION}"
+  name: "Cirrus linux aarch64 ${PYTHON_VERSION} ${IMAGE_SUFFIX}"
 
   arm_container:
     # https://hub.docker.com/_/python/
-    image: python:${PYTHON_VERSION}-slim
+    image: python:${PYTHON_VERSION}-${IMAGE_SUFFIX}
 
   matrix:
     - env:
-        PYTHON_VERSION: "3.9"
+        PYTHON_VERSION: "3.11"
+        IMAGE_SUFFIX: slim
+        BUILD_NUMPY: 0
+        TEST_NO_IMAGES: 0
     - env:
         PYTHON_VERSION: "3.11"
+        IMAGE_SUFFIX: alpine
+        BUILD_NUMPY: 1
+        TEST_NO_IMAGES: 1
 
   os_dependencies_script: |
-    apt update
-    apt install -yy g++
+    if [[ "$IMAGE_SUFFIX" != "alpine" ]];
+    then
+      apt update;
+      apt install -yy g++;
+    else
+      apk update;
+      apk add build-base;
+    fi
 
   python_venv_script: |
     which python
@@ -22,13 +34,29 @@ linux_aarch64_test_task:
     python -m venv venv
     source venv/bin/activate
 
+  install_numpy_from_source_script:
+    if [[ "$BUILD_NUMPY" == "1" ]];
+    then
+      python -m pip install -v --no-binary=numpy numpy -Csetup-args="-Dallow-noblas=true";
+    fi
+
   install_contourpy_script: |
-    python -m pip install -v .[test] -Cbuilddir=build
+    if [[ "$TEST_NO_IMAGES" ]];
+    then
+        python -m pip install -v .[test-no-images] -Cbuilddir=build;
+    else
+        python -m pip install -v .[test] -Cbuilddir=build;
+    fi
     python -m pip list
     python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"
 
   run_tests_script: |
-    python -m pytest -v tests/
+    if [[ "$TEST_NO_IMAGES" ]];
+    then
+      python -m pytest -v tests/ -k "not image";
+    else
+      python -m pytest -v tests/;
+    fi
 
 
 macos_arm64_test_task:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -280,13 +280,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # musllinux: run standard tests.
+          # musllinux x86_64.
           - arch: x86_64
             manylinux_version: musllinux
             image: musllinux_1_1_x86_64
             venv: venv
             test: test
-          # ppc64le and s390x: dependencies are conda packages, run standard tests.
+          # ppc64le and s390x: dependencies are conda packages.
           - arch: ppc64le
             manylinux_version: manylinux2014
             image: manylinux2014_ppc64le
@@ -349,8 +349,10 @@ jobs:
               conda list
             fi
 
-            echo "==> Install contourpy with test dependencies"
+            echo "==> Upgrade pip"
             python -m pip install --upgrade pip
+
+            echo "==> Install contourpy with test dependencies"
             python -m pip install -v .[$TEST]
             python -m pip list
             python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ setup = [
 [tool.cibuildwheel]
 build-frontend = "build"
 build = "cp39-* cp310-* cp311-* cp312-* pp39-*"
-skip = "*-musllinux_aarch64 *-musllinux_ppc64le *-musllinux_s390x pp*_aarch64 pp*_ppc64le pp*_s390x"
+skip = "*-musllinux_ppc64le *-musllinux_s390x pp*_aarch64 pp*_ppc64le pp*_s390x"
 test-command = [
     'python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"',
     'python -c "import contourpy as c; print(c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9))"',


### PR DESCRIPTION
NumPy has starting building musllinux aarch64 wheels (numpy/numpy#24993) so let's follow their lead. Building the wheels is easy thanks to cibuildwheel, but we will follow the usual policy of only building wheels for platforms we are actively testing on in CI. When numpy release such wheels it will be simplest to test using QEMU on a github runner in the same way as is currently done for musllinux x86_64, but building numpy from source within emulation is a slow process. So here using some of the limitied Cirrus CI resources to test on ARM64 hardware.