### PR TITLE
Update to asv 0.6.2

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,7 +9,7 @@ Installing ASV
 ASV creates virtualenvs to run benchmarks in.  Before using it you need to
 
 ```
-pip install asv==0.4.2 virtualenv
+pip install "asv>=0.6.2"
 ```
 or the `conda` equivalent.
 

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -1,161 +1,24 @@
 {
-    // The version of the config file format.  Do not change, unless
-    // you know what you are doing.
     "version": 1,
-
-    // The name of the project being benchmarked
     "project": "contourpy",
-
-    // The project's homepage
     "project_url": "http://github.com/contourpy/contourpy",
-
-    // The URL or local path of the source code repository for the
-    // project being benchmarked
     "repo": "..",
-
-    // The Python project's subdirectory in your repo.  If missing or
-    // the empty string, the project is assumed to be located at the root
-    // of the repository.
-    // "repo_subdir": "",
-
-    // Customizable commands for building, installing, and
-    // uninstalling the project. See asv.conf.json documentation.
-    //
-    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
-    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
-    // "build_command": [
-    //     "python setup.py build",
-    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
-    // ],
     "build_command": [
         "python -m pip install --upgrade build pip",
         "python -m build --wheel -o {build_cache_dir} {build_dir}"
     ],
-
-    // List of branches to benchmark. If not provided, defaults to "master"
-    // (for git) or "default" (for mercurial).
     "branches": ["main"],
-
-    // The DVCS being used.  If not set, it will be automatically
-    // determined from "repo" by looking at the protocol in the URL
-    // (if remote), or by looking for special directories, such as
-    // ".git" (if local).
     "dvcs": "git",
-
-    // The tool to use to create environments.  May be "conda",
-    // "virtualenv" or other value depending on the plugins in use.
-    // If missing or the empty string, the tool will be automatically
-    // determined by looking for tools on the PATH environment
-    // variable.
     "environment_type": "virtualenv",
-
-    // timeout in seconds for installing any dependencies in environment
-    // defaults to 10 min
-    //"install_timeout": 600,
-
-    // the base URL to show a commit for the project.
     "show_commit_url": "http://github.com/contourpy/contourpy/commit/",
-
-    // The Pythons you'd like to test against.  If not provided, defaults
-    // to the current version of Python used to run `asv`.
-    //"pythons": ["3.9"],
-
-    // The list of conda channel names to be searched for benchmark
-    // dependency packages in the specified order
-    // "conda_channels": ["conda-forge", "defaults"],
-
-    // The matrix of dependencies to test.  Each key is the name of a
-    // package (in PyPI) and the values are version numbers.  An empty
-    // list or empty string indicates to just test against the default
-    // (latest) version. null indicates that the package is to not be
-    // installed. If the package to be tested is only available from
-    // PyPi, and the 'environment_type' is conda, then you can preface
-    // the package name by 'pip+', and the package will be installed via
-    // pip (with all the conda available packages installed first,
-    // followed by the pip installed packages).
     "matrix": {
-        "matplotlib": [],
-        "numpy": []
+        "req": {
+            "matplotlib": [],
+            "numpy": []
+        }
     },
-
-    // Combinations of libraries/python versions can be excluded/included
-    // from the set to test. Each entry is a dictionary containing additional
-    // key-value pairs to include/exclude.
-    //
-    // An exclude entry excludes entries where all values match. The
-    // values are regexps that should match the whole string.
-    //
-    // An include entry adds an environment. Only the packages listed
-    // are installed. The 'python' key is required. The exclude rules
-    // do not apply to includes.
-    //
-    // In addition to package names, the following keys are available:
-    //
-    // - python
-    //     Python version, as in the *pythons* variable above.
-    // - environment_type
-    //     Environment type, as above.
-    // - sys_platform
-    //     Platform, as in sys.platform. Possible values for the common
-    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
-    //
-    // "exclude": [
-    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
-    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
-    // ],
-    //
-    // "include": [
-    //     // additional env for python2.7
-    //     {"python": "2.7", "numpy": "1.8"},
-    //     // additional env if run on windows+conda
-    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
-    // ],
-
-    // The directory (relative to the current directory) that benchmarks are
-    // stored in.  If not provided, defaults to "benchmarks"
     "benchmark_dir": "benchmarks",
-
-    // The directory (relative to the current directory) to cache the Python
-    // environments in.  If not provided, defaults to "env"
     "env_dir": ".asv/env",
-
-    // The directory (relative to the current directory) that raw benchmark
-    // results are stored in.  If not provided, defaults to "results".
     "results_dir": ".asv/results",
-
-    // The directory (relative to the current directory) that the html tree
-    // should be written to.  If not provided, defaults to "html".
-    "html_dir": ".asv/html",
-
-    // The number of characters to retain in the commit hashes.
-    // "hash_length": 8,
-
-    // `asv` will cache results of the recent builds in each
-    // environment, making them faster to install next time.  This is
-    // the number of builds to keep, per environment.
-    // "build_cache_size": 2,
-
-    // The commits after which the regression search in `asv publish`
-    // should start looking for regressions. Dictionary whose keys are
-    // regexps matching to benchmark names, and values corresponding to
-    // the commit (exclusive) after which to start looking for
-    // regressions.  The default is to start from the first commit
-    // with results. If the commit is `null`, regression detection is
-    // skipped for the matching benchmark.
-    //
-    // "regressions_first_commits": {
-    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
-    //    "another_benchmark": null,   // Skip regression detection altogether
-    // },
-
-    // The thresholds for relative change in results, after which `asv
-    // publish` starts reporting regressions. Dictionary of the same
-    // form as in ``regressions_first_commits``, with values
-    // indicating the thresholds.  If multiple entries match, the
-    // maximum is taken. If no entry matches, the default is 5%.
-    //
-    // "regressions_thresholds": {
-    //    "some_benchmark": 0.01,     // Threshold of 1%
-    //    "another_benchmark": 0.5,   // Threshold of 50%
-    // },
+    "html_dir": ".asv/html"
 }

--- a/benchmarks/benchmarks/bench_filled_mpl20xx.py
+++ b/benchmarks/benchmarks/bench_filled_mpl20xx.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from asv_runner.benchmarks.mark import SkipNotImplemented
+
 from contourpy import FillType, contour_generator
 
 from .bench_base import BenchBase
@@ -15,13 +17,13 @@ class BenchFilledMpl20xx(BenchBase):
     def setup(
         self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
     ) -> None:
+        if name == "mpl2005" and corner_mask is True:
+            raise SkipNotImplemented(f"{name} does not support corner_mask={corner_mask}")
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
     def time_filled_mpl20xx(
         self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
     ) -> None:
-        if name == "mpl2005" and corner_mask is True:
-            raise NotImplementedError  # Does not support corner_mask=True
         cont_gen = contour_generator(
             self.x, self.y, self.z, name=name, fill_type=fill_type,
             corner_mask=corner_mask_to_bool(corner_mask),

--- a/benchmarks/benchmarks/bench_filled_mpl20xx_render.py
+++ b/benchmarks/benchmarks/bench_filled_mpl20xx_render.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from asv_runner.benchmarks.mark import SkipNotImplemented
+
 from contourpy import FillType, contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
 
@@ -16,13 +18,13 @@ class BenchFilledMpl20xxRender(BenchBase):
     def setup(
         self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
     ) -> None:
+        if name == "mpl2005" and corner_mask is True:
+            raise SkipNotImplemented(f"{name} does not support corner_mask={corner_mask}")
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
     def time_filled_mpl20xx_render(
         self, name: str, dataset: str, fill_type: FillType, corner_mask: str | bool, n: int,
     ) -> None:
-        if name == "mpl2005" and corner_mask is True:
-            raise NotImplementedError  # Does not support corner_mask=True
         cont_gen = contour_generator(
             self.x, self.y, self.z, name=name, fill_type=fill_type,
             corner_mask=corner_mask_to_bool(corner_mask),

--- a/benchmarks/benchmarks/bench_lines_mpl20xx.py
+++ b/benchmarks/benchmarks/bench_lines_mpl20xx.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from asv_runner.benchmarks.mark import SkipNotImplemented
+
 from contourpy import LineType, contour_generator
 
 from .bench_base import BenchBase
@@ -16,13 +18,13 @@ class BenchLinesMpl20xx(BenchBase):
     def setup(
         self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
     ) -> None:
+        if name == "mpl2005" and corner_mask is True:
+            raise SkipNotImplemented(f"{name} does not support corner_mask={corner_mask}")
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
     def time_lines_mpl20xx(
         self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
     ) -> None:
-        if name == "mpl2005" and corner_mask is True:
-            raise NotImplementedError  # Does not support corner_mask=True
         cont_gen = contour_generator(
             self.x, self.y, self.z, name=name, line_type=line_type,
             corner_mask=corner_mask_to_bool(corner_mask),

--- a/benchmarks/benchmarks/bench_lines_mpl20xx_render.py
+++ b/benchmarks/benchmarks/bench_lines_mpl20xx_render.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from asv_runner.benchmarks.mark import SkipNotImplemented
+
 from contourpy import LineType, contour_generator
 from contourpy.util.mpl_renderer import MplTestRenderer
 
@@ -17,13 +19,13 @@ class BenchLinesMpl20xxRender(BenchBase):
     def setup(
         self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
     ) -> None:
+        if name == "mpl2005" and corner_mask is True:
+            raise SkipNotImplemented(f"{name} does not support corner_mask={corner_mask}")
         self.set_xyz_and_levels(dataset, n, corner_mask != "no mask")
 
     def time_lines_mpl20xx_render(
         self, name: str, dataset: str, line_type: LineType, corner_mask: str | bool, n: int,
     ) -> None:
-        if name == "mpl2005" and corner_mask is True:
-            raise NotImplementedError  # Does not support corner_mask=True
         cont_gen = contour_generator(
             self.x, self.y, self.z, name=name, line_type=line_type,
             corner_mask=corner_mask_to_bool(corner_mask),

--- a/benchmarks/loader.py
+++ b/benchmarks/loader.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, Any
 from asv.benchmarks import Benchmarks
 from asv.config import Config
 from asv.results import Results, iter_results_for_machine
-from asv.statistics import get_err
+from asv_runner.statistics import get_err
+import numpy as np
 
 from contourpy import FillType, LineType
 
@@ -87,7 +88,7 @@ class Loader:
                     param[i] = item
             ret[name] = param[0] if len(param) == 1 else param
 
-        if values[0] is None:
+        if values[0] is None or np.isnan(values[0]):
             ret["mean"] = ret["error"] = None
         else:
             ret["mean"] = values

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ warn_unused_ignores = true
 [[tool.mypy.overrides]]
 module = [
     "asv.*",
+    "asv_runner.*",
     "wurlitzer",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
Update `asv` to 0.6.2 as this is the first release containing fix airspeed-velocity/asv#1351 that is needed to support benchmarks with some parameter combinations skipped.