### PR TITLE
Prevent use of np.nan as lower or upper_level in filled()

### DIFF
--- a/src/base_impl.h
+++ b/src/base_impl.h
@@ -355,6 +355,8 @@ py::tuple BaseContourGenerator<Derived>::filled(double lower_level, double upper
 {
     if (lower_level >= upper_level)
         throw std::invalid_argument("upper_level must be larger than lower_level");
+    if (Util::is_nan(lower_level) || Util::is_nan(upper_level))
+        throw std::invalid_argument("lower_level and upper_level cannot be NaN");
 
     _filled = true;
     _lower_level = lower_level;

--- a/src/mpl2005.cpp
+++ b/src/mpl2005.cpp
@@ -1,4 +1,5 @@
 #include "mpl2005.h"
+#include "util.h"
 
 namespace contourpy {
 
@@ -50,6 +51,8 @@ py::tuple Mpl2005ContourGenerator::filled(double lower_level, double upper_level
 {
     if (lower_level >= upper_level)
         throw std::invalid_argument("upper_level must be larger than lower_level");
+    if (Util::is_nan(lower_level) || Util::is_nan(upper_level))
+        throw std::invalid_argument("lower_level and upper_level cannot be NaN");
 
     double levels[2] = {lower_level, upper_level};
     return cntr_trace(_site, levels, 2);

--- a/src/mpl2014.cpp
+++ b/src/mpl2014.cpp
@@ -7,6 +7,7 @@
 
 #include "mpl2014.h"
 #include "mpl_kind_code.h"
+#include "util.h"
 #include <algorithm>
 
 namespace contourpy {
@@ -487,6 +488,8 @@ py::tuple Mpl2014ContourGenerator::filled(double lower_level, double upper_level
 {
     if (lower_level >= upper_level)
         throw std::invalid_argument("upper_level must be larger than lower_level");
+    if (Util::is_nan(lower_level) || Util::is_nan(upper_level))
+        throw std::invalid_argument("lower_level and upper_level cannot be NaN");
 
     init_cache_levels(lower_level, upper_level);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,4 +1,5 @@
 #include "util.h"
+#include <cmath>
 #include <thread>
 
 namespace contourpy {
@@ -19,6 +20,11 @@ void Util::ensure_nan_loaded()
 index_t Util::get_max_threads()
 {
     return static_cast<index_t>(std::thread::hardware_concurrency());
+}
+
+bool Util::is_nan(double value)
+{
+    return std::isnan(value);
 }
 
 } // namespace contourpy

--- a/src/util.h
+++ b/src/util.h
@@ -12,6 +12,8 @@ public:
 
     static index_t get_max_threads();
 
+    static bool is_nan(double value);
+
     // This is the NaN used internally and returned to calling functions. The value is taken from
     // numpy rather than the standard C++ approach so that it is guaranteed to work with
     // numpy.isnan(). The value is actually the same for many platforms, but this approach

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -91,12 +91,13 @@ PYBIND11_MODULE(_contourpy, m) {
     const char* filled_doc =
         "Calculate and return filled contours between two levels.\n\n"
         "Args:\n"
-        "    lower_level (float): Lower z-level of the filled contours.\n"
-        "    upper_level (float): Upper z-level of the filled contours.\n"
+        "    lower_level (float): Lower z-level of the filled contours, cannot be ``np.nan``.\n"
+        "    upper_level (float): Upper z-level of the filled contours, cannot be ``np.nan``.\n"
         "Return:\n"
         "    Filled contour polygons as nested sequences of numpy arrays. The exact format is "
         "determined by the ``fill_type`` used by the ``ContourGenerator``.\n\n"
-        "Raises a ``ValueError`` if ``lower_level >= upper_level``.\n\n"
+        "Raises a ``ValueError`` if ``lower_level >= upper_level`` or if\n"
+        "``lower_level`` or ``upper_level`` are ``np.nan``.\n\n"
         "To return filled contours below a ``level`` use ``filled(-np.inf, level)``.\n"
         "To return filled contours above a ``level`` use ``filled(level, np.inf)``";
     const char* line_type_doc = "Return the ``LineType``.";
@@ -107,7 +108,9 @@ PYBIND11_MODULE(_contourpy, m) {
         "Return:\n"
         "    Contour lines (open line strips and closed line loops) as nested sequences of "
         "numpy arrays. The exact format is determined by the ``line_type`` used by the "
-        "``ContourGenerator``.";
+        "``ContourGenerator``.\n\n"
+        "``level`` may be ``np.nan``, ``np.inf`` or ``-np.inf``; they all return the same result "
+        "which is an empty line set.";
     const char* quad_as_tri_doc = "Return whether ``quad_as_tri`` is set or not.";
     const char* supports_corner_mask_doc =
         "Return whether this algorithm supports ``corner_mask``.";

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -41,6 +41,21 @@ def test_filled_decreasing_levels(name: str) -> None:
 
 
 @pytest.mark.parametrize("name", util_test.all_names())
+def test_filled_nan_levels(name: str) -> None:
+    cont_gen = contour_generator(z=[[0, 1], [2, 3]], name=name, fill_type=FillType.OuterCode)
+
+    msg = r"lower_level and upper_level cannot be NaN"
+    with pytest.raises(ValueError, match=msg):
+        cont_gen.filled(0, np.nan)
+
+    with pytest.raises(ValueError, match=msg):
+        cont_gen.filled(np.nan, 0)
+
+    with pytest.raises(ValueError, match=msg):
+        cont_gen.filled(np.nan, np.nan)
+
+
+@pytest.mark.parametrize("name", util_test.all_names())
 def test_filled_identical_levels(name: str) -> None:
     cont_gen = contour_generator(z=[[0, 1], [2, 3]], name=name, fill_type=FillType.OuterCode)
     with pytest.raises(ValueError, match="upper_level must be larger than lower_level"):
@@ -919,8 +934,8 @@ def test_filled_compare_slow(seed: int) -> None:
 
 @pytest.mark.parametrize("name", util_test.all_names())
 @pytest.mark.parametrize("z", [np.nan, -np.nan, np.inf, -np.inf])
-@pytest.mark.parametrize("lower_level", [0.0, np.nan, -np.nan, np.inf, -np.inf])
-@pytest.mark.parametrize("upper_level", [0.0, np.nan, -np.nan, np.inf, -np.inf])
+@pytest.mark.parametrize("lower_level", [0.0, np.inf, -np.inf])
+@pytest.mark.parametrize("upper_level", [0.0, np.inf, -np.inf])
 def test_filled_z_nonfinite(name: str, z: float, lower_level: float, upper_level: float) -> None:
     cont_gen = contour_generator(z=[[z, z], [z, z]], name=name, fill_type=FillType.OuterCode)
     if lower_level >= upper_level:


### PR DESCRIPTION
Up until now it has been possible to use `np.nan` as either/both of `lower_level` and `upper_level` passed to `filled()`. This isn't recommended as it can give strange results such as
```python
>>> cg = contour_generator(z=[[0, 0], [1, 1]])
>>> cg.filled(np.nan, 0.5)
([array([[0. , 0.5],
       [nan, nan],
       [nan, nan],
       [1. , 0.5],
       [0. , 0.5]])], [array([0, 5], dtype=uint32)])
```
This PR prevents passing `np.nan` to `filled()` and will raise a `ValueError`. Classifying it as a bugfix as it should probably never have been allowed. It may affect downstream usage, so the next release to include this will be 1.3.0.

Use of `np.nan` in `lines()` is still permitted, it gives the same uninteresting but valid results as using `-np.inf` or `np.inf` which is an empty line set.

The C++ nan check is performed in the `Util` class as this is where the other `np.nan` handling occurs. Initially implemented using `std::isnan` as this works locally, but this may potentially have to be altered in future on obscure hardware/OS combinations.