### PR TITLE
Add new functions Renderer.multi_lines and multi_filled

### DIFF
--- a/lib/contourpy/util/renderer.py
+++ b/lib/contourpy/util/renderer.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 class Renderer(ABC):
-    """Abstract base class for renderers, defining the interface that they must implement."""
+    """Abstract base class for renderers."""
 
     def _grid_as_2d(self, x: ArrayLike, y: ArrayLike) -> tuple[CoordinateArray, CoordinateArray]:
         x = np.asarray(x)
@@ -75,6 +75,68 @@ class Renderer(ABC):
         color: str = "black",
     ) -> None:
         pass
+
+    def multi_filled(
+        self,
+        multi_filled: list[FillReturn],
+        fill_type: FillType | str,
+        ax: Any = 0,
+        color: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Plot multiple sets of filled contours on a single axes.
+
+        Args:
+            multi_filled (list of filled contour arrays): Multiple filled contour sets as returned
+                by :func:`~contourpy.ContourGenerator.multi_filled`.
+            fill_type (FillType or str): Type of filled data as returned by
+                :attr:`~contourpy.ContourGenerator.fill_type`, or string equivalent.
+            ax (int or Renderer-specific axes or figure object, optional): Which axes to plot on,
+                default ``0``.
+            color (str or None, optional): If a string color then this same color is used for all
+                filled contours. If ``None``, the default, then the filled contour sets use colors
+                from the ``tab10`` colormap in order, wrapping around to the beginning if more than
+                10 sets of filled contours are rendered.
+            kwargs: All other keyword argument are passed on to
+                :func:`~contourpy.util.renderer.Renderer.filled` unchanged.
+        """
+        if color is not None:
+            kwargs["color"] = color
+        for i, filled in enumerate(multi_filled):
+            if color is None:
+                kwargs["color"] = f"C{i % 10}"
+            self.filled(filled, fill_type, ax, **kwargs)
+
+    def multi_lines(
+        self,
+        multi_lines: list[LineReturn],
+        line_type: LineType | str,
+        ax: Any = 0,
+        color: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Plot multiple sets of contour lines on a single axes.
+
+        Args:
+            multi_lines (list of contour line arrays): Multiple contour line sets as returned by
+                :func:`~contourpy.ContourGenerator.multi_lines`.
+            line_type (LineType or str): Type of line data as returned by
+                :attr:`~contourpy.ContourGenerator.line_type`, or string equivalent.
+            ax (int or Renderer-specific axes or figure object, optional): Which axes to plot on,
+                default ``0``.
+            color (str or None, optional): If a string color then this same color is used for all
+                lines. If ``None``, the default, then the line sets use colors from the ``tab10``
+                colormap in order, wrapping around to the beginning if more than 10 sets of lines
+                are rendered.
+            kwargs: All other keyword argument are passed on to
+                :func:`~contourpy.util.renderer.Renderer.lines` unchanged.
+        """
+        if color is not None:
+            kwargs["color"] = color
+        for i, lines in enumerate(multi_lines):
+            if color is None:
+                kwargs["color"] = f"C{i % 10}"
+            self.lines(lines, line_type, ax, **kwargs)
 
     @abstractmethod
     def save(self, filename: str, transparent: bool = False) -> None:

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -81,8 +81,7 @@ def test_filled_simple(name: str, fill_type: FillType, multi: bool) -> None:
     renderer = MplTestRenderer()
     if multi:
         multi_filled = cont_gen.multi_filled(levels)
-        for i in range(len(levels)-1):
-            renderer.filled(multi_filled[i], fill_type, color=f"C{i}")
+        renderer.multi_filled(multi_filled, fill_type)
     else:
         for i in range(len(levels)-1):
             renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
@@ -357,8 +356,7 @@ def test_filled_random(name: str, fill_type: FillType, multi: bool) -> None:
     renderer = MplTestRenderer()
     if multi:
         multi_filled = cont_gen.multi_filled(levels)
-        for i in range(len(levels)-1):
-            renderer.filled(multi_filled[i], fill_type, color=f"C{i}")
+        renderer.multi_filled(multi_filled, fill_type)
     else:
         for i in range(len(levels)-1):
             renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -131,8 +131,7 @@ def test_lines_simple(name: str, line_type: LineType, multi: bool) -> None:
     renderer = MplTestRenderer()
     if multi:
         multi_lines = cont_gen.multi_lines(levels)
-        for i in range(len(levels)):
-            renderer.lines(multi_lines[i], line_type, color=f"C{i}")
+        renderer.multi_lines(multi_lines, line_type)
     else:
         for i in range(len(levels)):
             renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
@@ -394,8 +393,7 @@ def test_lines_random(name: str, line_type: LineType, multi: bool) -> None:
     renderer = MplTestRenderer()
     if multi:
         multi_lines = cont_gen.multi_lines(levels)
-        for i in range(len(levels)):
-            renderer.lines(multi_lines[i], line_type, color=f"C{i}")
+        renderer.multi_lines(multi_lines, line_type)
     else:
         for i in range(len(levels)):
             renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")


### PR DESCRIPTION
This adds new functions `Renderer.multi_lines` and `Renderer.multi_filled` to easily render the outputs of the recently-added (#340 ) `ContourGenerator.multi_lines` and `ContourGenerator.multi_filled`.

If a `color` kwarg is not specified then the line/filled contour sets are rendered in sequential colors from the tab10 colormap, wrapping round to the first if there are more than 10 contour sets. If a `color` is specified then it is used for all contour sets. All other kwargs are passed on to the underlying `Renderer.lines()` or `filled()` functions.

Example use:
```python
from contourpy import contour_generator
from contourpy.util.mpl_renderer import MplRenderer as Renderer
import numpy as np

cont_gen = contour_generator(z=[[1, 2], [3, 4]])
levels = np.linspace(1, 4, 10)
mf = cont_gen.multi_filled(levels)

renderer = Renderer()
renderer.multi_filled(mf, cont_gen.fill_type)
renderer.title("multi_filled example")
renderer.show()
```
![temp](https://github.com/contourpy/contourpy/assets/580326/f1dc7781-24d5-43e7-a593-62f6e490bc82)



