### PR TITLE
Raise if call filled() with lower_level==upper_level

### DIFF
--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -353,8 +353,8 @@ LineType BaseContourGenerator<Derived>::default_line_type()
 template <typename Derived>
 py::sequence BaseContourGenerator<Derived>::filled(double lower_level, double upper_level)
 {
-    if (lower_level > upper_level)
-        throw std::invalid_argument("upper and lower levels are the wrong way round");
+    if (lower_level >= upper_level)
+        throw std::invalid_argument("upper_level must be larger than lower_level");
 
     _filled = true;
     _lower_level = lower_level;

--- a/src/mpl2005.cpp
+++ b/src/mpl2005.cpp
@@ -48,8 +48,8 @@ Mpl2005ContourGenerator::~Mpl2005ContourGenerator()
 
 py::tuple Mpl2005ContourGenerator::filled(const double& lower_level, const double& upper_level)
 {
-    if (lower_level > upper_level)
-        throw std::invalid_argument("upper and lower levels are the wrong way round");
+    if (lower_level >= upper_level)
+        throw std::invalid_argument("upper_level must be larger than lower_level");
 
     double levels[2] = {lower_level, upper_level};
     return cntr_trace(_site, levels, 2);

--- a/src/mpl2014.cpp
+++ b/src/mpl2014.cpp
@@ -485,8 +485,8 @@ void Mpl2014ContourGenerator::edge_interp(
 py::tuple Mpl2014ContourGenerator::filled(
     const double& lower_level, const double& upper_level)
 {
-    if (lower_level > upper_level)
-        throw std::invalid_argument("upper and lower levels are the wrong way round");
+    if (lower_level >= upper_level)
+        throw std::invalid_argument("upper_level must be larger than lower_level");
 
     init_cache_levels(lower_level, upper_level);
 

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -36,8 +36,15 @@ def xyz_chunk_test() -> tuple[cpy.CoordinateArray, ...]:
 @pytest.mark.parametrize("name", util_test.all_names())
 def test_filled_decreasing_levels(name: str) -> None:
     cont_gen = contour_generator(z=[[0, 1], [2, 3]], name=name, fill_type=FillType.OuterCode)
-    with pytest.raises(ValueError, match="upper and lower levels are the wrong way round"):
+    with pytest.raises(ValueError, match="upper_level must be larger than lower_level"):
         cont_gen.filled(2.0, 1.0)
+
+
+@pytest.mark.parametrize("name", util_test.all_names())
+def test_filled_identical_levels(name: str) -> None:
+    cont_gen = contour_generator(z=[[0, 1], [2, 3]], name=name, fill_type=FillType.OuterCode)
+    with pytest.raises(ValueError, match="upper_level must be larger than lower_level"):
+        cont_gen.filled(2.0, 2.0)
 
 
 @pytest.mark.image
@@ -909,11 +916,16 @@ def test_filled_compare_slow(seed: int) -> None:
 
 @pytest.mark.parametrize("name", util_test.all_names())
 @pytest.mark.parametrize("z", [np.nan, -np.nan, np.inf, -np.inf])
-@pytest.mark.parametrize("zlevel", [0.0, np.nan, -np.nan, np.inf, -np.inf])
-def test_filled_z_nonfinite(name: str, z: float, zlevel: float) -> None:
+@pytest.mark.parametrize("lower_level", [0.0, np.nan, -np.nan, np.inf, -np.inf])
+@pytest.mark.parametrize("upper_level", [0.0, np.nan, -np.nan, np.inf, -np.inf])
+def test_filled_z_nonfinite(name: str, z: float, lower_level: float, upper_level: float) -> None:
     cont_gen = contour_generator(z=[[z, z], [z, z]], name=name, fill_type=FillType.OuterCode)
-    filled = cont_gen.filled(zlevel, zlevel)
-    assert filled == ([], [])
+    if lower_level >= upper_level:
+        with pytest.raises(ValueError, match="upper_level must be larger than lower_level"):
+            cont_gen.filled(lower_level, upper_level)
+    else:
+        filled = cont_gen.filled(lower_level, upper_level)
+        assert filled == ([], [])
 
 
 @pytest.mark.parametrize("name", util_test.all_names())


### PR DESCRIPTION
ContourPy has always raised a `ValueError` if `filled()` is called with a `lower_level` that is larger than the `upper_level`. This PR also raises if `lower_level == upper_level`. The exception text for both is now "upper_level must be larger than lower_level" for all algorithms.

Instead of using `filled(level, level)` use `lines(level)` instead.