### PR TITLE
Support NumPy 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,6 +167,7 @@ jobs:
             short-name: "test-nightlies"
             nightly-wheels: true
             extra-install-args: "--no-build-isolation"
+            test-no-images: true
           - os: windows-latest
             python-version: "3.12"
             name: "Nightly wheels"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,25 +155,6 @@ jobs:
             nightly-wheels: true
             # The following will not be needed when can pin pybind11 to numpy2-compatible release.
             extra-install-args: "--no-build-isolation"
-          - os: macos-latest
-            python-version: "3.12"
-            name: "Nightly wheels"
-            short-name: "test-nightlies"
-            nightly-wheels: true
-            extra-install-args: "--no-build-isolation"
-          - os: macos-14
-            python-version: "3.12"
-            name: "Nightly wheels"
-            short-name: "test-nightlies"
-            nightly-wheels: true
-            extra-install-args: "--no-build-isolation"
-            test-no-images: true
-          - os: windows-latest
-            python-version: "3.12"
-            name: "Nightly wheels"
-            short-name: "test-nightlies"
-            nightly-wheels: true
-            extra-install-args: "--no-build-isolation"
 
     steps:
       - name: Checkout source
@@ -255,7 +236,6 @@ jobs:
       - name: Install latest pybind11 to support numpy 2
         # When pybind11 is released with https://github.com/pybind/pybind11/pull/5050 then this can
         # be replaced with a pin on pybind11 version in pyproject.toml, etc.
-        if: matrix.nightly-wheels
         run: |
           python -m pip install -r build_requirements.txt ninja
           python -m pip install git+https://github.com/seberg/pybind11@numpy2-compat
@@ -274,11 +254,16 @@ jobs:
           elif [[ "${{ matrix.test-no-images }}" != "" ]]
           then
             echo "Install contourpy with non-image-generating test dependencies"
-            python -m pip install -v .[test-no-images]
+            python -m pip install -v .[test-no-images] --no-build-isolation
           else
             echo "Install contourpy with standard test dependencies"
-            python -m pip install -v .[test] ${{ matrix.extra-install-args }}
+            python -m pip install -v .[test] ${{ matrix.extra-install-args }} --no-build-isolation
           fi
+
+      - name: Install numpy 2.0.0b1
+        if: ${{ matrix.short-name != 'test-earliest-numpy' }}
+        run: |
+          python -m pip install --upgrade --pre numpy==2.0.0b1
 
       - name: Install nightly wheels
         if: matrix.nightly-wheels

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,8 @@ jobs:
             name: "Nightly wheels"
             short-name: "test-nightlies"
             nightly-wheels: true
+            # The following will not be needed when can pin pybind11 to numpy2-compatible release.
+            extra-install-args: "--no-build-isolation"
 
     steps:
       - name: Checkout source
@@ -229,6 +231,15 @@ jobs:
             # Install requirements when not using build isolation.
             python -m pip install -r build_requirements.txt ninja
           fi
+          python -m pip list
+
+      - name: Install latest pybind11 to support numpy 2
+        # When pybind11 is released with https://github.com/pybind/pybind11/pull/5050 then this can
+        # be replaced with a pin on pybind11 version in pyproject.toml, etc.
+        if: matrix.nightly-wheels
+        run: |
+          python -m pip install -r build_requirements.txt ninja
+          python -m pip install git+https://github.com/seberg/pybind11@numpy2-compat
           python -m pip list
 
       - name: Install contourpy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,24 @@ jobs:
             nightly-wheels: true
             # The following will not be needed when can pin pybind11 to numpy2-compatible release.
             extra-install-args: "--no-build-isolation"
+          - os: macos-latest
+            python-version: "3.12"
+            name: "Nightly wheels"
+            short-name: "test-nightlies"
+            nightly-wheels: true
+            extra-install-args: "--no-build-isolation"
+          - os: macos-14
+            python-version: "3.12"
+            name: "Nightly wheels"
+            short-name: "test-nightlies"
+            nightly-wheels: true
+            extra-install-args: "--no-build-isolation"
+          - os: windows-latest
+            python-version: "3.12"
+            name: "Nightly wheels"
+            short-name: "test-nightlies"
+            nightly-wheels: true
+            extra-install-args: "--no-build-isolation"
 
     steps:
       - name: Checkout source

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -257,7 +257,7 @@ jobs:
             python -m pip install -v .[test-no-images] --no-build-isolation
           else
             echo "Install contourpy with standard test dependencies"
-            python -m pip install -v .[test] ${{ matrix.extra-install-args }} --no-build-isolation
+            python -m pip install -v .[test-no-images] ${{ matrix.extra-install-args }} --no-build-isolation
           fi
 
       - name: Install numpy 2.0.0b1
@@ -281,11 +281,11 @@ jobs:
           if [[ "${{ matrix.debug }}" != "" ]]
           then
             echo "Run normal tests with coverage"
-            ${PYTEST} tests/ --cov=lib --cov-report=lcov
+            ${PYTEST} tests/ --cov=lib --cov-report=lcov -k "not image"
           elif [[ "${{ matrix.test-text }}" != "" ]]
           then
             echo "Run normal and text tests with coverage"
-            ${PYTEST} -rP tests/test_bokeh_renderer.py tests/test_renderer.py --runtext --driver-path=/snap/bin/chromium.chromedriver --cov=lib --cov-report=lcov
+            ${PYTEST} -rP tests/test_bokeh_renderer.py tests/test_renderer.py --runtext --driver-path=/snap/bin/chromium.chromedriver --cov=lib --cov-report=lcov  -k "not image"
           elif [[ "${{ matrix.test-no-images }}" != "" ]]
           then
             echo "Run only tests that do not generate images"
@@ -293,10 +293,10 @@ jobs:
           elif [[ "${{ matrix.test-no-big }}" != "" ]]
           then
             echo "Run all tests except big ones"
-            ${PYTEST} tests/ -k "not big"
+            ${PYTEST} tests/ -k "not big" -k "not image"
           else
             echo "Run all tests"
-            ${PYTEST} tests/
+            ${PYTEST} tests/ -k "not image"
           fi
 
       - name: Collect C++ coverage
@@ -432,7 +432,6 @@ jobs:
 
   merge:
     name: Merge test artifacts
-    if: github.event_name != 'schedule' || github.repository_owner == 'contourpy'
     runs-on: ubuntu-latest
     needs: [test, test-in-docker]
     steps:

--- a/src/common.h
+++ b/src/common.h
@@ -2,6 +2,7 @@
 #define CONTOURPY_COMMON_H
 
 #include <pybind11/pybind11.h>
+#define PYBIND11_NUMPY2_SUPPORT
 #include <pybind11/numpy.h>
 
 namespace contourpy {

--- a/src/common.h
+++ b/src/common.h
@@ -2,7 +2,6 @@
 #define CONTOURPY_COMMON_H
 
 #include <pybind11/pybind11.h>
-#define PYBIND11_NUMPY2_SUPPORT
 #include <pybind11/numpy.h>
 
 namespace contourpy {


### PR DESCRIPTION
Tests using NumPy nightly wheels (`numpy >= 2`) have been failing for the last few days. There are changes needed in pybind11 for this which are currently underway in pybind/pybind11#5050. Here I am changing the nightly wheels tests to install pybind11 from that PR branch, which isn't an ideal approach but I'd like get as much of this work done as early as possible prior to numpy/pybind11 releases.

The only code change required here is to use
```c++
#define PYBIND11_NUMPY2_SUPPORT
```
before
```c++
#include <pybind11/numpy.h>
```

After the next pybind11 release, assuming it includes pybind/pybind11#5050 or an equivalent, the CI changes here can be replaced with a pybind11 pin in `pyproject.toml` and `build_requirements.txt`.
