### PR TITLE
Rename convert functions

### DIFF
--- a/docs/api/top.rst
+++ b/docs/api/top.rst
@@ -12,7 +12,9 @@ contourpy
 
 .. autofunction:: contour_generator
 
-.. autofunction:: convert_line_type
+.. autofunction:: convert_filled
+
+.. autofunction:: convert_lines
 
 .. autofunction:: dechunk_filled
 

--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -10,7 +10,7 @@ from contourpy._contourpy import (
 )
 from contourpy._version import __version__
 from contourpy.chunk import calc_chunk_sizes
-from contourpy.convert import convert_fill_type, convert_line_type
+from contourpy.convert import convert_filled, convert_lines
 from contourpy.dechunk import dechunk_filled, dechunk_lines
 from contourpy.enum_util import as_fill_type, as_line_type, as_z_interp
 
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 __all__ = [
     "__version__",
     "contour_generator",
-    "convert_fill_type",
-    "convert_line_type",
+    "convert_filled",
+    "convert_lines",
     "dechunk_filled",
     "dechunk_lines",
     "max_threads",

--- a/lib/contourpy/convert.py
+++ b/lib/contourpy/convert.py
@@ -251,7 +251,7 @@ def _convert_filled_from_ChunkCombinedOffsetOffset(
         raise ValueError(f"Invalid FillType {fill_type_to}")
 
 
-def convert_fill_type(
+def convert_filled(
     filled: cpy.FillReturn,
     fill_type_from: FillType | str,
     fill_type_to:  FillType | str,
@@ -497,7 +497,7 @@ def _convert_lines_from_ChunkCombinedNan(
         raise ValueError(f"Invalid LineType {line_type_to}")
 
 
-def convert_line_type(
+def convert_lines(
     lines: cpy.LineReturn,
     line_type_from: LineType | str,
     line_type_to:  LineType | str,

--- a/lib/contourpy/util/bokeh_util.py
+++ b/lib/contourpy/util/bokeh_util.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, cast
 
 from contourpy import FillType, LineType
 from contourpy.array import offsets_from_codes
-from contourpy.convert import convert_line_type
+from contourpy.convert import convert_lines
 from contourpy.dechunk import dechunk_lines
 
 if TYPE_CHECKING:
@@ -60,7 +60,7 @@ def lines_to_bokeh(
     lines: LineReturn,
     line_type: LineType,
 ) -> tuple[CoordinateArray | None, CoordinateArray | None]:
-    lines = convert_line_type(lines, line_type, LineType.ChunkCombinedNan)
+    lines = convert_lines(lines, line_type, LineType.ChunkCombinedNan)
     lines = dechunk_lines(lines, LineType.ChunkCombinedNan)
     if TYPE_CHECKING:
         lines = cast(LineReturn_ChunkCombinedNan, lines)

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from contourpy import FillType, LineType
-from contourpy.convert import convert_fill_type, convert_line_type
+from contourpy.convert import convert_filled, convert_lines
 from contourpy.enum_util import as_fill_type, as_line_type
 from contourpy.util.mpl_util import filled_to_mpl_paths, lines_to_mpl_paths
 from contourpy.util.renderer import Renderer
@@ -395,7 +395,7 @@ class MplDebugRenderer(MplRenderer):
             return
 
         ax = self._get_ax(ax)
-        filled = convert_fill_type(filled, fill_type, FillType.ChunkCombinedOffset)
+        filled = convert_filled(filled, fill_type, FillType.ChunkCombinedOffset)
 
         # Lines.
         if line_color is not None:
@@ -447,7 +447,7 @@ class MplDebugRenderer(MplRenderer):
             return
 
         ax = self._get_ax(ax)
-        separate_lines = convert_line_type(lines, line_type, LineType.Separate)
+        separate_lines = convert_lines(lines, line_type, LineType.Separate)
         if TYPE_CHECKING:
             separate_lines = cast(cpy.LineReturn_Separate, separate_lines)
 

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -244,7 +244,7 @@ class MplRenderer(Renderer):
         """Show plots in an interactive window, in the usual Matplotlib manner.
         """
         self._autoscale()
-        plt.show()  # type: ignore[no-untyped-call]
+        plt.show()
 
     def title(self, title: str, ax: Axes | int = 0, color: str | None = None) -> None:
         """Set the title of a single Axes.

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from contourpy import (
-    FillType, LineType, contour_generator, convert_fill_type, convert_line_type, dechunk_filled,
+    FillType, LineType, contour_generator, convert_filled, convert_lines, dechunk_filled,
     dechunk_lines,
 )
 
@@ -39,7 +39,7 @@ def z() -> cpy.CoordinateArray:
 @pytest.mark.parametrize("fill_type_from", FillType.__members__.values())
 @pytest.mark.parametrize("chunk_size", (0, 2, 3))
 @pytest.mark.parametrize("empty", (False, True))
-def test_convert_fill_type(
+def test_convert_filled(
     z: cpy.CoordinateArray,
     fill_type_from: FillType,
     fill_type_to: FillType,
@@ -60,9 +60,9 @@ def test_convert_fill_type(
         fill_type_to not in (FillType.ChunkCombinedCode, FillType.ChunkCombinedOffset)):
         msg = f"Conversion from {fill_type_from} to {fill_type_to} not supported"
         with pytest.raises(ValueError, match=msg):
-            convert_fill_type(filled, fill_type_from, fill_type_to)
+            convert_filled(filled, fill_type_from, fill_type_to)
     else:
-        converted = convert_fill_type(filled, fill_type_from, fill_type_to)
+        converted = convert_filled(filled, fill_type_from, fill_type_to)
         util_test.assert_filled(converted, fill_type_to)
 
         compare = contour_generator(z=z, fill_type=fill_type_to, chunk_size=chunk_size).filled(
@@ -81,7 +81,7 @@ def test_convert_fill_type(
 @pytest.mark.parametrize("line_type_from", LineType.__members__.values())
 @pytest.mark.parametrize("chunk_size", (0, 2, 3))
 @pytest.mark.parametrize("empty", (False, True))
-def test_convert_line_type(
+def test_convert_lines(
     z: cpy.CoordinateArray,
     line_type_from: LineType,
     line_type_to: LineType,
@@ -96,7 +96,7 @@ def test_convert_line_type(
         # and using chunk_size=2 or 3 there is an empty chunk.
         level = 0.5
     lines = contour_generator(z=z, line_type=line_type_from, chunk_size=chunk_size).lines(level)
-    converted = convert_line_type(lines, line_type_from, line_type_to)
+    converted = convert_lines(lines, line_type_from, line_type_to)
 
     compare = contour_generator(z=z, line_type=line_type_to, chunk_size=chunk_size).lines(level)
     util_test.assert_lines(converted, line_type_to)


### PR DESCRIPTION
Rename convert functions from `convert_fill_type` to `convert_filled` and from `convert_line_type` to `convert_lines`. This fits in better with the `dechunk` names, and allows future inclusion of `multi_lines` functions that take a sequence of lines, etc.