### PR TITLE
Make lines() and filled() virtual C++ functions

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -24,10 +24,12 @@ template <typename Derived>
 class BaseContourGenerator : public ContourGenerator
 {
 public:
-    ~BaseContourGenerator();
+    virtual ~BaseContourGenerator();
 
     static FillType default_fill_type();
     static LineType default_line_type();
+
+    py::tuple filled(double lower_level, double upper_level) override;
 
     py::tuple get_chunk_count() const;  // Return (y_chunk_count, x_chunk_count)
     py::tuple get_chunk_size() const;   // Return (y_chunk_size, x_chunk_size)
@@ -41,8 +43,7 @@ public:
 
     ZInterp get_z_interp() const;
 
-    py::sequence filled(double lower_level, double upper_level);
-    py::sequence lines(double level);
+    py::sequence lines(double level) override;
 
     static bool supports_fill_type(FillType fill_type);
     static bool supports_line_type(LineType line_type);

--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -351,7 +351,7 @@ LineType BaseContourGenerator<Derived>::default_line_type()
 }
 
 template <typename Derived>
-py::sequence BaseContourGenerator<Derived>::filled(double lower_level, double upper_level)
+py::tuple BaseContourGenerator<Derived>::filled(double lower_level, double upper_level)
 {
     if (lower_level >= upper_level)
         throw std::invalid_argument("upper_level must be larger than lower_level");

--- a/src/contour_generator.h
+++ b/src/contour_generator.h
@@ -14,6 +14,12 @@ public:
     ContourGenerator& operator=(const ContourGenerator& other) = delete;
     ContourGenerator& operator=(const ContourGenerator&& other) = delete;
 
+    virtual ~ContourGenerator() = default;
+
+    virtual py::tuple filled(double lower_level, double upper_level) = 0;
+
+    virtual py::sequence lines(double level) = 0;
+
 protected:
     ContourGenerator() = default;
 };

--- a/src/mpl2005.cpp
+++ b/src/mpl2005.cpp
@@ -46,7 +46,7 @@ Mpl2005ContourGenerator::~Mpl2005ContourGenerator()
     cntr_del(_site);
 }
 
-py::tuple Mpl2005ContourGenerator::filled(const double& lower_level, const double& upper_level)
+py::tuple Mpl2005ContourGenerator::filled(double lower_level, double upper_level)
 {
     if (lower_level >= upper_level)
         throw std::invalid_argument("upper_level must be larger than lower_level");
@@ -67,7 +67,7 @@ py::tuple Mpl2005ContourGenerator::get_chunk_size() const
     return py::make_tuple(_site->j_chunk_size, _site->i_chunk_size);
 }
 
-py::tuple Mpl2005ContourGenerator::lines(const double& level)
+py::sequence Mpl2005ContourGenerator::lines(double level)
 {
     double levels[2] = {level, 0.0};
     return cntr_trace(_site, levels, 1);

--- a/src/mpl2005.h
+++ b/src/mpl2005.h
@@ -13,14 +13,14 @@ public:
         const CoordinateArray& x, const CoordinateArray& y, const CoordinateArray& z,
         const MaskArray& mask, index_t x_chunk_size, index_t y_chunk_size);
 
-    ~Mpl2005ContourGenerator();
+    virtual ~Mpl2005ContourGenerator();
 
-    py::tuple filled(const double& lower_level, const double& upper_level);
+    py::tuple filled(double lower_level, double upper_level) override;
 
     py::tuple get_chunk_count() const;  // Return (y_chunk_count, x_chunk_count)
     py::tuple get_chunk_size() const;   // Return (y_chunk_size, x_chunk_size)
 
-    py::tuple lines(const double& level);
+    py::sequence lines(double level) override;
 
 private:
     CoordinateArray _x, _y, _z;

--- a/src/mpl2014.cpp
+++ b/src/mpl2014.cpp
@@ -483,8 +483,7 @@ void Mpl2014ContourGenerator::edge_interp(
            level, contour_line);
 }
 
-py::tuple Mpl2014ContourGenerator::filled(
-    const double& lower_level, const double& upper_level)
+py::tuple Mpl2014ContourGenerator::filled(double lower_level, double upper_level)
 {
     if (lower_level >= upper_level)
         throw std::invalid_argument("upper_level must be larger than lower_level");
@@ -1218,7 +1217,7 @@ bool Mpl2014ContourGenerator::is_edge_a_boundary(
     }
 }
 
-py::tuple Mpl2014ContourGenerator::lines(const double& level)
+py::sequence Mpl2014ContourGenerator::lines(double level)
 {
     init_cache_levels(level, level);
 

--- a/src/mpl2014.h
+++ b/src/mpl2014.h
@@ -270,11 +270,11 @@ public:
         const MaskArray& mask, bool corner_mask, index_t x_chunk_size, index_t y_chunk_size);
 
     // Destructor.
-    ~Mpl2014ContourGenerator();
+    virtual ~Mpl2014ContourGenerator();
 
     // Create and return polygons for a filled contour between the two
     // specified levels.
-    py::tuple filled(const double& lower_level, const double& upper_level);
+    py::tuple filled(double lower_level, double upper_level) override;
 
     py::tuple get_chunk_count() const;  // Return (y_chunk_count, x_chunk_count)
     py::tuple get_chunk_size() const;   // Return (y_chunk_size, x_chunk_size)
@@ -283,7 +283,7 @@ public:
 
     // Create and return polygons for a line (i.e. non-filled) contour at the
     // specified level.
-    py::tuple lines(const double& level);
+    py::sequence lines(double level) override;
 
 private:
     // Typedef for following either a boundary of the domain or the interior;

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -94,7 +94,7 @@ PYBIND11_MODULE(_contourpy, m) {
         "    lower_level (float): Lower z-level of the filled contours.\n"
         "    upper_level (float): Upper z-level of the filled contours.\n"
         "Return:\n"
-        "    Filled contour polygons as one or more sequences of numpy arrays. The exact format is "
+        "    Filled contour polygons as nested sequences of numpy arrays. The exact format is "
         "determined by the ``fill_type`` used by the ``ContourGenerator``.\n\n"
         "Raises a ``ValueError`` if ``lower_level >= upper_level``.\n\n"
         "To return filled contours below a ``level`` use ``filled(-np.inf, level)``.\n"
@@ -105,7 +105,7 @@ PYBIND11_MODULE(_contourpy, m) {
         "Args:\n"
         "    level (float): z-level to calculate contours at.\n\n"
         "Return:\n"
-        "    Contour lines (open line strips and closed line loops) as one or more sequences of "
+        "    Contour lines (open line strips and closed line loops) as nested sequences of "
         "numpy arrays. The exact format is determined by the ``line_type`` used by the "
         "``ContourGenerator``.";
     const char* quad_as_tri_doc = "Return whether ``quad_as_tri`` is set or not.";
@@ -128,18 +128,12 @@ PYBIND11_MODULE(_contourpy, m) {
     py::class_<contourpy::ContourGenerator>(m, "ContourGenerator",
         "Abstract base class for contour generator classes, defining the interface that they all "
         "implement.")
-        .def("create_contour",
-            [](py::object /* self */, double level) {return py::make_tuple();},
-            "level"_a, create_contour_doc)
-        .def("create_filled_contour",
-            [](py::object /* self */, double lower_level, double upper_level) {return py::make_tuple();},
-            "lower_level"_a, "upper_level"_a, create_filled_contour_doc)
-        .def("filled",
-            [](py::object /* self */, double lower_level, double upper_level) {return py::make_tuple();},
-            "lower_level"_a, "upper_level"_a, filled_doc)
-        .def("lines",
-            [](py::object /* self */, double level) {return py::make_tuple();},
-            "level"_a, lines_doc)
+        .def("create_contour", &contourpy::ContourGenerator::lines, create_contour_doc, "level"_a)
+        .def("create_filled_contour", &contourpy::ContourGenerator::filled,
+             create_filled_contour_doc, "lower_level"_a, "upper_level"_a)
+        .def("filled", &contourpy::ContourGenerator::filled, filled_doc,
+             "lower_level"_a, "upper_level"_a)
+        .def("lines", &contourpy::ContourGenerator::lines, lines_doc, "level"_a)
         .def_property_readonly(
             "chunk_count", [](py::object /* self */) {return py::make_tuple(1, 1);},
             chunk_count_doc)
@@ -196,11 +190,6 @@ PYBIND11_MODULE(_contourpy, m) {
                       contourpy::index_t>(),
              "x"_a, "y"_a, "z"_a, "mask"_a, py::kw_only(), "x_chunk_size"_a = 0,
              "y_chunk_size"_a = 0)
-        .def("create_contour", &contourpy::Mpl2005ContourGenerator::lines, create_contour_doc)
-        .def("create_filled_contour", &contourpy::Mpl2005ContourGenerator::filled,
-            create_filled_contour_doc)
-        .def("filled", &contourpy::Mpl2005ContourGenerator::filled, filled_doc)
-        .def("lines", &contourpy::Mpl2005ContourGenerator::lines, lines_doc)
         .def_property_readonly(
             "chunk_count", &contourpy::Mpl2005ContourGenerator::get_chunk_count, chunk_count_doc)
         .def_property_readonly(
@@ -245,12 +234,6 @@ PYBIND11_MODULE(_contourpy, m) {
                       contourpy::index_t>(),
              "x"_a, "y"_a, "z"_a, "mask"_a, py::kw_only(), "corner_mask"_a, "x_chunk_size"_a = 0,
              "y_chunk_size"_a = 0)
-        .def("create_contour", &contourpy::mpl2014::Mpl2014ContourGenerator::lines,
-            create_contour_doc)
-        .def("create_filled_contour", &contourpy::mpl2014::Mpl2014ContourGenerator::filled,
-            create_filled_contour_doc)
-        .def("filled", &contourpy::mpl2014::Mpl2014ContourGenerator::filled, filled_doc)
-        .def("lines", &contourpy::mpl2014::Mpl2014ContourGenerator::lines, lines_doc)
         .def_property_readonly(
             "chunk_count", &contourpy::mpl2014::Mpl2014ContourGenerator::get_chunk_count,
             chunk_count_doc)
@@ -301,11 +284,6 @@ PYBIND11_MODULE(_contourpy, m) {
              "fill_type"_a, "quad_as_tri"_a, "z_interp"_a, "x_chunk_size"_a = 0,
              "y_chunk_size"_a = 0)
         .def("_write_cache", &contourpy::SerialContourGenerator::write_cache)
-        .def("create_contour", &contourpy::SerialContourGenerator::lines, create_contour_doc)
-        .def("create_filled_contour", &contourpy::SerialContourGenerator::filled,
-            create_filled_contour_doc)
-        .def("filled", &contourpy::SerialContourGenerator::filled, filled_doc)
-        .def("lines", &contourpy::SerialContourGenerator::lines, lines_doc)
         .def_property_readonly(
             "chunk_count", &contourpy::SerialContourGenerator::get_chunk_count, chunk_count_doc)
         .def_property_readonly(
@@ -359,11 +337,6 @@ PYBIND11_MODULE(_contourpy, m) {
              "fill_type"_a, "quad_as_tri"_a, "z_interp"_a, "x_chunk_size"_a = 0,
              "y_chunk_size"_a = 0, "thread_count"_a = 0)
         .def("_write_cache", &contourpy::ThreadedContourGenerator::write_cache)
-        .def("create_contour", &contourpy::ThreadedContourGenerator::lines, create_contour_doc)
-        .def("create_filled_contour", &contourpy::ThreadedContourGenerator::filled,
-            create_filled_contour_doc)
-        .def("filled", &contourpy::ThreadedContourGenerator::filled, filled_doc)
-        .def("lines", &contourpy::ThreadedContourGenerator::lines, lines_doc)
         .def_property_readonly(
             "chunk_count", &contourpy::ThreadedContourGenerator::get_chunk_count, chunk_count_doc)
         .def_property_readonly(


### PR DESCRIPTION
Up until now `lines()` and `filled()` have been non-virtual C++ functions that have been separately defined in `wrap.cpp` for each of the concrete `ContourGenerator`-derived classes and so they have been resolved at runtime using the usual Python MRO. This has been acceptable as the functions have only ever been called from Python, not internally within the C++ code.

This PR makes them virtual C++ functions so that they can be called from within the C++ code without dropping back to Python, as will be required in the soon to be added functions `multi_lines()` and `multi_filled()`. Here we will have a single implementation of each `multi_*` function in the `ContourGenerator` class that calls the appropriate `lines()` or `filled()` multiple times.

Summary of changes:

1. New virtual C++ functions `ContourGenerator::lines` and `ContourGenerator::filled`.
2. Overridden C++ functions for each in the concrete contour generator classes.
3. Identical argument and return types, which were previously not required. Levels are passed by value not reference, `lines()` returns a Python `sequence` (may be a `tuple` or `list` depending on `LineType`) and `filled()` always returns a `tuple`.
4. Simpler `wrap.cpp` code as `lines()` and `filled()` only need to be defined for the abstract base `ContourGenerator` class. 

There will be a slight performance penalty for this as the Python MRO will need to walk the class hierarchy to the wrapped `ContourGenerator` class and there will be a C++ vtable lookup.