### PR TITLE
Add new functions convert_multi_lines and convert_multi_filled

### DIFF
--- a/docs/api/contourpy/other.rst
+++ b/docs/api/contourpy/other.rst
@@ -7,6 +7,10 @@ Other functions
 
 .. autofunction:: convert_lines
 
+.. autofunction:: convert_multi_filled
+
+.. autofunction:: convert_multi_lines
+
 .. autofunction:: dechunk_filled
 
 .. autofunction:: dechunk_lines

--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -17,7 +17,12 @@ from contourpy._contourpy import (
 )
 from contourpy._version import __version__
 from contourpy.chunk import calc_chunk_sizes
-from contourpy.convert import convert_filled, convert_lines
+from contourpy.convert import (
+    convert_filled,
+    convert_lines,
+    convert_multi_filled,
+    convert_multi_lines,
+)
 from contourpy.dechunk import (
     dechunk_filled,
     dechunk_lines,
@@ -38,6 +43,8 @@ __all__ = [
     "contour_generator",
     "convert_filled",
     "convert_lines",
+    "convert_multi_filled",
+    "convert_multi_lines",
     "dechunk_filled",
     "dechunk_lines",
     "dechunk_multi_filled",

--- a/lib/contourpy/convert.py
+++ b/lib/contourpy/convert.py
@@ -553,3 +553,33 @@ def convert_lines(
         return _convert_lines_from_ChunkCombinedNan(lines, line_type_to)
     else:
         raise ValueError(f"Invalid LineType {line_type_from}")
+
+
+def convert_multi_filled(
+    multi_filled: list[cpy.FillReturn],
+    fill_type_from: FillType | str,
+    fill_type_to:  FillType | str,
+) -> list[cpy.FillReturn]:
+    """
+
+    .. versionadded:: 1.3.0
+    """
+    fill_type_from = as_fill_type(fill_type_from)
+    fill_type_to = as_fill_type(fill_type_to)
+
+    return [convert_filled(filled, fill_type_from, fill_type_to) for filled in multi_filled]
+
+
+def convert_multi_lines(
+    multi_lines: list[cpy.LineReturn],
+    line_type_from: LineType | str,
+    line_type_to:  LineType | str,
+) -> list[cpy.LineReturn]:
+    """
+
+    .. versionadded:: 1.3.0
+    """
+    line_type_from = as_line_type(line_type_from)
+    line_type_to = as_line_type(line_type_to)
+
+    return [convert_lines(lines, line_type_from, line_type_to) for lines in multi_lines]


### PR DESCRIPTION
Add new convenience functions `convert_multi_lines` and `convert_multi_filled` to support converting of the returns of `ContourGenerator.multi_lines` and `ContourGenerator.multi_filled`.