### PR TITLE
Convert return from np.split to list

### DIFF
--- a/lib/contourpy/array.py
+++ b/lib/contourpy/array.py
@@ -228,7 +228,7 @@ def split_codes_by_offsets(codes: cpy.CodeArray, offsets: cpy.OffsetArray) -> li
     check_offset_array(offsets)
 
     if len(offsets) > 2:
-        return np.split(codes, offsets[1:-1])
+        return list(np.split(codes, offsets[1:-1]))
     else:
         return [codes]
 
@@ -243,7 +243,7 @@ def split_points_by_offsets(
     check_offset_array(offsets)
 
     if len(offsets) > 2:
-        return np.split(points, offsets[1:-1])
+        return list(np.split(points, offsets[1:-1]))
     else:
         return [points]
 

--- a/lib/contourpy/convert.py
+++ b/lib/contourpy/convert.py
@@ -387,7 +387,7 @@ def _convert_lines_from_ChunkCombinedCode(
                     assert codes is not None
                 split_at = np.nonzero(codes == MOVETO)[0]
                 if len(split_at) > 1:
-                    separate_lines += np.split(points, split_at[1:])
+                    separate_lines += list(np.split(points, split_at[1:]))
                 else:
                     separate_lines.append(points)
         if line_type_to == LineType.Separate:

--- a/lib/contourpy/util/mpl_util.py
+++ b/lib/contourpy/util/mpl_util.py
@@ -23,8 +23,8 @@ def filled_to_mpl_paths(filled: FillReturn, fill_type: FillType) -> list[mpath.P
         for points, codes, outer_offsets in zip(*filled):
             if points is None:
                 continue
-            points = np.split(points, outer_offsets[1:-1])
-            codes = np.split(codes, outer_offsets[1:-1])
+            points = list(np.split(points, outer_offsets[1:-1]))
+            codes = list(np.split(codes, outer_offsets[1:-1]))
             paths += [mpath.Path(p, c) for p, c in zip(points, codes)]
     elif fill_type == FillType.ChunkCombinedOffsetOffset:
         paths = []


### PR DESCRIPTION
Fixes #353 by casting returns from `np.split` to `list` as that is how they are dealt with internally in ContourPy.