### PR TITLE
Add pytest option to log image differences to CSV file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -328,7 +328,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: quay.io/pypa/${{ matrix.image }}:latest
-          options: -v ${{ github.workspace }}:/work -e ARCH=${{ matrix.arch }} -e VENV=${{ matrix.venv}} -e TEST=${{ matrix.test }}
+          options: -v ${{ github.workspace }}:/work -e ARCH=${{ matrix.arch }} -e VENV=${{ matrix.venv}} -e TEST=${{ matrix.test }} -e PYTEST=${PYTEST}
           shell: bash
           run: |
             echo "-------------------- start --------------------"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -328,7 +328,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: quay.io/pypa/${{ matrix.image }}:latest
-          options: -v ${{ github.workspace }}:/work -e ARCH=${{ matrix.arch }} -e VENV=${{ matrix.venv}} -e TEST=${{ matrix.test }} -e PYTEST=${PYTEST}
+          options: -v ${{ github.workspace }}:/work -e ARCH=${{ matrix.arch }} -e VENV=${{ matrix.venv}} -e TEST=${{ matrix.test }}
           shell: bash
           run: |
             echo "-------------------- start --------------------"
@@ -371,6 +371,7 @@ jobs:
             python -m pip list
             python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"
 
+            PYTEST="python -m pytest -v -n auto --color=yes --log-image-diffs"
             if [[ $TEST == "test-no-images" ]]
             then
               echo "==> Run non-image and non-big tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  PYTEST: python -m pytest -v -n auto --color=yes --log-image-diffs
+
 jobs:
   pre-commit:
     name: pre-commit
@@ -67,7 +70,7 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m pytest -v -n auto --color=yes tests/test_codebase.py
+          ${PYTEST} tests/test_codebase.py
 
   test:
     name: "${{ matrix.name }} ${{ matrix.python-version }} ${{ matrix.os }}"
@@ -228,22 +231,22 @@ jobs:
           if [[ "${{ matrix.debug }}" != "" ]]
           then
             echo "Run normal tests with coverage"
-            python -m pytest -v -n auto --color=yes tests/ --cov=lib --cov-report=lcov
+            ${PYTEST} tests/ --cov=lib --cov-report=lcov
           elif [[ "${{ matrix.test-text }}" != "" ]]
           then
             echo "Run normal and text tests with coverage"
-            python -m pytest -v -n auto --color=yes -rP tests/test_bokeh_renderer.py tests/test_renderer.py --runtext --driver-path=/snap/bin/chromium.chromedriver --cov=lib --cov-report=lcov
+            ${PYTEST} -rP tests/test_bokeh_renderer.py tests/test_renderer.py --runtext --driver-path=/snap/bin/chromium.chromedriver --cov=lib --cov-report=lcov
           elif [[ "${{ matrix.test-no-images }}" != "" ]]
           then
             echo "Run only tests that do not generate images"
-            python -m pytest -v -n auto --color=yes tests/ -k "not image"
+            ${PYTEST} tests/ -k "not image"
           elif [[ "${{ matrix.test-no-big }}" != "" ]]
           then
             echo "Run all tests except big ones"
-            python -m pytest -v -n auto --color=yes tests/ -k "not big"
+            ${PYTEST} tests/ -k "not big"
           else
             echo "Run all tests"
-            python -m pytest -v -n auto --color=yes tests/
+            ${PYTEST} tests/
           fi
 
       - name: Collect C++ coverage
@@ -371,10 +374,10 @@ jobs:
             if [[ $TEST == "test-no-images" ]]
             then
               echo "==> Run non-image and non-big tests"
-              python -m pytest -v -n auto --color=yes tests/ -k "not (big or image)"
+              ${PYTEST} tests/ -k "not (big or image)"
             else
               echo "==> Run tests except 'big' ones as on emulated hardware"
-              python -m pytest -v -n auto --color=yes tests/ -k "not big"
+              ${PYTEST} tests/ -k "not big"
             fi
             echo "-------------------- end --------------------"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -12,6 +13,23 @@ if TYPE_CHECKING:
     from _pytest.fixtures import SubRequest
 
 
+image_diffs_log: list[str] = []
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    if session.config.getoption("--log-image-diffs"):
+        result_directory = "result_images"
+        if not os.path.exists(result_directory):
+            os.makedirs(result_directory)
+
+        log_filename = os.path.join(result_directory, "image_diffs.log")
+        print(f"\nWriting to {log_filename}")
+
+        with open(log_filename, "w") as f:
+            for line in image_diffs_log:
+                f.write(f"{line}\n")
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests",
@@ -21,6 +39,10 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
     parser.addoption(
         "--driver-path", type=str, action="store", default="", help="path to chrome driver",
+    )
+    parser.addoption(
+        "--log-image-diffs", action="store_true", default=False,
+        help="log image differences to result_images/image_diffs.log",
     )
 
 

--- a/tests/image_comparison.py
+++ b/tests/image_comparison.py
@@ -19,6 +19,8 @@ def compare_images(
 ) -> None:
     from PIL import Image
 
+    from .conftest import image_diffs_log
+
     if max_threshold is None:
         max_threshold = 100
     if mean_threshold is None:
@@ -50,6 +52,9 @@ def compare_images(
             diff[diff == 1] = 0
         max_diff = diff.max()
         mean_diff = diff.mean()
+
+        log = f"{max_diff},{max_threshold},{mean_diff:g},{mean_threshold},{test_filename}"
+        image_diffs_log.append(log)
 
         assert max_diff < max_threshold and mean_diff < mean_threshold
     except AssertionError:


### PR DESCRIPTION
Currently image comparison tests either pass or fail, and there is no logging of how much each generated image differs from its image baseline. This PR adds a `pytest` option `pytest --log-image-diffs` that logs all the image differences to the file `result_images/image_diffs.log`, and this is enabled in test github actions so that the logs will be added to the uploaded artifact.

It will be possible to analyse the results to see if there are any particular hardware/OS combinations that give worse results than others (although still within the allowed difference limits).