### PR TITLE
Clarify use of quotes in pip install

### DIFF
--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -127,6 +127,14 @@ ContourPy and then run the tests using ``pytest``:
    $ python -m pip install -ve .[test]
    $ pytest -v
 
+.. note::
+
+   In some shells, such as ``zsh``, quotes are required around ``.[test]``. For example:
+
+   .. code-block:: console
+
+      $ python -m pip install -ve ".[test]"
+
 It is possible to exclude certain tests. To exclude image comparison tests, for example if you do
 not have Matplotlib or Pillow installed:
 


### PR DESCRIPTION
Clarify in docs that some uses of `pip install` (e.g. on zsh) such as
```bash
python -m pip install -ve .[test]
```
need quotes around the `.[test]` so
```
python -m pip install -ve ".[test]"
```