### PR TITLE
Add more doc cross-references to explain returned data formats

### DIFF
--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -127,10 +127,14 @@ def contour_generator(
             to :meth:`~.ContourGenerator.lines`, specified either as a :class:`~.LineType` or its
             string equivalent such as ``"SeparateCode"``.
             If not specified, uses the default provided by the algorithm ``name``.
+            The relationship between the :class:`~.LineType` enum and the data format returned from
+            :meth:`~.ContourGenerator.lines` is explained at :ref:`line_type`.
         fill_type (FillType or str, optional): The format of filled contour data returned from calls
             to :meth:`~.ContourGenerator.filled`, specified either as a :class:`~.FillType` or its
             string equivalent such as ``"OuterOffset"``.
             If not specified, uses the default provided by the algorithm ``name``.
+            The relationship between the :class:`~.FillType` enum and the data format returned from
+            :meth:`~.ContourGenerator.filled` is explained at :ref:`fill_type`.
         chunk_size (int or tuple(int, int), optional): Chunk size in (y, x) directions, or the same
             size in both directions if only one value is specified.
         chunk_count (int or tuple(int, int), optional): Chunk count in (y, x) directions, or the

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -97,7 +97,8 @@ PYBIND11_MODULE(_contourpy, m) {
         "    upper_level (float): Upper z-level of the filled contours, cannot be ``np.nan``.\n"
         "Return:\n"
         "    Filled contour polygons as nested sequences of numpy arrays. The exact format is "
-        "determined by the ``fill_type`` used by the ``ContourGenerator``.\n\n"
+        "determined by the :attr:`~.ContourGenerator.fill_type` used by the ``ContourGenerator`` "
+        "and the options are explained at :ref:`fill_type`.\n\n"
         "Raises a ``ValueError`` if ``lower_level >= upper_level`` or if\n"
         "``lower_level`` or ``upper_level`` are ``np.nan``.\n\n"
         "To return filled contours below a ``level`` use ``filled(-np.inf, level)``.\n"
@@ -109,11 +110,10 @@ PYBIND11_MODULE(_contourpy, m) {
         "    level (float): z-level to calculate contours at.\n\n"
         "Return:\n"
         "    Contour lines (open line strips and closed line loops) as nested sequences of "
-        "numpy arrays. The exact format is determined by the ``line_type`` used by the "
-        "``ContourGenerator``.\n\n"
+        "numpy arrays. The exact format is determined by the :attr:`~.ContourGenerator.line_type` "
+        "used by the ``ContourGenerator`` and the options are explained at :ref:`line_type`.\n\n"
         "``level`` may be ``np.nan``, ``np.inf`` or ``-np.inf``; they all return the same result "
-        "which is an empty line set.\n\n"
-        ".. versionadded:: 1.3.0";
+        "which is an empty line set.";
     const char* multi_filled_doc =
         "Calculate and return filled contours between multiple levels.\n\n"
         "Args:\n"
@@ -145,7 +145,8 @@ PYBIND11_MODULE(_contourpy, m) {
         "    ret = obj.multi_lines(levels)\n\n"
         "is equivalent to:\n\n"
         ".. code-block:: python\n\n"
-        "    ret = [obj.lines(level) for level in levels]";
+        "    ret = [obj.lines(level) for level in levels]\n\n"
+        ".. versionadded:: 1.3.0";
     const char* quad_as_tri_doc = "Return whether ``quad_as_tri`` is set or not.";
     const char* supports_corner_mask_doc =
         "Return whether this algorithm supports ``corner_mask``.";


### PR DESCRIPTION
This adds more cross-references in the API docs to the explanations of how the returned data formats of `lines()` and `filled()` calls relate to the contour generator's `line_type` and `fill_type`.

Fixes #365.