### PR TITLE
Remove unneeded type:ignore using Bokeh 3.3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,12 @@ jobs:
           cd cppcheck-$CPPCHECK_VERSION
           sudo make install MATCHCOMPILER=yes FILESDIR=/usr/share/cppcheck CXXFLAGS="-O2 -DNDEBUG" -j 2
 
+      - name: Smoke test
+        run: |
+          python -m pip list
+          python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"
+          python -c "import contourpy as c; print('NDEBUG', c._contourpy.NDEBUG)"
+
       - name: Run tests
         run: |
           ${PYTEST} tests/test_codebase.py

--- a/tests/test_bokeh_renderer.py
+++ b/tests/test_bokeh_renderer.py
@@ -28,8 +28,8 @@ def driver(driver_path: str) -> Iterator[WebDriver]:
         from selenium.webdriver.chrome.webdriver import WebDriver as Chrome
 
         options = Options()
-        options.add_argument("--headless")  # type: ignore[no-untyped-call]
-        options.add_argument("--no-sandbox")  # type: ignore[no-untyped-call]
+        options.add_argument("--headless")
+        options.add_argument("--no-sandbox")
 
         if driver_path:
             from selenium.webdriver.chrome.service import Service


### PR DESCRIPTION
There are two `type: ignore` comments that were needed in the test suite when using Bokeh 3.3.3 but are no longer needed with Bokeh 3.3.4. This PR removes them.

```
tests/test_bokeh_renderer.py:31: error: Unused "type: ignore" comment  [unused-ignore]
tests/test_bokeh_renderer.py:32: error: Unused "type: ignore" comment  [unused-ignore]
```