### PR TITLE
Drop numpy < 2.0 pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "numpy >= 1.20, < 2.0",
+    "numpy >= 1.20",
 ]
 description = "Python library for calculating contours of 2D quadrilateral grids"
 dynamic = ["version"]


### PR DESCRIPTION
Drop `numpy < 2.0` pin in `main` (i.e. development) branch.