### PR TITLE
Use explicit dtype in np.concatenate calls

### DIFF
--- a/lib/contourpy/convert.py
+++ b/lib/contourpy/convert.py
@@ -23,8 +23,8 @@ def _convert_filled_from_OuterCode(
         return (filled[0], [arr.offsets_from_codes(codes) for codes in filled[1]])
 
     if len(filled[0]) > 0:
-        points = np.concatenate(filled[0])
-        codes = np.concatenate(filled[1])
+        points = arr.concat_points(filled[0])
+        codes = arr.concat_codes(filled[1])
     else:
         points = None
         codes = None
@@ -60,7 +60,7 @@ def _convert_filled_from_OuterOffset(
         return filled
 
     if len(filled[0]) > 0:
-        points = np.concatenate(filled[0])
+        points = arr.concat_points(filled[0])
         offsets = arr.concat_offsets(filled[1])
     else:
         points = None
@@ -318,7 +318,7 @@ def _convert_lines_from_Separate(
         if not lines:
             ret1: cpy.LineReturn_ChunkCombinedCode = ([None], [None])
         else:
-            points = np.concatenate(lines)
+            points = arr.concat_points(lines)
             offsets = arr.offsets_from_lengths(lines)
             codes = arr.codes_from_offsets_and_points(offsets, points)
             ret1 = ([points], [codes])
@@ -327,7 +327,7 @@ def _convert_lines_from_Separate(
         if not lines:
             ret2: cpy.LineReturn_ChunkCombinedOffset = ([None], [None])
         else:
-            ret2 = ([np.concatenate(lines)], [arr.offsets_from_lengths(lines)])
+            ret2 = ([arr.concat_points(lines)], [arr.offsets_from_lengths(lines)])
         return ret2
     elif line_type_to == LineType.ChunkCombinedNan:
         if not lines:
@@ -352,13 +352,13 @@ def _convert_lines_from_SeparateCode(
         if not lines[0]:
             ret1: cpy.LineReturn_ChunkCombinedCode = ([None], [None])
         else:
-            ret1 = ([np.concatenate(lines[0])], [np.concatenate(lines[1])])
+            ret1 = ([arr.concat_points(lines[0])], [arr.concat_codes(lines[1])])
         return ret1
     elif line_type_to == LineType.ChunkCombinedOffset:
         if not lines[0]:
             ret2: cpy.LineReturn_ChunkCombinedOffset = ([None], [None])
         else:
-            ret2 = ([np.concatenate(lines[0])], [arr.offsets_from_lengths(lines[0])])
+            ret2 = ([arr.concat_points(lines[0])], [arr.offsets_from_lengths(lines[0])])
         return ret2
     elif line_type_to == LineType.ChunkCombinedNan:
         if not lines[0]:

--- a/lib/contourpy/util/mpl_util.py
+++ b/lib/contourpy/util/mpl_util.py
@@ -66,8 +66,7 @@ def lines_to_mpl_paths(lines: LineReturn, line_type: LineType) -> list[mpath.Pat
             if points is None:
                 continue
             nan_offsets = np.nonzero(np.isnan(points[:, 0]))[0]
-            nan_offsets = \
-                np.concatenate(([-1], nan_offsets, [len(points)]))  # type: ignore[arg-type]
+            nan_offsets = np.concatenate([[-1], nan_offsets, [len(points)]])
             for s, e in zip(nan_offsets[:-1], nan_offsets[1:]):
                 line = points[s+1:e]
                 closed = line[0, 0] == line[-1, 0] and line[0, 1] == line[-1, 1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "numpy >= 1.16, < 2.0",
+    "numpy >= 1.20, < 2.0",
 ]
 description = "Python library for calculating contours of 2D quadrilateral grids"
 dynamic = ["version"]


### PR DESCRIPTION
Use explicit `dtype` in `np.concatenate` calls. The recent additions of `np.concatenate` in `array.py` (and some other places) has worked fine in CI until some very recent changes in the numpy 2.0 nightlies. To avoid problems concatenating arrays with different `dtype`s it is best to explicitly specify the required `dtype`.

The one exception is in `mpl_util.py` where offsets are calculated and used immediately without having to be a particular `dtype`.

This kwarg needs `numpy >= 1.20`.