### PR TITLE
Update pybind11 to 2.12.0

### DIFF
--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,4 +1,4 @@
 # These are the requirements from the build-system section of pyproject.toml
 meson >= 1.2.0
 meson-python >= 0.13.1
-pybind11 >= 2.10.4
+pybind11 >= 2.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "mesonpy"
 requires = [
     "meson >= 1.2.0",
     "meson-python >= 0.13.1",
-    "pybind11 >= 2.10.4",
+    "pybind11 >= 2.12.0",
 ]
 
 [project]


### PR DESCRIPTION
Update pybind11 to 2.12.0. This supports NumPy 2 with no other changes required.

Replaces #369.