### PR TITLE
Extra validation when dechunking and converting contour lines and filled contours

### DIFF
--- a/lib/contourpy/convert.py
+++ b/lib/contourpy/convert.py
@@ -7,6 +7,7 @@ import numpy as np
 from contourpy._contourpy import FillType, LineType
 import contourpy.array as arr
 from contourpy.enum_util import as_fill_type, as_line_type
+from contourpy.typecheck import check_filled, check_lines
 from contourpy.types import MOVETO, offset_dtype
 
 if TYPE_CHECKING:
@@ -277,6 +278,8 @@ def convert_filled(
     fill_type_from = as_fill_type(fill_type_from)
     fill_type_to = as_fill_type(fill_type_to)
 
+    check_filled(filled, fill_type_from)
+
     if fill_type_from == FillType.OuterCode:
         if TYPE_CHECKING:
             filled = cast(cpy.FillReturn_OuterCode, filled)
@@ -521,6 +524,8 @@ def convert_lines(
     """
     line_type_from = as_line_type(line_type_from)
     line_type_to = as_line_type(line_type_to)
+
+    check_lines(lines, line_type_from)
 
     if line_type_from == LineType.Separate:
         if TYPE_CHECKING:

--- a/lib/contourpy/dechunk.py
+++ b/lib/contourpy/dechunk.py
@@ -8,6 +8,7 @@ from contourpy.array import (
     concat_points_or_none_with_nan,
 )
 from contourpy.enum_util import as_fill_type, as_line_type
+from contourpy.typecheck import check_filled, check_lines
 
 if TYPE_CHECKING:
     import contourpy._contourpy as cpy
@@ -32,8 +33,13 @@ def dechunk_filled(filled: cpy.FillReturn, fill_type: FillType | str) -> cpy.Fil
     """
     fill_type = as_fill_type(fill_type)
 
-    if fill_type in (FillType.OuterCode, FillType.OuterOffset) or len(filled[0]) < 2:
-        # No-op if fill_type is not chunked or there is just one chunk.
+    if fill_type in (FillType.OuterCode, FillType.OuterOffset):
+        # No-op if fill_type is not chunked.
+        return filled
+
+    check_filled(filled, fill_type)
+    if len(filled[0]) < 2:
+        # No-op if just one chunk.
         return filled
 
     if TYPE_CHECKING:
@@ -96,9 +102,13 @@ def dechunk_lines(lines: cpy.LineReturn, line_type: LineType | str) -> cpy.LineR
     .. versionadded:: 1.1.2
     """
     line_type = as_line_type(line_type)
+    if line_type in (LineType.Separate, LineType.SeparateCode):
+        # No-op if line_type is not chunked.
+        return lines
 
-    if line_type in (LineType.Separate, LineType.SeparateCode) or len(lines[0]) < 2:
-        # No-op if line_type is not chunked or there is just one chunk.
+    check_lines(lines, line_type)
+    if len(lines[0]) < 2:
+        # No-op if just one chunk.
         return lines
 
     if TYPE_CHECKING:

--- a/lib/contourpy/typecheck.py
+++ b/lib/contourpy/typecheck.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
+from contourpy import FillType, LineType
+from contourpy.enum_util import as_fill_type, as_line_type
 from contourpy.types import MOVETO, code_dtype, offset_dtype, point_dtype
+
+if TYPE_CHECKING:
+    import contourpy._contourpy as cpy
 
 
 # Minimalist array-checking functions that check dtype, ndims and shape only.
@@ -38,3 +43,161 @@ def check_point_array(points: Any) -> None:
         raise ValueError(f"Expected numpy array of dtype {point_dtype} not {points.dtype}")
     if not (points.ndim == 2 and points.shape[1] ==2 and points.shape[0] > 1):
         raise ValueError(f"Expected numpy array of shape (?, 2) not {points.shape}")
+
+
+def _check_tuple_of_lists_with_same_length(
+    maybe_tuple: Any,
+    tuple_length: int,
+    allow_empty_lists: bool = True,
+) -> None:
+    if not isinstance(maybe_tuple, tuple):
+        raise TypeError(f"Expected tuple not {type(maybe_tuple)}")
+    if len(maybe_tuple) != tuple_length:
+        raise ValueError(f"Expected tuple of length {tuple_length} not {len(maybe_tuple)}")
+    for maybe_list in maybe_tuple:
+        if not isinstance(maybe_list, list):
+            msg = f"Expected tuple to contain {tuple_length} lists but found a {type(maybe_list)}"
+            raise TypeError(msg)
+    lengths = [len(item) for item in maybe_tuple]
+    if len(set(lengths)) != 1:
+        msg = f"Expected {tuple_length} lists with same length but lengths are {lengths}"
+        raise ValueError(msg)
+    if not allow_empty_lists and lengths[0] == 0:
+        raise ValueError(f"Expected {tuple_length} non-empty lists")
+
+
+def check_filled(filled: cpy.FillReturn, fill_type: FillType | str) -> None:
+    fill_type = as_fill_type(fill_type)
+
+    if fill_type == FillType.OuterCode:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_OuterCode, filled)
+        _check_tuple_of_lists_with_same_length(filled, 2)
+        for i, (points, codes) in enumerate(zip(*filled)):
+            check_point_array(points)
+            check_code_array(codes)
+            if len(points) != len(codes):
+                raise ValueError(f"Points and codes have different lengths in polygon {i}")
+    elif fill_type == FillType.OuterOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_OuterOffset, filled)
+        _check_tuple_of_lists_with_same_length(filled, 2)
+        for i, (points, offsets) in enumerate(zip(*filled)):
+            check_point_array(points)
+            check_offset_array(offsets)
+            if offsets[-1] != len(points):
+                raise ValueError(f"Inconsistent points and offsets in polygon {i}")
+    elif fill_type == FillType.ChunkCombinedCode:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedCode, filled)
+        _check_tuple_of_lists_with_same_length(filled, 2, allow_empty_lists=False)
+        for chunk, (points_or_none, codes_or_none) in enumerate(zip(*filled)):
+            if points_or_none is not None and codes_or_none is not None:
+                check_point_array(points_or_none)
+                check_code_array(codes_or_none)
+                if len(points_or_none) != len(codes_or_none):
+                    raise ValueError(f"Points and codes have different lengths in chunk {chunk}")
+            elif not (points_or_none is None and codes_or_none is None):
+                raise ValueError(f"Inconsistent Nones in chunk {chunk}")
+    elif fill_type == FillType.ChunkCombinedOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedOffset, filled)
+        _check_tuple_of_lists_with_same_length(filled, 2, allow_empty_lists=False)
+        for chunk, (points_or_none, offsets_or_none) in enumerate(zip(*filled)):
+            if points_or_none is not None and offsets_or_none is not None:
+                check_point_array(points_or_none)
+                check_offset_array(offsets_or_none)
+                if offsets_or_none[-1] != len(points_or_none):
+                    raise ValueError(f"Inconsistent points and offsets in chunk {chunk}")
+            elif not (points_or_none is None and offsets_or_none is None):
+                raise ValueError(f"Inconsistent Nones in chunk {chunk}")
+    elif fill_type == FillType.ChunkCombinedCodeOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedCodeOffset, filled)
+        _check_tuple_of_lists_with_same_length(filled, 3, allow_empty_lists=False)
+        for i, (points_or_none, codes_or_none, outer_offsets_or_none) in enumerate(zip(*filled)):
+            if (points_or_none is not None and codes_or_none is not None and
+                    outer_offsets_or_none is not None):
+                check_point_array(points_or_none)
+                check_code_array(codes_or_none)
+                check_offset_array(outer_offsets_or_none)
+                if len(codes_or_none) != len(points_or_none):
+                    raise ValueError(f"Points and codes have different lengths in chunk {i}")
+                if outer_offsets_or_none[-1] != len(codes_or_none):
+                    raise ValueError(f"Inconsistent codes and outer_offsets in chunk {i}")
+            elif not (points_or_none is None and codes_or_none is None and
+                      outer_offsets_or_none is None):
+                raise ValueError(f"Inconsistent Nones in chunk {i}")
+    elif fill_type == FillType.ChunkCombinedOffsetOffset:
+        if TYPE_CHECKING:
+            filled = cast(cpy.FillReturn_ChunkCombinedOffsetOffset, filled)
+        _check_tuple_of_lists_with_same_length(filled, 3, allow_empty_lists=False)
+        for i, (points_or_none, offsets_or_none, outer_offsets_or_none) in enumerate(zip(*filled)):
+            if (points_or_none is not None and offsets_or_none is not None and
+                    outer_offsets_or_none is not None):
+                check_point_array(points_or_none)
+                check_offset_array(offsets_or_none)
+                check_offset_array(outer_offsets_or_none)
+                if offsets_or_none[-1] != len(points_or_none):
+                    raise ValueError(f"Inconsistent points and offsets in chunk {i}")
+                if outer_offsets_or_none[-1] != len(offsets_or_none) - 1:
+                    raise ValueError(f"Inconsistent offsets and outer_offsets in chunk {i}")
+            elif not (points_or_none is None and offsets_or_none is None and
+                      outer_offsets_or_none is None):
+                raise ValueError(f"Inconsistent Nones in chunk {i}")
+    else:
+        raise ValueError(f"Invalid FillType {fill_type}")
+
+
+def check_lines(lines: cpy.LineReturn, line_type: LineType | str) -> None:
+    line_type = as_line_type(line_type)
+
+    if line_type == LineType.Separate:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_Separate, lines)
+        if not isinstance(lines, list):
+            raise TypeError(f"Expected list not {type(lines)}")
+        for points in lines:
+            check_point_array(points)
+    elif line_type == LineType.SeparateCode:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_SeparateCode, lines)
+        _check_tuple_of_lists_with_same_length(lines, 2)
+        for i, (points, codes) in enumerate(zip(*lines)):
+            check_point_array(points)
+            check_code_array(codes)
+            if len(points) != len(codes):
+                raise ValueError(f"Points and codes have different lengths in line {i}")
+    elif line_type == LineType.ChunkCombinedCode:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_ChunkCombinedCode, lines)
+        _check_tuple_of_lists_with_same_length(lines, 2, allow_empty_lists=False)
+        for chunk, (points_or_none, codes_or_none) in enumerate(zip(*lines)):
+            if points_or_none is not None and codes_or_none is not None:
+                check_point_array(points_or_none)
+                check_code_array(codes_or_none)
+                if len(points_or_none) != len(codes_or_none):
+                    raise ValueError(f"Points and codes have different lengths in chunk {chunk}")
+            elif not (points_or_none is None and codes_or_none is None):
+                raise ValueError(f"Inconsistent Nones in chunk {chunk}")
+    elif line_type == LineType.ChunkCombinedOffset:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_ChunkCombinedOffset, lines)
+        _check_tuple_of_lists_with_same_length(lines, 2, allow_empty_lists=False)
+        for chunk, (points_or_none, offsets_or_none) in enumerate(zip(*lines)):
+            if points_or_none is not None and offsets_or_none is not None:
+                check_point_array(points_or_none)
+                check_offset_array(offsets_or_none)
+                if offsets_or_none[-1] != len(points_or_none):
+                    raise ValueError(f"Inconsistent points and offsets in chunk {chunk}")
+            elif not (points_or_none is None and offsets_or_none is None):
+                raise ValueError(f"Inconsistent Nones in chunk {chunk}")
+    elif line_type == LineType.ChunkCombinedNan:
+        if TYPE_CHECKING:
+            lines = cast(cpy.LineReturn_ChunkCombinedNan, lines)
+        _check_tuple_of_lists_with_same_length(lines, 1, allow_empty_lists=False)
+        for chunk, points_or_none in enumerate(lines[0]):
+            if points_or_none is not None:
+                check_point_array(points_or_none)
+    else:
+        raise ValueError(f"Invalid LineType {line_type}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,10 @@ ignore_missing_imports = true
 module = "tests.test_internal"
 disable_error_code = "call-arg"
 
+[[tool.mypy.overrides]]
+module = "tests.test_typecheck"
+disable_error_code = ["arg-type", "list-item"]
+
 
 [tool.ruff]
 exclude = [

--- a/tests/test_typecheck.py
+++ b/tests/test_typecheck.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from contourpy.typecheck import check_code_array, check_offset_array, check_point_array
+from contourpy import FillType, LineType
+from contourpy.typecheck import (
+    check_code_array, check_filled, check_lines, check_offset_array, check_point_array,
+)
 from contourpy.types import code_dtype, offset_dtype, point_dtype
 
 
@@ -53,3 +56,329 @@ def test_check_point_array() -> None:
 
     with pytest.raises(ValueError, match=r"Expected numpy array of shape"):
         check_point_array(np.array([[1.1, 2.2, 3.3, 4.4]], dtype=point_dtype))
+
+
+def test_check_filled_OuterCode() -> None:
+    # Valid filled, does not raise.
+    points = np.array([[1.1, 2.2], [3.3, 4.4], [5.5, 6.6]], dtype=point_dtype)
+    codes = np.array([1, 2, 79], dtype=code_dtype)
+    check_filled(([points], [codes]), FillType.OuterCode)
+
+    with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
+        check_filled(list(), FillType.OuterCode)
+    with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
+        check_filled(([], [], []), FillType.OuterCode)
+    with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
+        check_filled(([], None), FillType.OuterCode)
+    with pytest.raises(ValueError, match=r"Expected 2 lists with same length"):
+        check_filled(([1, 2, 3], [1, 2]), FillType.OuterCode)
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([list(points)], [codes]), FillType.OuterCode)
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([points], [list(codes)]), FillType.OuterCode)
+
+    with pytest.raises(ValueError, match=r"Points and codes have different lengths in polygon 0"):
+        check_filled(([points], [codes[:-1]]), FillType.OuterCode)
+
+
+def test_check_filled_OuterOffset() -> None:
+    # Valid filled, does not raise.
+    points = np.array([[1.1, 2.2], [3.3, 4.4], [5.5, 6.6], [7.7, 8.8]], dtype=point_dtype)
+    offsets = np.array([0, 2, 4], dtype=offset_dtype)
+    check_filled(([points], [offsets]), FillType.OuterOffset)
+
+    with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
+        check_filled(list(), FillType.OuterOffset)
+    with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
+        check_filled(([], [], []), FillType.OuterOffset)
+    with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
+        check_filled(([], None), FillType.OuterOffset)
+    with pytest.raises(ValueError, match=r"Expected 2 lists with same length"):
+        check_filled(([1, 2, 3], [1, 2]), FillType.OuterOffset)
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([list(points)], [offsets]), FillType.OuterOffset)
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([points], [list(offsets)]), FillType.OuterOffset)
+
+    with pytest.raises(ValueError, match=r"Inconsistent points and offsets in polygon 0"):
+        check_filled(([points], [offsets[:-1]]), FillType.OuterOffset)
+
+
+def test_check_filled_ChunkCombinedCode() -> None:
+    # Valid filled, does not raise.
+    points = np.array([[1.1, 2.2], [3.3, 4.4], [5.5, 6.6]], dtype=point_dtype)
+    codes = np.array([1, 2, 79], dtype=code_dtype)
+    check_filled(([points], [codes]), FillType.ChunkCombinedCode)
+    check_filled(([None], [None]), FillType.ChunkCombinedCode)
+    check_filled(([None, points], [None, codes]), FillType.ChunkCombinedCode)
+
+    with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
+        check_filled(list(), FillType.ChunkCombinedCode)
+    with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
+        check_filled(([], [], []), FillType.ChunkCombinedCode)
+    with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
+        check_filled(([], None), FillType.ChunkCombinedCode)
+    with pytest.raises(ValueError, match=r"Expected 2 lists with same length"):
+        check_filled(([1, 2, 3], [1, 2]), FillType.ChunkCombinedCode)
+    with pytest.raises(ValueError, match=r"Expected 2 non-empty lists"):
+        check_filled(([], []), FillType.ChunkCombinedCode)
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([list(points)], [codes]), FillType.ChunkCombinedCode)
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([points], [list(codes)]), FillType.ChunkCombinedCode)
+
+    with pytest.raises(ValueError, match=r"Points and codes have different lengths in chunk 1"):
+        check_filled(([None, points], [None, codes[:-1]]), FillType.ChunkCombinedCode)
+
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_filled(([points], [None]), FillType.ChunkCombinedCode)
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_filled(([None], [codes]), FillType.ChunkCombinedCode)
+
+
+def test_check_filled_ChunkCombinedOffset() -> None:
+    # Valid filled, does not raise.
+    points = np.array([[1.1, 2.2], [3.3, 4.4], [5.5, 6.6], [7.7, 8.8]], dtype=point_dtype)
+    offsets = np.array([0, 2, 4], dtype=offset_dtype)
+    check_filled(([points], [offsets]), FillType.ChunkCombinedOffset)
+    check_filled(([None], [None]), FillType.ChunkCombinedOffset)
+    check_filled(([None, points], [None, offsets]), FillType.ChunkCombinedOffset)
+
+    with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
+        check_filled(list(), FillType.ChunkCombinedOffset)
+    with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
+        check_filled(([], [], []), FillType.ChunkCombinedOffset)
+    with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
+        check_filled(([], None), FillType.ChunkCombinedOffset)
+    with pytest.raises(ValueError, match=r"Expected 2 lists with same length"):
+        check_filled(([1, 2, 3], [1, 2]), FillType.ChunkCombinedOffset)
+    with pytest.raises(ValueError, match=r"Expected 2 non-empty lists"):
+        check_filled(([], []), FillType.ChunkCombinedOffset)
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([list(points)], [offsets]), FillType.ChunkCombinedOffset)
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([points], [list(offsets)]), FillType.ChunkCombinedOffset)
+
+    with pytest.raises(ValueError, match=r"Inconsistent points and offsets in chunk 1"):
+        check_filled(([None, points], [None, offsets[:-1]]), FillType.ChunkCombinedOffset)
+
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_filled(([points], [None]), FillType.ChunkCombinedOffset)
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_filled(([None], [offsets]), FillType.ChunkCombinedOffset)
+
+
+def test_check_filled_ChunkCombinedCodeOffset() -> None:
+    # Valid filled, does not raise.
+    points = np.array([[1.1, 2.2], [3.3, 4.4], [5.5, 6.6], [7.7, 8.8]], dtype=point_dtype)
+    codes = np.array([1, 2, 1, 79], dtype=code_dtype)
+    outer_offsets = np.array([0, 4], dtype=offset_dtype)
+    check_filled(([points], [codes], [outer_offsets]), FillType.ChunkCombinedCodeOffset)
+    check_filled(([None], [None], [None]), FillType.ChunkCombinedCodeOffset)
+    check_filled(([None, points], [None, codes], [None, outer_offsets]),
+                 FillType.ChunkCombinedCodeOffset)
+
+    with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
+        check_filled(list(), FillType.ChunkCombinedCodeOffset)
+    with pytest.raises(ValueError, match=r"Expected tuple of length 3 not 2"):
+        check_filled(([], []), FillType.ChunkCombinedCodeOffset)
+    with pytest.raises(TypeError, match=r"Expected tuple to contain 3 lists"):
+        check_filled(([], None, []), FillType.ChunkCombinedCodeOffset)
+    with pytest.raises(ValueError, match=r"Expected 3 lists with same length"):
+        check_filled(([1, 2, 3], [1, 2], [1, 2, 3]), FillType.ChunkCombinedCodeOffset)
+    with pytest.raises(ValueError, match=r"Expected 3 non-empty lists"):
+        check_filled(([], [], []), FillType.ChunkCombinedCodeOffset)
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([list(points)], [codes], [outer_offsets]), FillType.ChunkCombinedCodeOffset)
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([points], [list(codes)], [outer_offsets]), FillType.ChunkCombinedCodeOffset)
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([points], [codes], [list(outer_offsets)]), FillType.ChunkCombinedCodeOffset)
+
+    with pytest.raises(ValueError, match=r"Points and codes have different lengths in chunk 1"):
+        check_filled(([None, points], [None, codes[:-1]], [None, outer_offsets]),
+                     FillType.ChunkCombinedCodeOffset)
+    with pytest.raises(ValueError, match=r"Inconsistent codes and outer_offsets in chunk 0"):
+        check_filled(([points], [codes], [np.array([0, 4, 5], dtype=offset_dtype)]),
+                     FillType.ChunkCombinedCodeOffset)
+
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_filled(([points], [codes], [None]), FillType.ChunkCombinedCodeOffset)
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_filled(([points], [None], [outer_offsets]), FillType.ChunkCombinedCodeOffset)
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_filled(([None], [codes], [outer_offsets]), FillType.ChunkCombinedCodeOffset)
+
+
+def test_check_filled_ChunkCombinedOffsetOffset() -> None:
+    # Valid filled, does not raise.
+    points = np.array([[1.1, 2.2], [3.3, 4.4], [5.5, 6.6], [7.7, 8.8]], dtype=point_dtype)
+    offsets = np.array([0, 2, 4], dtype=offset_dtype)
+    outer_offsets = np.array([0, 2], dtype=offset_dtype)
+    check_filled(([points], [offsets], [outer_offsets]), FillType.ChunkCombinedOffsetOffset)
+    check_filled(([None], [None], [None]), FillType.ChunkCombinedOffsetOffset)
+    check_filled(([None, points], [None, offsets], [None, outer_offsets]),
+                 FillType.ChunkCombinedOffsetOffset)
+
+    with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
+        check_filled(list(), FillType.ChunkCombinedOffsetOffset)
+    with pytest.raises(ValueError, match=r"Expected tuple of length 3 not 2"):
+        check_filled(([], []), FillType.ChunkCombinedOffsetOffset)
+    with pytest.raises(TypeError, match=r"Expected tuple to contain 3 lists"):
+        check_filled(([], None, []), FillType.ChunkCombinedOffsetOffset)
+    with pytest.raises(ValueError, match=r"Expected 3 lists with same length"):
+        check_filled(([1, 2, 3], [1, 2], [1, 2, 3]), FillType.ChunkCombinedOffsetOffset)
+    with pytest.raises(ValueError, match=r"Expected 3 non-empty lists"):
+        check_filled(([], [], []), FillType.ChunkCombinedOffsetOffset)
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([list(points)], [offsets], [outer_offsets]),
+                      FillType.ChunkCombinedOffsetOffset)
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([points], [list(offsets)], [outer_offsets]),
+                      FillType.ChunkCombinedOffsetOffset)
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_filled(([points], [offsets], [list(outer_offsets)]),
+                      FillType.ChunkCombinedOffsetOffset)
+
+    with pytest.raises(ValueError, match=r"Inconsistent points and offsets in chunk 1"):
+        check_filled(([None, points], [None, offsets[:-1]], [None, outer_offsets]),
+                     FillType.ChunkCombinedOffsetOffset)
+    with pytest.raises(ValueError, match=r"Inconsistent offsets and outer_offsets in chunk 0"):
+        check_filled(([points], [offsets], [np.array([0, 4, 5], dtype=offset_dtype)]),
+                     FillType.ChunkCombinedOffsetOffset)
+
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_filled(([points], [offsets], [None]), FillType.ChunkCombinedOffsetOffset)
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_filled(([points], [None], [outer_offsets]), FillType.ChunkCombinedOffsetOffset)
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_filled(([None], [offsets], [outer_offsets]), FillType.ChunkCombinedOffsetOffset)
+
+
+def test_check_lines_Separate() -> None:
+    # Valid lines, does not raise.
+    points = np.array([[1.1, 2.2], [3.3, 4.4]], dtype=point_dtype)
+    check_lines([points], LineType.Separate)
+
+    with pytest.raises(TypeError, match=r"Expected list not <class 'tuple'>"):
+        check_lines(tuple(), LineType.Separate)
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'>"):
+        check_lines([[]], LineType.Separate)
+
+
+def test_check_lines_SeparateCode() -> None:
+    # Valid lines, does not raise.
+    points = np.array([[1.1, 2.2], [3.3, 4.4], [5.5, 6.6]], dtype=point_dtype)
+    codes = np.array([1, 2, 79], dtype=code_dtype)
+    check_lines(([points], [codes]), LineType.SeparateCode)
+
+    with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
+        check_lines(list(), LineType.SeparateCode)
+    with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
+        check_lines(([], [], []), LineType.SeparateCode)
+    with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
+        check_lines(([], None), LineType.SeparateCode)
+    with pytest.raises(ValueError, match=r"Expected 2 lists with same length"):
+        check_lines(([1, 2, 3], [1, 2]), LineType.SeparateCode)
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_lines(([list(points)], [codes]), LineType.SeparateCode)
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'"):
+        check_lines(([points], [list(codes)]), LineType.SeparateCode)
+
+    with pytest.raises(ValueError, match=r"Points and codes have different lengths in line 0"):
+        check_lines(([points], [codes[:-1]]), LineType.SeparateCode)
+
+
+def test_check_lines_ChunkCombinedCode() -> None:
+    # Valid lines, does not raise.
+    points = np.array([[1.1, 2.2], [3.3, 4.4], [5.5, 6.6], [7.7, 8.8]], dtype=point_dtype)
+    codes = np.array([1, 2, 1, 2], dtype=code_dtype)
+    check_lines(([points], [codes]), LineType.ChunkCombinedCode)
+    check_lines(([None], [None]), LineType.ChunkCombinedCode)
+    check_lines(([None, points], [None, codes]), LineType.ChunkCombinedCode)
+
+    with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
+        check_lines(list(), LineType.ChunkCombinedCode)
+    with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
+        check_lines(([], [], []), LineType.ChunkCombinedCode)
+    with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
+        check_lines(([], None), LineType.ChunkCombinedCode)
+    with pytest.raises(ValueError, match=r"Expected 2 lists with same length"):
+        check_lines(([None, None], [None]), LineType.ChunkCombinedCode)
+    with pytest.raises(ValueError, match=r"Expected 2 non-empty lists"):
+        check_lines(([], []), LineType.ChunkCombinedCode)
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'>"):
+        check_lines(([list(points)], [codes]), LineType.ChunkCombinedCode)
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'>"):
+        check_lines(([points], [list(codes)]), LineType.ChunkCombinedCode)
+
+    with pytest.raises(ValueError, match=r"Points and codes have different lengths in chunk 1"):
+        check_lines(([None, points], [None, codes[:-1]]), LineType.ChunkCombinedCode)
+
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_lines(([points], [None]), LineType.ChunkCombinedCode)
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_lines(([None], [codes]), LineType.ChunkCombinedCode)
+
+
+def test_check_lines_ChunkCombinedOffset() -> None:
+    # Valid lines, does not raise.
+    points = np.array([[1.1, 2.2], [3.3, 4.4], [5.5, 6.6], [7.7, 8.8]], dtype=point_dtype)
+    offsets = np.array([0, 2, 4], dtype=offset_dtype)
+    check_lines(([points], [offsets]), LineType.ChunkCombinedOffset)
+    check_lines(([None], [None]), LineType.ChunkCombinedOffset)
+    check_lines(([None, points], [None, offsets]), LineType.ChunkCombinedOffset)
+
+    with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
+        check_lines(list(), LineType.ChunkCombinedOffset)
+    with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
+        check_lines(([], [], []), LineType.ChunkCombinedOffset)
+    with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
+        check_lines(([], None), LineType.ChunkCombinedOffset)
+    with pytest.raises(ValueError, match=r"Expected 2 lists with same length"):
+        check_lines(([None, None], [None]), LineType.ChunkCombinedOffset)
+    with pytest.raises(ValueError, match=r"Expected 2 non-empty lists"):
+        check_lines(([], []), LineType.ChunkCombinedOffset)
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'>"):
+        check_lines(([list(points)], [offsets]), LineType.ChunkCombinedOffset)
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'>"):
+        check_lines(([points], [list(offsets)]), LineType.ChunkCombinedOffset)
+
+    with pytest.raises(ValueError, match=r"Inconsistent points and offsets in chunk 1"):
+        check_lines(([None, points], [None, offsets[:-1]]), LineType.ChunkCombinedOffset)
+
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_lines(([points], [None]), LineType.ChunkCombinedOffset)
+    with pytest.raises(ValueError, match=r"Inconsistent Nones in chunk 0"):
+        check_lines(([None], [offsets]), LineType.ChunkCombinedOffset)
+
+
+def test_check_lines_ChunkCombinedNan() -> None:
+    # Valid lines, does not raise.
+    points = np.array([[1.1, 2.2], [3.3, 4.4], [np.nan, np.nan], [5.5, 6.6], [7.7, 8.8]],
+                       dtype=point_dtype)
+    check_lines(([points],), LineType.ChunkCombinedNan)
+    check_lines(([None],), LineType.ChunkCombinedNan)
+    check_lines(([None, points],), LineType.ChunkCombinedNan)
+
+    with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
+        check_lines(list(), LineType.ChunkCombinedNan)
+    with pytest.raises(ValueError, match=r"Expected tuple of length 1 not 2"):
+        check_lines(([], []), LineType.ChunkCombinedNan)
+    with pytest.raises(TypeError, match=r"Expected tuple to contain 1 lists"):
+        check_lines((None,), LineType.ChunkCombinedNan)
+    with pytest.raises(ValueError, match=r"Expected 1 non-empty lists"):
+        check_lines(([],), LineType.ChunkCombinedNan)
+
+    with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'>"):
+        check_lines(([list(points)],), LineType.ChunkCombinedNan)


### PR DESCRIPTION
This adds extra internal validation functions `check_filled` and `check_lines` to the `convert_*` and `dechunk_*` functions, to check that the inputs are reasonable. They don't check absolutely everything, like the array checking functions they will walk tuples and lists (e.g. chunked data) but not the contained arrays because that might take a long time.

Most of the new code is tests that all the various error modes are caught for each of the different `FillType` and `LineType`.