### PR TITLE
Add CI run using earliest supported numpy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,11 @@ jobs:
             python-version: "3.11"
             name: "Test numpy debug"
             build-numpy-debug: true
+          # Test against earliest supported numpy
+          - os: ubuntu-latest
+            python-version: "3.9"
+            name: "Test earliest numpy"
+            extra-install-args: "numpy==1.20"
           # Compile using C++11.
           - os: ubuntu-latest
             python-version: "3.11"


### PR DESCRIPTION
Add new CI run using earliest supported numpy. This is currently numpy 1.20, which implies python <= 3.9. This will pick up earlier matplotlib as well.