### PR TITLE
Improve array checking functions

### DIFF
--- a/lib/contourpy/convert.py
+++ b/lib/contourpy/convert.py
@@ -136,8 +136,8 @@ def _convert_filled_from_ChunkCombinedCodeOffset(
                 if TYPE_CHECKING:
                     assert codes is not None
                     assert outer_offsets is not None
-                separate_points += arr.split_by_offsets(points, outer_offsets)
-                separate_codes += arr.split_by_offsets(codes, outer_offsets)
+                separate_points += arr.split_points_by_offsets(points, outer_offsets)
+                separate_codes += arr.split_codes_by_offsets(codes, outer_offsets)
         return (separate_points, separate_codes)
     elif fill_type_to == FillType.OuterOffset:
         separate_points = []
@@ -147,8 +147,8 @@ def _convert_filled_from_ChunkCombinedCodeOffset(
                 if TYPE_CHECKING:
                     assert codes is not None
                     assert outer_offsets is not None
-                separate_points += arr.split_by_offsets(points, outer_offsets)
-                separate_codes = arr.split_by_offsets(codes, outer_offsets)
+                separate_points += arr.split_points_by_offsets(points, outer_offsets)
+                separate_codes = arr.split_codes_by_offsets(codes, outer_offsets)
                 separate_offsets += [arr.offsets_from_codes(codes) for codes in separate_codes]
         return (separate_points, separate_offsets)
     elif fill_type_to == FillType.ChunkCombinedCode:
@@ -198,8 +198,8 @@ def _convert_filled_from_ChunkCombinedOffsetOffset(
                     assert outer_offsets is not None
                 codes = arr.codes_from_offsets_and_points(offsets, points)
                 outer_offsets = offsets[outer_offsets]
-                separate_points += arr.split_by_offsets(points, outer_offsets)
-                separate_codes += arr.split_by_offsets(codes, outer_offsets)
+                separate_points += arr.split_points_by_offsets(points, outer_offsets)
+                separate_codes += arr.split_codes_by_offsets(codes, outer_offsets)
         return (separate_points, separate_codes)
     elif fill_type_to == FillType.OuterOffset:
         separate_points = []
@@ -214,7 +214,7 @@ def _convert_filled_from_ChunkCombinedOffsetOffset(
                                          zip(outer_offsets[:-1], outer_offsets[1:])]
                 else:
                     separate_offsets.append(offsets)
-                separate_points += arr.split_by_offsets(points, offsets[outer_offsets])
+                separate_points += arr.split_points_by_offsets(points, offsets[outer_offsets])
         return (separate_points, separate_offsets)
     elif fill_type_to == FillType.ChunkCombinedCode:
         chunk_codes: list[cpy.CodeArray | None] = []
@@ -421,7 +421,7 @@ def _convert_lines_from_ChunkCombinedOffset(
             if points is not None:
                 if TYPE_CHECKING:
                     assert offsets is not None
-                separate_lines += arr.split_by_offsets(points, offsets)
+                separate_lines += arr.split_points_by_offsets(points, offsets)
         if line_type_to == LineType.Separate:
             return separate_lines
         else:

--- a/lib/contourpy/meson.build
+++ b/lib/contourpy/meson.build
@@ -6,6 +6,7 @@ python_sources = [
   'convert.py',
   'dechunk.py',
   'enum_util.py',
+  'typecheck.py',
   'types.py',
   '_contourpy.pyi',
   'py.typed',

--- a/lib/contourpy/typecheck.py
+++ b/lib/contourpy/typecheck.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from contourpy.types import MOVETO, code_dtype, offset_dtype, point_dtype
+
+
+# Minimalist array-checking functions that check dtype, ndims and shape only.
+# They do not walk the arrays to check the contents for performance reasons.
+def check_code_array(codes: Any) -> None:
+    if not isinstance(codes, np.ndarray):
+        raise TypeError(f"Expected numpy array not {type(codes)}")
+    if codes.dtype != code_dtype:
+        raise ValueError(f"Expected numpy array of dtype {code_dtype} not {codes.dtype}")
+    if not (codes.ndim == 1 and len(codes) > 1):
+        raise ValueError(f"Expected numpy array of shape (?,) not {codes.shape}")
+    if codes[0] != MOVETO:
+        raise ValueError(f"First element of code array must be {MOVETO}, not {codes[0]}")
+
+
+def check_offset_array(offsets: Any) -> None:
+    if not isinstance(offsets, np.ndarray):
+        raise TypeError(f"Expected numpy array not {type(offsets)}")
+    if offsets.dtype != offset_dtype:
+        raise ValueError(f"Expected numpy array of dtype {offset_dtype} not {offsets.dtype}")
+    if not (offsets.ndim == 1 and len(offsets) > 1):
+        raise ValueError(f"Expected numpy array of shape (?,) not {offsets.shape}")
+    if offsets[0] != 0:
+        raise ValueError(f"First element of offset array must be 0, not {offsets[0]}")
+
+
+def check_point_array(points: Any) -> None:
+    if not isinstance(points, np.ndarray):
+        raise TypeError(f"Expected numpy array not {type(points)}")
+    if points.dtype != point_dtype:
+        raise ValueError(f"Expected numpy array of dtype {point_dtype} not {points.dtype}")
+    if not (points.ndim == 2 and points.shape[1] ==2 and points.shape[0] > 1):
+        raise ValueError(f"Expected numpy array of shape (?, 2) not {points.shape}")

--- a/tests/test_typecheck.py
+++ b/tests/test_typecheck.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from contourpy.typecheck import check_code_array, check_offset_array, check_point_array
+from contourpy.types import code_dtype, offset_dtype, point_dtype
+
+
+def test_check_code_array() -> None:
+    # Valid code array, does not raise.
+    check_code_array(np.array([1, 2, 79], dtype=code_dtype))
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'>"):
+        check_code_array([1, 2, 79])
+
+    with pytest.raises(ValueError, match=r"Expected numpy array of dtype <class 'numpy.uint8'>"):
+        check_code_array(np.array([1, 2, 79], dtype=np.int64))
+
+    with pytest.raises(ValueError, match=r"Expected numpy array of shape"):
+        check_code_array(np.array([[1, 2, 79]], dtype=code_dtype))
+
+    with pytest.raises(ValueError, match=r"First element of code array must be 1"):
+        check_code_array(np.array([2, 2, 79], dtype=code_dtype))
+
+
+def test_check_offset_array() -> None:
+    # Valid offset array, does not raise.
+    check_offset_array(np.array([0, 5], dtype=offset_dtype))
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'>"):
+        check_offset_array([0, 5])
+
+    with pytest.raises(ValueError, match=r"Expected numpy array of dtype <class 'numpy.uint32'>"):
+        check_offset_array(np.array([0, 5], dtype=np.int64))
+
+    with pytest.raises(ValueError, match=r"Expected numpy array of shape"):
+        check_offset_array(np.array([[0], [5]], dtype=offset_dtype))
+
+    with pytest.raises(ValueError, match=r"First element of offset array must be 0"):
+        check_offset_array(np.array([1, 5], dtype=offset_dtype))
+
+
+def test_check_point_array() -> None:
+    # Valid point array, does not raise.
+    check_point_array(np.array([[1.1, 2.2], [3.3, 4.4]], dtype=point_dtype))
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'>"):
+        check_point_array([[1.1, 2.2], [3.3, 4.4]])
+
+    with pytest.raises(ValueError, match=r"Expected numpy array of dtype <class 'numpy.float64'>"):
+        check_point_array(np.array([[1.1, 2.2], [3.3, 4.4]], dtype=np.float32))
+
+    with pytest.raises(ValueError, match=r"Expected numpy array of shape"):
+        check_point_array(np.array([[1.1, 2.2, 3.3, 4.4]], dtype=point_dtype))


### PR DESCRIPTION
Some improvements to the array checking functions `check_code_array`, `check_offset_array` and `check_point_array`:

- Move them to their own file `typecheck.py` (more functions will follow)
- Explicit checks for these 3 functions in `test_typecheck.py`
- Check the first element of code and offset arrays, should be 1 and 0 respectively
- Separate `split_by_offsets` into the two more specific `split_codes_by_offsets` and `split_points_by_offsets`
- Correctly name two of the test functions in `test_array.py`