### PR TITLE
Add ruff C4 rules

### DIFF
--- a/benchmarks/plot_benchmarks.py
+++ b/benchmarks/plot_benchmarks.py
@@ -86,7 +86,7 @@ def by_name_and_type(loader: Loader, filled: bool, dataset: str, render: bool, n
 
             i = 0
             for corner_mask in corner_masks:
-                kwargs = dict(name=name, dataset=dataset, corner_mask=corner_mask, n=n)
+                kwargs = {"name": name, "dataset": dataset, "corner_mask": corner_mask, "n": n}
 
                 results = loader.get(benchmarks_name, **kwargs)
                 if results["name"] != name:
@@ -201,7 +201,7 @@ def comparison_two_benchmarks(
     corner_mask = "no mask"
 
     filled_str = "filled" if filled else "lines"
-    kwargs: dict[str, Any] = dict(dataset=dataset, corner_mask=corner_mask, n=n)
+    kwargs: dict[str, Any] = {"dataset":dataset, "corner_mask": corner_mask, "n": n}
     if varying == "thread_count":
         kwargs["total_chunk_count"] = 40
 
@@ -237,7 +237,8 @@ def comparison_two_benchmarks(
     speedups_flat = speedups.ravel()
 
     def in_bar_label(ax: Axes, rect: Rectangle, value: str) -> None:
-        kwargs: dict[str, Any] = dict(fontsize="medium", ha="center", va="bottom", color="k")
+        kwargs: dict[str, Any] = {"fontsize": "medium", "ha": "center", "va": "bottom",
+                                  "color": "k"}
         if varying != "thread_count":
             kwargs["rotation"] = "vertical"
         ax.annotate(value, (rect.xy[0] + 0.5*rect.get_width(), rect.xy[1]), **kwargs)

--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -41,12 +41,12 @@ __all__ = [
 
 
 # Simple mapping of algorithm name to class name.
-_class_lookup: dict[str, type[ContourGenerator]] = dict(
-    mpl2005=Mpl2005ContourGenerator,
-    mpl2014=Mpl2014ContourGenerator,
-    serial=SerialContourGenerator,
-    threaded=ThreadedContourGenerator,
-)
+_class_lookup: dict[str, type[ContourGenerator]] = {
+    "mpl2005": Mpl2005ContourGenerator,
+    "mpl2014": Mpl2014ContourGenerator,
+    "serial": SerialContourGenerator,
+    "threaded": ThreadedContourGenerator,
+}
 
 
 def _remove_z_mask(

--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -146,21 +146,21 @@ class BokehRenderer(Renderer):
         """
         fig = self._get_figure(ax)
         x, y = self._grid_as_2d(x, y)
-        xs = [row for row in x] + [row for row in x.T]
-        ys = [row for row in y] + [row for row in y.T]
-        kwargs = dict(line_color=color, alpha=alpha)
+        xs = list(x) + list(x.T)
+        ys = list(y) + list(y.T)
+        kwargs = {"line_color": color, "alpha": alpha}
         fig.multi_line(xs, ys, **kwargs)
         if quad_as_tri_alpha > 0:
             # Assumes no quad mask.
             xmid = (0.25*(x[:-1, :-1] + x[1:, :-1] + x[:-1, 1:] + x[1:, 1:])).ravel()
             ymid = (0.25*(y[:-1, :-1] + y[1:, :-1] + y[:-1, 1:] + y[1:, 1:])).ravel()
             fig.multi_line(
-                [row for row in np.stack((x[:-1, :-1].ravel(), xmid, x[1:, 1:].ravel()), axis=1)],
-                [row for row in np.stack((y[:-1, :-1].ravel(), ymid, y[1:, 1:].ravel()), axis=1)],
+                list(np.stack((x[:-1, :-1].ravel(), xmid, x[1:, 1:].ravel()), axis=1)),
+                list(np.stack((y[:-1, :-1].ravel(), ymid, y[1:, 1:].ravel()), axis=1)),
                 **kwargs)
             fig.multi_line(
-                [row for row in np.stack((x[:-1, 1:].ravel(), xmid, x[1:, :-1].ravel()), axis=1)],
-                [row for row in np.stack((y[:-1, 1:].ravel(), ymid, y[1:, :-1].ravel()), axis=1)],
+                list(np.stack((x[:-1, 1:].ravel(), xmid, x[1:, :-1].ravel()), axis=1)),
+                list(np.stack((y[:-1, 1:].ravel(), ymid, y[1:, :-1].ravel()), axis=1)),
                 **kwargs)
         if point_color is not None:
             fig.circle(
@@ -323,7 +323,7 @@ class BokehRenderer(Renderer):
         x, y = self._grid_as_2d(x, y)
         z = np.asarray(z)
         ny, nx = z.shape
-        kwargs = dict(text_color=color, text_align="center", text_baseline="middle")
+        kwargs = {"text_color": color, "text_align": "center", "text_baseline": "middle"}
         for j in range(ny):
             for i in range(nx):
                 fig.add_layout(Label(x=x[j, i], y=y[j, i], text=f"{z[j, i]:{fmt}}", **kwargs))

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -53,11 +53,12 @@ class MplRenderer(Renderer):
             import matplotlib as mpl
             mpl.use(backend)
 
-        kwargs: dict[str, Any] = dict(figsize=figsize, squeeze=False, sharex=True, sharey=True)
+        kwargs: dict[str, Any] = {"figsize": figsize, "squeeze": False,
+                                  "sharex": True, "sharey": True}
         if gridspec_kw is not None:
             kwargs["gridspec_kw"] = gridspec_kw
         else:
-            kwargs["subplot_kw"] = dict(aspect="equal")
+            kwargs["subplot_kw"] = {"aspect": "equal"}
 
         self._fig, axes = plt.subplots(nrows, ncols, **kwargs)
         self._axes = axes.flatten()
@@ -146,7 +147,7 @@ class MplRenderer(Renderer):
         """
         ax = self._get_ax(ax)
         x, y = self._grid_as_2d(x, y)
-        kwargs: dict[str, Any] = dict(color=color, alpha=alpha)
+        kwargs: dict[str, Any] = {"color": color, "alpha": alpha}
         ax.plot(x, y, x.T, y.T, **kwargs)
         if quad_as_tri_alpha > 0:
             # Assumes no quad mask.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,12 +161,12 @@ line-length = 100
 select = [
     "B",
     "BLE",
+    "C4",
     "COM",
     "E",
     "F",
     "FA",
     "FLY",
-    "FURB",
     "G",
     "ICN",
     "INT",

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -902,7 +902,7 @@ def test_filled_compare_slow(seed: int) -> None:
         code_list = filled_mpl2014[1]
         n_points = reduce(add, map(len, code_list))
         n_outers = len(code_list)
-        n_lines = reduce(add, map(lambda c: np.count_nonzero(c == 1), code_list))
+        n_lines = reduce(add, (np.count_nonzero(c == 1) for c in code_list))
 
         assert filled_serial[0][0] is not None
         assert n_points == len(filled_serial[0][0])

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -80,7 +80,7 @@ def test_renderer_filled(show_text: bool, debug: bool, fill_type: FillType) -> N
     from .image_comparison import compare_images
 
     # Same results from MplDebugRenderer if extra kwargs supplied to renderer.Filled() call.
-    filled_kw: dict[str, Any] = dict(line_color=None, point_color=None) if debug else {}
+    filled_kw: dict[str, Any] = {"line_color": None, "point_color": None} if debug else {}
 
     if not debug:
         renderer = MplRenderer(ncols=2, figsize=(8, 3), show_frame=False)
@@ -126,7 +126,7 @@ def test_renderer_lines(show_text: bool, debug: bool, line_type: LineType) -> No
     from .image_comparison import compare_images
 
     # Same results from MplDebugRenderer if extra kwargs supplied to renderer.lines() call.
-    lines_kw: dict[str, Any] = dict(arrow_size=0, point_color=None) if debug else {}
+    lines_kw: dict[str, Any] = {"arrow_size": 0, "point_color": None} if debug else {}
 
     if not debug:
         renderer = MplRenderer(ncols=2, figsize=(8, 3), show_frame=show_text)

--- a/tests/test_typecheck.py
+++ b/tests/test_typecheck.py
@@ -65,7 +65,7 @@ def test_check_filled_OuterCode() -> None:
     check_filled(([points], [codes]), FillType.OuterCode)
 
     with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
-        check_filled(list(), FillType.OuterCode)
+        check_filled([], FillType.OuterCode)
     with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
         check_filled(([], [], []), FillType.OuterCode)
     with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
@@ -89,7 +89,7 @@ def test_check_filled_OuterOffset() -> None:
     check_filled(([points], [offsets]), FillType.OuterOffset)
 
     with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
-        check_filled(list(), FillType.OuterOffset)
+        check_filled([], FillType.OuterOffset)
     with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
         check_filled(([], [], []), FillType.OuterOffset)
     with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
@@ -115,7 +115,7 @@ def test_check_filled_ChunkCombinedCode() -> None:
     check_filled(([None, points], [None, codes]), FillType.ChunkCombinedCode)
 
     with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
-        check_filled(list(), FillType.ChunkCombinedCode)
+        check_filled([], FillType.ChunkCombinedCode)
     with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
         check_filled(([], [], []), FillType.ChunkCombinedCode)
     with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
@@ -148,7 +148,7 @@ def test_check_filled_ChunkCombinedOffset() -> None:
     check_filled(([None, points], [None, offsets]), FillType.ChunkCombinedOffset)
 
     with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
-        check_filled(list(), FillType.ChunkCombinedOffset)
+        check_filled([], FillType.ChunkCombinedOffset)
     with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
         check_filled(([], [], []), FillType.ChunkCombinedOffset)
     with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
@@ -183,7 +183,7 @@ def test_check_filled_ChunkCombinedCodeOffset() -> None:
                  FillType.ChunkCombinedCodeOffset)
 
     with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
-        check_filled(list(), FillType.ChunkCombinedCodeOffset)
+        check_filled([], FillType.ChunkCombinedCodeOffset)
     with pytest.raises(ValueError, match=r"Expected tuple of length 3 not 2"):
         check_filled(([], []), FillType.ChunkCombinedCodeOffset)
     with pytest.raises(TypeError, match=r"Expected tuple to contain 3 lists"):
@@ -226,7 +226,7 @@ def test_check_filled_ChunkCombinedOffsetOffset() -> None:
                  FillType.ChunkCombinedOffsetOffset)
 
     with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
-        check_filled(list(), FillType.ChunkCombinedOffsetOffset)
+        check_filled([], FillType.ChunkCombinedOffsetOffset)
     with pytest.raises(ValueError, match=r"Expected tuple of length 3 not 2"):
         check_filled(([], []), FillType.ChunkCombinedOffsetOffset)
     with pytest.raises(TypeError, match=r"Expected tuple to contain 3 lists"):
@@ -267,7 +267,7 @@ def test_check_lines_Separate() -> None:
     check_lines([points], LineType.Separate)
 
     with pytest.raises(TypeError, match=r"Expected list not <class 'tuple'>"):
-        check_lines(tuple(), LineType.Separate)
+        check_lines((), LineType.Separate)
 
     with pytest.raises(TypeError, match=r"Expected numpy array not <class 'list'>"):
         check_lines([[]], LineType.Separate)
@@ -280,7 +280,7 @@ def test_check_lines_SeparateCode() -> None:
     check_lines(([points], [codes]), LineType.SeparateCode)
 
     with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
-        check_lines(list(), LineType.SeparateCode)
+        check_lines([], LineType.SeparateCode)
     with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
         check_lines(([], [], []), LineType.SeparateCode)
     with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
@@ -306,7 +306,7 @@ def test_check_lines_ChunkCombinedCode() -> None:
     check_lines(([None, points], [None, codes]), LineType.ChunkCombinedCode)
 
     with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
-        check_lines(list(), LineType.ChunkCombinedCode)
+        check_lines([], LineType.ChunkCombinedCode)
     with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
         check_lines(([], [], []), LineType.ChunkCombinedCode)
     with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
@@ -339,7 +339,7 @@ def test_check_lines_ChunkCombinedOffset() -> None:
     check_lines(([None, points], [None, offsets]), LineType.ChunkCombinedOffset)
 
     with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
-        check_lines(list(), LineType.ChunkCombinedOffset)
+        check_lines([], LineType.ChunkCombinedOffset)
     with pytest.raises(ValueError, match=r"Expected tuple of length 2 not 3"):
         check_lines(([], [], []), LineType.ChunkCombinedOffset)
     with pytest.raises(TypeError, match=r"Expected tuple to contain 2 lists"):
@@ -372,7 +372,7 @@ def test_check_lines_ChunkCombinedNan() -> None:
     check_lines(([None, points],), LineType.ChunkCombinedNan)
 
     with pytest.raises(TypeError, match=r"Expected tuple not <class 'list'>"):
-        check_lines(list(), LineType.ChunkCombinedNan)
+        check_lines([], LineType.ChunkCombinedNan)
     with pytest.raises(ValueError, match=r"Expected tuple of length 1 not 2"):
         check_lines(([], []), LineType.ChunkCombinedNan)
     with pytest.raises(TypeError, match=r"Expected tuple to contain 1 lists"):

--- a/tests/util_config.py
+++ b/tests/util_config.py
@@ -69,7 +69,7 @@ class Config:
         self.marker_size = 3.5
         self.gap = 0.1
         self.text_gap = self.gap/2
-        self.grid_kwargs = dict(color="gray", linewidth=0.35)
+        self.grid_kwargs = {"color": "gray", "linewidth": 0.35}
         self.fill_alpha = 0.2
 
         self.x, self.y = np.meshgrid([0.0, 1.0], [0.0, 1.0])
@@ -380,7 +380,7 @@ class ConfigFilled(ConfigFilledCommon):
     def __init__(self, name: str, quad_as_tri: bool = False, show_text: bool = True) -> None:
         super().__init__(name, False, quad_as_tri, show_text)
 
-        subplot_kw = dict(aspect="equal")
+        subplot_kw = {"aspect": "equal"}
         if self.quad_as_tri:
             self.fig, axes = plt.subplots(18, 12, figsize=(10.4, 17.1), subplot_kw=subplot_kw)
         else:
@@ -546,7 +546,7 @@ class ConfigLines(ConfigLinesCommon):
     def __init__(self, name: str, quad_as_tri: bool = False, show_text: bool = True) -> None:
         super().__init__(name, False, quad_as_tri, show_text)
 
-        subplot_kw = dict(aspect="equal")
+        subplot_kw = {"aspect": "equal"}
         if self.quad_as_tri:
             self.fig, axes = plt.subplots(5, 6, figsize=(5.2, 4.75), subplot_kw=subplot_kw)
         else:


### PR DESCRIPTION
Add ruff C4 rules, unnecessary `list`, `dict`, `map`, `tuple` calls.