### PR TITLE
Update upload artifact github action to v4

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -65,12 +65,13 @@ jobs:
           rm /c/Program\ Files/Git/usr/bin/link.EXE
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.4
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheels_${{ matrix.os }}_${{ matrix.arch }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -95,6 +96,18 @@ jobs:
         run: |
           python -m build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: sdist
           path: dist/*.tar.gz
+
+  merge:
+    name: Merge build artifacts
+    runs-on: ubuntu-latest
+    needs: [build_wheels, build_sdist]
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: build_wheels_artifacts
+          delete-merged: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, macos-14, windows-latest]  # macos-14 is M1
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         name: ["Test"]
+        short-name: ["test"]
         exclude:
           # M1 mac setup-python doesn't yet have python 3.9
           # https://github.com/actions/setup-python/issues/808
@@ -102,44 +103,52 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.11"
             name: "Test debug with coverage"
+            short-name: "test-debug"
             coverage-files: "coverage.lcov,coverage.cpp"
             debug: true
           # Bokeh and text tests with Python (not C++) coverage.
           - os: ubuntu-latest
             python-version: "3.11"
             name: "Test bokeh and text tests with coverage"
+            short-name: "test-bokeh"
             coverage-files: "coverage.lcov"
             test-text: true
           # Test against numpy debug build.
           - os: ubuntu-latest
             python-version: "3.11"
             name: "Test numpy debug"
+            short-name: "test-numpy-debug"
             build-numpy-debug: true
           # Test against earliest supported numpy
           - os: ubuntu-latest
             python-version: "3.9"
             name: "Test earliest numpy"
+            short-name: "test-earliest-numpy"
             extra-install-args: "numpy==1.20"
           # Compile using C++11.
           - os: ubuntu-latest
             python-version: "3.11"
             name: "Test C++11"
+            short-name: "test-c++11"
             extra-install-args: "-Csetup-args=-Dcpp_std=c++11"
           # PyPy only tested on ubuntu for speed, exclude big tests.
           - os: ubuntu-latest
             python-version: "pypy3.9"
             name: "Test"
+            short-name: "test"
             test-no-big: true
           # Win32 test.
           - os: windows-latest
             python-version: "3.11"
             name: "Win32"
+            short-name: "test-win32"
             win32: true
             extra-install-args: "--only-binary Pillow"
           # Test against matplotlib and numpy nightly wheels.
           - os: ubuntu-latest
             python-version: "3.12"
             name: "Nightly wheels"
+            short-name: "test-nightlies"
             nightly-wheels: true
 
     steps:
@@ -285,22 +294,12 @@ jobs:
           files: ${{ matrix.coverage-files }}
           verbose: true
 
-      - name: Collect test image failures
-        if: always()
-        run: |
-          if [[ -e result_images ]]
-          then
-            DIR="test-artifacts/${{ matrix.os }}_${{ matrix.python-version }}_${{ matrix.name }}"
-            mkdir -p "${DIR}"
-            mv result_images/* "${DIR}/"
-          fi
-
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-artifacts
-          path: test-artifacts/
+          name: ${{ matrix.short-name }}_${{ matrix.os }}_${{ matrix.python-version }}
+          path: result_images/
 
   test-in-docker:
     # In-docker tests are either emulated hardware or musllinux
@@ -405,19 +404,21 @@ jobs:
             fi
             echo "-------------------- end --------------------"
 
-      - name: Collect test image failures
-        if: always()
-        run: |
-          if [[ -e result_images ]]
-          then
-            DIR="test-artifacts/docker_${{ matrix.arch }}_${{ matrix.manylinux_version }}"
-            mkdir -p ${DIR}
-            sudo mv result_images/* ${DIR}/
-          fi
-
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker_${{ matrix.arch }}_${{ matrix.manylinux_version }}
+          path: result_images/
+
+  merge:
+    name: Merge test artifacts
+    runs-on: ubuntu-latest
+    needs: [test, test-in-docker]
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
         with:
           name: test-artifacts
-          path: test-artifacts/
+          separate-directories: true
+          delete-merged: true


### PR DESCRIPTION
Update `upload-artifact` github action to v4. This prohibits multiple uploads to the same named artifact, so here we now have different naming conventions for artifacts and their contents.