### PR TITLE
Streamlined BaseContourGenerator::multi_filled and multi_lines

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -45,6 +45,9 @@ public:
 
     py::sequence lines(double level) override;
 
+    py::list multi_filled(const LevelArray levels) override;
+    py::list multi_lines(const LevelArray levels) override;
+
     static bool supports_fill_type(FillType fill_type);
     static bool supports_line_type(LineType line_type);
 
@@ -166,6 +169,10 @@ protected:
     py::sequence march_wrapper();
 
     void move_to_next_boundary_edge(index_t& quad, index_t& forward, index_t& left) const;
+
+    // Common initialisation for filled/multi_filled and lines/multi_lines calls.
+    void pre_filled();
+    void pre_lines();
 
     void set_look_flags(index_t hole_start_quad);
 

--- a/src/contour_generator.h
+++ b/src/contour_generator.h
@@ -20,8 +20,8 @@ public:
 
     virtual py::sequence lines(double level) = 0;
 
-    py::list multi_filled(const LevelArray levels);
-    py::list multi_lines(const LevelArray levels);
+    virtual py::list multi_filled(const LevelArray levels);
+    virtual py::list multi_lines(const LevelArray levels);
 
 protected:
     ContourGenerator() = default;


### PR DESCRIPTION
Streamline `multi_filled` and `multi_lines` for `serial` and `threaded` algorithms as setting various properties of the algorithm, such as whether holes are identified or not, only needs to be performed once at the start rather than for every underlying `filled` or `lines` call.