### PR TITLE
Use multi_lines and multi_filled in tests and benchmarks

### DIFF
--- a/benchmarks/benchmarks/bench_filled_mpl20xx.py
+++ b/benchmarks/benchmarks/bench_filled_mpl20xx.py
@@ -26,5 +26,4 @@ class BenchFilledMpl20xx(BenchBase):
             self.x, self.y, self.z, name=name, fill_type=fill_type,
             corner_mask=corner_mask_to_bool(corner_mask),
         )
-        for i in range(len(self.levels)-1):
-            cont_gen.filled(self.levels[i], self.levels[i+1])
+        cont_gen.multi_filled(self.levels)

--- a/benchmarks/benchmarks/bench_filled_mpl20xx_render.py
+++ b/benchmarks/benchmarks/bench_filled_mpl20xx_render.py
@@ -28,7 +28,5 @@ class BenchFilledMpl20xxRender(BenchBase):
             corner_mask=corner_mask_to_bool(corner_mask),
         )
         renderer = MplTestRenderer()
-        for i in range(len(self.levels)-1):
-            filled = cont_gen.filled(self.levels[i], self.levels[i+1])
-            renderer.filled(filled, fill_type, color=f"C{i}")
+        renderer.multi_filled(cont_gen.multi_filled(self.levels), fill_type)
         renderer.save(f"filled_{name}_{corner_mask}_{fill_type}_{n}.png")

--- a/benchmarks/benchmarks/bench_filled_serial.py
+++ b/benchmarks/benchmarks/bench_filled_serial.py
@@ -24,5 +24,4 @@ class BenchFilledSerial(BenchBase):
             self.x, self.y, self.z, name=name, fill_type=fill_type,
             corner_mask=corner_mask_to_bool(corner_mask),
         )
-        for i in range(len(self.levels)-1):
-            cont_gen.filled(self.levels[i], self.levels[i+1])
+        cont_gen.multi_filled(self.levels)

--- a/benchmarks/benchmarks/bench_filled_serial_chunk.py
+++ b/benchmarks/benchmarks/bench_filled_serial_chunk.py
@@ -28,5 +28,4 @@ class BenchFilledSerialChunk(BenchBase):
             self.x, self.y, self.z, name=name, fill_type=fill_type,
             corner_mask=corner_mask_to_bool(corner_mask), total_chunk_count=total_chunk_count,
         )
-        for i in range(len(self.levels)-1):
-            cont_gen.filled(self.levels[i], self.levels[i+1])
+        cont_gen.multi_filled(self.levels)

--- a/benchmarks/benchmarks/bench_filled_serial_quad_as_tri.py
+++ b/benchmarks/benchmarks/bench_filled_serial_quad_as_tri.py
@@ -24,5 +24,4 @@ class BenchFilledSerialQuadAsTri(BenchBase):
             self.x, self.y, self.z, name=name, fill_type=fill_type,
             corner_mask=corner_mask_to_bool(corner_mask), quad_as_tri=True,
         )
-        for i in range(len(self.levels)-1):
-            cont_gen.filled(self.levels[i], self.levels[i+1])
+        cont_gen.multi_filled(self.levels)

--- a/benchmarks/benchmarks/bench_filled_serial_quad_as_tri_render.py
+++ b/benchmarks/benchmarks/bench_filled_serial_quad_as_tri_render.py
@@ -26,7 +26,5 @@ class BenchFilledSerialQuadAsTriRender(BenchBase):
             corner_mask=corner_mask_to_bool(corner_mask), quad_as_tri=True,
         )
         renderer = MplTestRenderer()
-        for i in range(len(self.levels)-1):
-            filled = cont_gen.filled(self.levels[i], self.levels[i+1])
-            renderer.filled(filled, fill_type, color=f"C{i}")
+        renderer.multi_filled(cont_gen.multi_filled(self.levels), fill_type)
         renderer.save(f"filled_{name}_{corner_mask}_{fill_type}_{n}.png")

--- a/benchmarks/benchmarks/bench_filled_serial_render.py
+++ b/benchmarks/benchmarks/bench_filled_serial_render.py
@@ -26,7 +26,5 @@ class BenchFilledSerialRender(BenchBase):
             corner_mask=corner_mask_to_bool(corner_mask),
         )
         renderer = MplTestRenderer()
-        for i in range(len(self.levels)-1):
-            filled = cont_gen.filled(self.levels[i], self.levels[i+1])
-            renderer.filled(filled, fill_type, color=f"C{i}")
+        renderer.multi_filled(cont_gen.multi_filled(self.levels), fill_type)
         renderer.save(f"filled_{name}_{corner_mask}_{fill_type}_{n}.png")

--- a/benchmarks/benchmarks/bench_filled_threaded.py
+++ b/benchmarks/benchmarks/bench_filled_threaded.py
@@ -38,5 +38,4 @@ class BenchFilledThreaded(BenchBase):
             corner_mask=corner_mask_to_bool(corner_mask), total_chunk_count=total_chunk_count,
             thread_count=thread_count,
         )
-        for i in range(len(self.levels)-1):
-            cont_gen.filled(self.levels[i], self.levels[i+1])
+        cont_gen.multi_filled(self.levels)

--- a/benchmarks/benchmarks/bench_lines_mpl20xx.py
+++ b/benchmarks/benchmarks/bench_lines_mpl20xx.py
@@ -27,5 +27,4 @@ class BenchLinesMpl20xx(BenchBase):
             self.x, self.y, self.z, name=name, line_type=line_type,
             corner_mask=corner_mask_to_bool(corner_mask),
         )
-        for level in self.levels:
-            cont_gen.lines(level)
+        cont_gen.multi_lines(self.levels)

--- a/benchmarks/benchmarks/bench_lines_mpl20xx_render.py
+++ b/benchmarks/benchmarks/bench_lines_mpl20xx_render.py
@@ -29,7 +29,5 @@ class BenchLinesMpl20xxRender(BenchBase):
             corner_mask=corner_mask_to_bool(corner_mask),
         )
         renderer = MplTestRenderer()
-        for i, level in enumerate(self.levels):
-            lines = cont_gen.lines(level)
-            renderer.lines(lines, line_type, color=f"C{i}")
+        renderer.multi_lines(cont_gen.multi_lines(self.levels), line_type)
         renderer.save(f"lines_{name}_{corner_mask}_{line_type}_{n}.png")

--- a/benchmarks/benchmarks/bench_lines_serial.py
+++ b/benchmarks/benchmarks/bench_lines_serial.py
@@ -24,5 +24,4 @@ class BenchLinesSerial(BenchBase):
             self.x, self.y, self.z, name=name, line_type=line_type,
             corner_mask=corner_mask_to_bool(corner_mask),
         )
-        for level in self.levels:
-            cont_gen.lines(level)
+        cont_gen.multi_lines(self.levels)

--- a/benchmarks/benchmarks/bench_lines_serial_chunk.py
+++ b/benchmarks/benchmarks/bench_lines_serial_chunk.py
@@ -28,5 +28,4 @@ class BenchLinesSerialChunk(BenchBase):
             self.x, self.y, self.z, name=name, line_type=line_type,
             corner_mask=corner_mask_to_bool(corner_mask), total_chunk_count=total_chunk_count,
         )
-        for level in self.levels:
-            cont_gen.lines(level)
+        cont_gen.multi_lines(self.levels)

--- a/benchmarks/benchmarks/bench_lines_serial_quad_as_tri.py
+++ b/benchmarks/benchmarks/bench_lines_serial_quad_as_tri.py
@@ -24,5 +24,4 @@ class BenchLinesSerialQuadAsTri(BenchBase):
             self.x, self.y, self.z, name=name, line_type=line_type,
             corner_mask=corner_mask_to_bool(corner_mask), quad_as_tri=True,
         )
-        for level in self.levels:
-            cont_gen.lines(level)
+        cont_gen.multi_lines(self.levels)

--- a/benchmarks/benchmarks/bench_lines_serial_quad_as_tri_render.py
+++ b/benchmarks/benchmarks/bench_lines_serial_quad_as_tri_render.py
@@ -26,7 +26,5 @@ class BenchLinesSerialQuadAsTriRender(BenchBase):
             corner_mask=corner_mask_to_bool(corner_mask), quad_as_tri=True,
         )
         renderer = MplTestRenderer()
-        for i, level in enumerate(self.levels):
-            lines = cont_gen.lines(level)
-            renderer.lines(lines, line_type, color=f"C{i}")
+        renderer.multi_lines(cont_gen.multi_lines(self.levels), line_type)
         renderer.save(f"lines_{name}_{corner_mask}_{line_type}_{n}_True.png")

--- a/benchmarks/benchmarks/bench_lines_serial_render.py
+++ b/benchmarks/benchmarks/bench_lines_serial_render.py
@@ -26,7 +26,5 @@ class BenchLinesSerialRender(BenchBase):
             corner_mask=corner_mask_to_bool(corner_mask),
         )
         renderer = MplTestRenderer()
-        for i, level in enumerate(self.levels):
-            lines = cont_gen.lines(level)
-            renderer.lines(lines, line_type, color=f"C{i}")
+        renderer.multi_lines(cont_gen.multi_lines(self.levels), line_type)
         renderer.save(f"lines_{name}_{corner_mask}_{line_type}_{n}.png")

--- a/benchmarks/benchmarks/bench_lines_threaded.py
+++ b/benchmarks/benchmarks/bench_lines_threaded.py
@@ -38,5 +38,4 @@ class BenchLinesThreaded(BenchBase):
             corner_mask=corner_mask_to_bool(corner_mask), total_chunk_count=total_chunk_count,
             thread_count=thread_count,
         )
-        for level in self.levels:
-            cont_gen.lines(level)
+        cont_gen.multi_lines(self.levels)

--- a/tests/test_filled.py
+++ b/tests/test_filled.py
@@ -91,8 +91,9 @@ def test_filled_simple(name: str, fill_type: FillType, multi: bool) -> None:
 
 
 @pytest.mark.image
+@pytest.mark.parametrize("multi", [False, True])
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
-def test_filled_simple_chunk(name: str, fill_type: FillType) -> None:
+def test_filled_simple_chunk(name: str, fill_type: FillType, multi: bool) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -108,12 +109,15 @@ def test_filled_simple_chunk(name: str, fill_type: FillType) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    if multi:
+        renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
+    else:
+        for i in range(len(levels)-1):
+            renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
     image_buffer = renderer.save_to_buffer()
 
     compare_images(
-        image_buffer, "filled_simple_chunk.png", f"{name}_{fill_type}", mean_threshold=0.12,
+        image_buffer, "filled_simple_chunk.png", f"{name}_{fill_type}_{multi}", mean_threshold=0.12,
     )
 
 
@@ -137,8 +141,7 @@ def test_filled_simple_chunk_threads(fill_type: FillType, thread_count: int) -> 
     assert cont_gen.thread_count == thread_count
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(
@@ -162,8 +165,7 @@ def test_filled_simple_no_corner_mask(name: str, fill_type: FillType) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "filled_simple_no_corner_mask.png", f"{name}_{fill_type}")
@@ -187,8 +189,7 @@ def test_filled_simple_no_corner_mask_chunk(name: str, fill_type: FillType) -> N
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(
@@ -218,8 +219,7 @@ def test_filled_simple_no_corner_mask_chunk_threads(fill_type: FillType, thread_
     assert cont_gen.thread_count == thread_count
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(
@@ -245,8 +245,7 @@ def test_filled_simple_corner_mask(name: str) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "filled_simple_corner_mask.png", f"{name}_{fill_type}")
@@ -271,8 +270,7 @@ def test_filled_simple_corner_mask_chunk(name: str) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(
@@ -303,8 +301,7 @@ def test_filled_simple_corner_mask_chunk_threads(fill_type: FillType, thread_cou
     assert cont_gen.thread_count == thread_count
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(
@@ -330,8 +327,7 @@ def test_filled_simple_quad_as_tri(name: str) -> None:
 
     fill_type = cont_gen.fill_type
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "filled_simple_quad_as_tri.png", f"{name}")
@@ -366,8 +362,9 @@ def test_filled_random(name: str, fill_type: FillType, multi: bool) -> None:
 
 
 @pytest.mark.image
+@pytest.mark.parametrize("multi", [False, True])
 @pytest.mark.parametrize("name, fill_type", util_test.all_names_and_fill_types())
-def test_filled_random_chunk(name: str, fill_type: FillType) -> None:
+def test_filled_random_chunk(name: str, fill_type: FillType, multi: bool) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -383,8 +380,11 @@ def test_filled_random_chunk(name: str, fill_type: FillType) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    if multi:
+        renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
+    else:
+        for i in range(len(levels)-1):
+            renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
     image_buffer = renderer.save_to_buffer()
 
     max_threshold = None
@@ -401,7 +401,7 @@ def test_filled_random_chunk(name: str, fill_type: FillType) -> None:
             mean_threshold = 0.19
 
     compare_images(
-        image_buffer, "filled_random_chunk.png", f"{name}_{fill_type}",
+        image_buffer, "filled_random_chunk.png", f"{name}_{fill_type}_{multi}",
         max_threshold=max_threshold, mean_threshold=mean_threshold,
     )
 
@@ -426,8 +426,7 @@ def test_filled_random_chunk_threads(fill_type: FillType, thread_count: int) -> 
     assert cont_gen.thread_count == thread_count
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     if fill_type in (FillType.ChunkCombinedCode, FillType.ChunkCombinedOffset):
@@ -459,8 +458,7 @@ def test_filled_random_no_corner_mask(name: str, fill_type: FillType) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "filled_random_no_corner_mask.png", f"{name}_{fill_type}")
@@ -484,8 +482,7 @@ def test_filled_random_no_corner_mask_chunk(name: str, fill_type: FillType) -> N
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     max_threshold = None
@@ -528,8 +525,7 @@ def test_filled_random_no_corner_mask_chunk_threads(fill_type: FillType, thread_
     assert cont_gen.thread_count == thread_count
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     if fill_type in (FillType.ChunkCombinedCode, FillType.ChunkCombinedOffset):
@@ -562,8 +558,7 @@ def test_filled_random_corner_mask(name: str) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "filled_random_corner_mask.png", f"{name}_{fill_type}")
@@ -588,8 +583,7 @@ def test_filled_random_corner_mask_chunk(name: str) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     max_threshold = None
@@ -626,8 +620,7 @@ def test_filled_random_corner_mask_chunk_threads(fill_type: FillType, thread_cou
     assert cont_gen.thread_count == thread_count
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(
@@ -652,8 +645,7 @@ def test_filled_random_quad_as_tri(name: str) -> None:
 
     fill_type = cont_gen.fill_type
     renderer = MplTestRenderer()
-    for i in range(len(levels)-1):
-        renderer.filled(cont_gen.filled(levels[i], levels[i+1]), fill_type, color=f"C{i}")
+    renderer.multi_filled(cont_gen.multi_filled(levels), fill_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "filled_random_quad_as_tri.png", f"{name}")

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -141,8 +141,9 @@ def test_lines_simple(name: str, line_type: LineType, multi: bool) -> None:
 
 
 @pytest.mark.image
+@pytest.mark.parametrize("multi", [False, True])
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
-def test_lines_simple_chunk(name: str, line_type: LineType) -> None:
+def test_lines_simple_chunk(name: str, line_type: LineType, multi: bool) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -158,11 +159,14 @@ def test_lines_simple_chunk(name: str, line_type: LineType) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    if multi:
+        renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
+    else:
+        for i in range(len(levels)):
+            renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
     image_buffer = renderer.save_to_buffer()
 
-    compare_images(image_buffer, "lines_simple_chunk.png", f"{name}_{line_type}")
+    compare_images(image_buffer, "lines_simple_chunk.png", f"{name}_{line_type}_{multi}")
 
 
 @pytest.mark.image
@@ -185,8 +189,7 @@ def test_lines_simple_chunk_threads(line_type: LineType, thread_count: int) -> N
     assert cont_gen.thread_count == thread_count
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "lines_simple_chunk.png", f"{line_type}_{thread_count}")
@@ -208,8 +211,7 @@ def test_lines_simple_no_corner_mask(name: str, line_type: LineType) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "lines_simple_no_corner_mask.png", f"{name}_{line_type}")
@@ -233,8 +235,7 @@ def test_lines_simple_no_corner_mask_chunk(name: str, line_type: LineType) -> No
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "lines_simple_no_corner_mask_chunk.png", f"{name}_{line_type}")
@@ -261,8 +262,7 @@ def test_lines_simple_no_corner_mask_chunk_threads(line_type: LineType, thread_c
     assert cont_gen.thread_count == thread_count
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(
@@ -287,8 +287,7 @@ def test_lines_simple_corner_mask(name: str) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "lines_simple_corner_mask.png", f"{name}_{line_type}")
@@ -313,8 +312,7 @@ def test_lines_simple_corner_mask_chunk(name: str) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "lines_simple_corner_mask_chunk.png", f"{name}_{line_type}")
@@ -341,8 +339,7 @@ def test_lines_simple_corner_mask_chunk_threads(line_type: LineType, thread_coun
     assert cont_gen.thread_count == thread_count
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(
@@ -365,10 +362,8 @@ def test_lines_simple_quad_as_tri(name: str) -> None:
     assert cont_gen.thread_count == 1
     assert cont_gen.quad_as_tri
 
-    line_type = cont_gen.line_type
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), cont_gen.line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "lines_simple_quad_as_tri.png", f"{name}")
@@ -405,8 +400,9 @@ def test_lines_random(name: str, line_type: LineType, multi: bool) -> None:
 
 
 @pytest.mark.image
+@pytest.mark.parametrize("multi", [False, True])
 @pytest.mark.parametrize("name, line_type", util_test.all_names_and_line_types())
-def test_lines_random_chunk(name: str, line_type: LineType) -> None:
+def test_lines_random_chunk(name: str, line_type: LineType, multi: bool) -> None:
     from contourpy.util.mpl_renderer import MplTestRenderer
 
     from .image_comparison import compare_images
@@ -422,8 +418,11 @@ def test_lines_random_chunk(name: str, line_type: LineType) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    if multi:
+        renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
+    else:
+        for i in range(len(levels)):
+            renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
     image_buffer = renderer.save_to_buffer()
 
     max_threshold = None
@@ -433,7 +432,7 @@ def test_lines_random_chunk(name: str, line_type: LineType) -> None:
         mean_threshold = 0.11
 
     compare_images(
-        image_buffer, "lines_random_chunk.png", f"{name}_{line_type}",
+        image_buffer, "lines_random_chunk.png", f"{name}_{line_type}_{multi}",
         max_threshold=max_threshold, mean_threshold=mean_threshold,
     )
 
@@ -458,8 +457,7 @@ def test_lines_random_chunk_threads(line_type: LineType, thread_count: int) -> N
     assert cont_gen.thread_count == thread_count
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(
@@ -483,8 +481,7 @@ def test_lines_random_no_corner_mask(name: str, line_type: LineType) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "lines_random_no_corner_mask.png", f"{name}_{line_type}")
@@ -511,8 +508,7 @@ def test_lines_random_no_corner_mask_chunk(name: str, line_type: LineType) -> No
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "lines_random_no_corner_mask_chunk.png", f"{name}_{line_type}")
@@ -539,8 +535,7 @@ def test_lines_random_no_corner_mask_chunk_threads(line_type: LineType, thread_c
     assert cont_gen.thread_count == thread_count
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(
@@ -565,8 +560,7 @@ def test_lines_random_corner_mask(name: str) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "lines_random_corner_mask.png", f"{name}_{line_type}")
@@ -591,8 +585,7 @@ def test_lines_random_corner_mask_chunk(name: str) -> None:
     assert cont_gen.thread_count == 1
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "lines_random_corner_mask_chunk.png", f"{name}_{line_type}")
@@ -619,8 +612,7 @@ def test_lines_random_corner_mask_chunk_threads(line_type: LineType, thread_coun
     assert cont_gen.thread_count == thread_count
 
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(
@@ -643,10 +635,8 @@ def test_lines_random_quad_as_tri(name: str) -> None:
     assert cont_gen.thread_count == 1
     assert cont_gen.quad_as_tri
 
-    line_type = cont_gen.line_type
     renderer = MplTestRenderer()
-    for i in range(len(levels)):
-        renderer.lines(cont_gen.lines(levels[i]), line_type, color=f"C{i}")
+    renderer.multi_lines(cont_gen.multi_lines(levels), cont_gen.line_type)
     image_buffer = renderer.save_to_buffer()
 
     compare_images(image_buffer, "lines_random_quad_as_tri.png", f"{name}")


### PR DESCRIPTION
Switch to using `multi_lines` and `multi_filled` in tests and benchmarks wherever possible to make the code simpler. Have kept some tests that use both the multi and non-multi approaches to demonstrate they produce the same results.