### PR TITLE
Support running tests on unicore hosts

### DIFF
--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 
-from contourpy import FillType, contour_generator
+from contourpy import FillType, contour_generator, max_threads
 from contourpy.util.data import random, simple
 
 from . import util_test
@@ -734,7 +734,10 @@ def test_return_by_fill_type(
 @pytest.mark.threads
 @pytest.mark.parametrize("fill_type", FillType.__members__.values())
 @pytest.mark.parametrize("name, thread_count",
-                         [("serial", 1), ("threaded", 1), ("threaded", 2)])
+                         [("serial", 1), ("threaded", 1),
+                         pytest.param("threaded", 2,
+                            marks = pytest.mark.skipif(
+                            max_threads() <= 1, reason = "executing on unicore host"))])
 def test_return_by_fill_type_chunk(
     xyz_chunk_test: tuple[cpy.CoordinateArray, ...],
     name: str,

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 
-from contourpy import LineType, contour_generator
+from contourpy import LineType, contour_generator, max_threads
 from contourpy.util.data import random, simple
 
 from . import util_test
@@ -707,7 +707,10 @@ def test_return_by_line_type(
 @pytest.mark.threads
 @pytest.mark.parametrize("line_type", LineType.__members__.values())
 @pytest.mark.parametrize("name, thread_count",
-                         [("serial", 1), ("threaded", 1), ("threaded", 2)])
+                         [("serial", 1), ("threaded", 1),
+                         pytest.param("threaded", 2,
+                            marks = pytest.mark.skipif(
+                            max_threads() <= 1, reason = "executing on unicore host"))])
 def test_return_by_line_type_chunk(
     xyz_chunk_test: tuple[cpy.CoordinateArray, ...],
     name: str,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,13 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from contourpy import _remove_z_mask, contour_generator, max_threads
-
-
-def test_max_threads() -> None:
-    n = max_threads()
-    # Assume testing on machine with 2 or more cores.
-    assert n > 1
+from contourpy import _remove_z_mask, contour_generator
 
 
 def test_nan() -> None:


### PR DESCRIPTION
All tests pass except those explicitly asserting that they are on a multicore system.  Adds a conditional skip to those which are only useful on multicore hosts.