### PR TITLE
Disable scheduled CI test runs on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   pre-commit:
     name: pre-commit
+    if: github.event_name != 'schedule' || github.repository_owner == 'contourpy'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -36,6 +37,7 @@ jobs:
 
   codebase:
     name: codebase
+    if: github.event_name != 'schedule' || github.repository_owner == 'contourpy'
     runs-on: ubuntu-latest
 
     strategy:
@@ -80,6 +82,7 @@ jobs:
 
   test:
     name: "${{ matrix.name }} ${{ matrix.python-version }} ${{ matrix.os }}"
+    if: github.event_name != 'schedule' || github.repository_owner == 'contourpy'
     runs-on: ${{ matrix.os }}
     env:
       # Required version of chromium used for Bokeh image tests.
@@ -304,6 +307,7 @@ jobs:
   test-in-docker:
     # In-docker tests are either emulated hardware or musllinux
     name: In docker ${{ matrix.arch }} ${{ matrix.manylinux_version }}
+    if: github.event_name != 'schedule' || github.repository_owner == 'contourpy'
     runs-on: ubuntu-latest
 
     strategy:
@@ -413,6 +417,7 @@ jobs:
 
   merge:
     name: Merge test artifacts
+    if: github.event_name != 'schedule' || github.repository_owner == 'contourpy'
     runs-on: ubuntu-latest
     needs: [test, test-in-docker]
     steps:


### PR DESCRIPTION
Disable scheduled CI test runs on forks, only run them on the main repo, i.e. in the `contourpy` github organisation.