### PR TITLE
Add new functions dechunk_multi_lines and dechunk_multi_filled

### DIFF
--- a/docs/api/contourpy/other.rst
+++ b/docs/api/contourpy/other.rst
@@ -11,4 +11,8 @@ Other functions
 
 .. autofunction:: dechunk_lines
 
+.. autofunction:: dechunk_multi_filled
+
+.. autofunction:: dechunk_multi_lines
+
 .. autofunction:: max_threads

--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -18,7 +18,12 @@ from contourpy._contourpy import (
 from contourpy._version import __version__
 from contourpy.chunk import calc_chunk_sizes
 from contourpy.convert import convert_filled, convert_lines
-from contourpy.dechunk import dechunk_filled, dechunk_lines
+from contourpy.dechunk import (
+    dechunk_filled,
+    dechunk_lines,
+    dechunk_multi_filled,
+    dechunk_multi_lines,
+)
 from contourpy.enum_util import as_fill_type, as_line_type, as_z_interp
 
 if TYPE_CHECKING:
@@ -35,6 +40,8 @@ __all__ = [
     "convert_lines",
     "dechunk_filled",
     "dechunk_lines",
+    "dechunk_multi_filled",
+    "dechunk_multi_lines",
     "max_threads",
     "FillType",
     "LineType",

--- a/lib/contourpy/dechunk.py
+++ b/lib/contourpy/dechunk.py
@@ -104,6 +104,7 @@ def dechunk_lines(lines: cpy.LineReturn, line_type: LineType | str) -> cpy.LineR
     .. versionadded:: 1.2.0
     """
     line_type = as_line_type(line_type)
+
     if line_type in (LineType.Separate, LineType.SeparateCode):
         # No-op if line_type is not chunked.
         return lines
@@ -142,3 +143,37 @@ def dechunk_lines(lines: cpy.LineReturn, line_type: LineType | str) -> cpy.LineR
         return ret3
     else:
         raise ValueError(f"Invalid LineType {line_type}")
+
+
+def dechunk_multi_filled(
+    multi_filled: list[cpy.FillReturn],
+    fill_type: FillType | str,
+) -> list[cpy.FillReturn]:
+    """
+
+    .. versionadded:: 1.3.0
+    """
+    fill_type = as_fill_type(fill_type)
+
+    if fill_type in (FillType.OuterCode, FillType.OuterOffset):
+        # No-op if fill_type is not chunked.
+        return multi_filled
+
+    return [dechunk_filled(filled, fill_type) for filled in multi_filled]
+
+
+def dechunk_multi_lines(
+    multi_lines: list[cpy.LineReturn],
+    line_type: LineType | str,
+) -> list[cpy.LineReturn]:
+    """
+
+    .. versionadded:: 1.3.0
+    """
+    line_type = as_line_type(line_type)
+
+    if line_type in (LineType.Separate, LineType.SeparateCode):
+        # No-op if line_type is not chunked.
+        return multi_lines
+
+    return [dechunk_lines(lines, line_type) for lines in multi_lines]

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -110,7 +110,8 @@ PYBIND11_MODULE(_contourpy, m) {
         "numpy arrays. The exact format is determined by the ``line_type`` used by the "
         "``ContourGenerator``.\n\n"
         "``level`` may be ``np.nan``, ``np.inf`` or ``-np.inf``; they all return the same result "
-        "which is an empty line set.";
+        "which is an empty line set.\n\n"
+        ".. versionadded:: 1.3.0";
     const char* multi_filled_doc =
         "Calculate and return filled contours between multiple levels.\n\n"
         "Args:\n"
@@ -128,7 +129,8 @@ PYBIND11_MODULE(_contourpy, m) {
         "    ret = obj.multi_filled(levels)\n\n"
         "is equivalent to:\n\n"
         ".. code-block:: python\n\n"
-        "    ret = [obj.filled(lower, upper) for lower, upper in zip(levels[:-1], levels[1:])]";
+        "    ret = [obj.filled(lower, upper) for lower, upper in zip(levels[:-1], levels[1:])]\n\n"
+        ".. versionadded:: 1.3.0";
     const char* multi_lines_doc =
         "Calculate and return contour lines at multiple levels.\n\n"
         "Args:\n"


### PR DESCRIPTION
Add new convenience functions `dechunk_multi_lines` and `dechunk_multi_filled` to support dechunking of the returns of `ContourGenerator.multi_lines` and `ContourGenerator.multi_filled`.