### PR TITLE
Update codecov-action to v4

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,6 @@
 codecov:
   notify:
     after_n_builds: 2
-    wait_for_ci: no
 
 comment: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -292,9 +292,10 @@ jobs:
 
       - name: Upload coverage
         if: matrix.coverage-files
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ${{ matrix.coverage-files }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
       - name: Upload test artifacts


### PR DESCRIPTION
Update `codecov-action` to v4. `token` is now required.