### PR TITLE
Update CI following NumPy 1.26.2 release

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,7 +38,7 @@ linux_aarch64_test_task:
   install_numpy_from_source_script:
     if [[ "$BUILD_NUMPY" == "1" ]];
     then
-      python -m pip install -v --no-binary=numpy numpy -Csetup-args="-Dallow-noblas=true";
+      python -m pip install -v --no-binary=numpy numpy";
     fi
 
   install_contourpy_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,11 +12,11 @@ linux_aarch64_test_task:
         IMAGE_SUFFIX: slim
         BUILD_NUMPY: 0
         TEST_NO_IMAGES: 0
-    - env:
-        PYTHON_VERSION: "3.11"
-        IMAGE_SUFFIX: alpine
-        BUILD_NUMPY: 1
-        TEST_NO_IMAGES: 1
+    #- env:
+    #    PYTHON_VERSION: "3.11"
+    #    IMAGE_SUFFIX: alpine
+    #    BUILD_NUMPY: 1
+    #    TEST_NO_IMAGES: 1
 
   os_dependencies_script: |
     if [[ "$IMAGE_SUFFIX" != "alpine" ]];
@@ -38,7 +38,7 @@ linux_aarch64_test_task:
   install_numpy_from_source_script:
     if [[ "$BUILD_NUMPY" == "1" ]];
     then
-      python -m pip install -v --no-binary=numpy numpy";
+      python -m pip install -v --no-binary=numpy numpy;
     fi
 
   install_contourpy_script: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -291,6 +291,12 @@ jobs:
             image: musllinux_1_1_x86_64
             venv: venv
             test: test
+          # musllinux aarch64.
+          - arch: aarch64
+            manylinux_version: musllinux
+            image: musllinux_1_1_aarch64
+            venv: venv
+            test: test-no-images
           # ppc64le and s390x: dependencies are conda packages.
           - arch: ppc64le
             manylinux_version: manylinux2014
@@ -364,8 +370,8 @@ jobs:
 
             if [[ $TEST == "test-no-images" ]]
             then
-              echo "==> Run non-image tests"
-              python -m pytest -v -n auto --color=yes tests/ -k "not image"
+              echo "==> Run non-image and non-big tests"
+              python -m pytest -v -n auto --color=yes tests/ -k "not (big or image)"
             else
               echo "==> Run tests except 'big' ones as on emulated hardware"
               python -m pytest -v -n auto --color=yes tests/ -k "not big"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,12 +176,12 @@ jobs:
       - name: Build and install numpy from sdist
         if: matrix.build-numpy
         run: |
-          python -m pip install -v --no-binary=numpy numpy -Csetup-args="-Dallow-noblas=true"
+          python -m pip install -v --no-binary=numpy numpy"
 
       - name: Build and install numpy from sdist with debug asserts enabled
         if: matrix.build-numpy-debug
         run: |
-          python -m pip install -v --no-binary=numpy numpy -Csetup-args="-Dallow-noblas=true" -Csetup-args=-Dbuildtype=debug
+          python -m pip install -v --no-binary=numpy numpy -Csetup-args=-Dbuildtype=debug
 
       - name: Pre-install Python dependencies
         run: |


### PR DESCRIPTION
Some updates to CI following the release of NumPy 1.26.2.

1. No longer need `-D=allow-noblas=true` when building NumPy from source as this is the default.
2. Availability of NumPy `musllinux_aarch64` wheels means we no longer need to build NumPy from source to test on `musllinux_aarch64`, so move those tests to github actions (QEMU+docker) from Cirrus CI.