### PR TITLE
Test against numpy 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,16 +92,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-14, windows-latest]  # macos-14 is M1
+        #os: [ubuntu-latest, macos-latest, macos-14, windows-latest]  # macos-14 is M1
+        os: [ubuntu-latest, macos-latest, windows-latest]  # macos-14 is M1
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         name: ["Test"]
         short-name: ["test"]
-        exclude:
+        #exclude:
           # M1 mac setup-python doesn't yet have python 3.9
           # https://github.com/actions/setup-python/issues/808
-          - os: macos-14
-            python-version: "3.9"
+        #  - os: macos-14
+        #    python-version: "3.9"
         include:
+          # macos-14 runs exclude image tests as matplotlib nightly wheel has incompatible tag
+          - os: macos-14
+            python-version: "3.10"
+            name: "Test"
+            short-name: "test"
+            test-no-images: true
+          - os: macos-14
+            python-version: "3.11"
+            name: "Test"
+            short-name: "test"
+            test-no-images: true
+          - os: macos-14
+            python-version: "3.12"
+            name: "Test"
+            short-name: "test"
+            test-no-images: true
           # Debug build including Python and C++ coverage.
           - os: ubuntu-latest
             python-version: "3.11"
@@ -272,7 +289,7 @@ jobs:
           then
             # This is temporary until there are full releases of numpy 2 and matplotlib supporting numpy 2
             python -m pip install --pre --upgrade --no-deps --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib
-            python -m pip install --upgrade --pre numpy
+            python -m pip install --pre --upgrade --no-deps numpy
           fi
 
       - name: Smoke test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -267,11 +267,13 @@ jobs:
           python -m pip install --pre --upgrade --no-deps --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib numpy
 
       - name: Install numpy 2 pre-release
-        if: ${{ matrix.short-name }} == "test"
         run: |
-          # This is temporary until there are full releases of numpy 2 and matplotlib supporting numpy 2
-          python -m pip install --pre --upgrade --no-deps --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib
-          python -m pip install --upgrade --pre numpy
+          if [[ "${{ matrix.short-name }}" == "test" ]]
+          then
+            # This is temporary until there are full releases of numpy 2 and matplotlib supporting numpy 2
+            python -m pip install --pre --upgrade --no-deps --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib
+            python -m pip install --upgrade --pre numpy
+          fi
 
       - name: Smoke test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         #os: [ubuntu-latest, macos-latest, macos-14, windows-latest]  # macos-14 is M1
-        os: [ubuntu-latest, macos-latest, windows-latest]  # macos-14 is M1
+        os: [ubuntu-latest, macos-latest]  # macos-14 is M1
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         name: ["Test"]
         short-name: ["test"]
@@ -115,6 +115,27 @@ jobs:
             short-name: "test"
             test-no-images: true
           - os: macos-14
+            python-version: "3.12"
+            name: "Test"
+            short-name: "test"
+            test-no-images: true
+          # windows run exclude image tests
+          - os: windows-latest
+            python-version: "3.9"
+            name: "Test"
+            short-name: "test"
+            test-no-images: true
+          - os: windows-latest
+            python-version: "3.10"
+            name: "Test"
+            short-name: "test"
+            test-no-images: true
+          - os: windows-latest
+            python-version: "3.11"
+            name: "Test"
+            short-name: "test"
+            test-no-images: true
+          - os: windows-latest
             python-version: "3.12"
             name: "Test"
             short-name: "test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
             name: "Win32"
             short-name: "test-win32"
             win32: true
-            extra-install-args: "--only-binary Pillow"
+            test-no-images: true
           # Test against matplotlib and numpy nightly wheels.
           - os: ubuntu-latest
             python-version: "3.12"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,6 +266,13 @@ jobs:
         run: |
           python -m pip install --pre --upgrade --no-deps --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib numpy
 
+      - name: Install numpy 2 pre-release
+        if: ${{ matrix.short-name }} == "test"
+        run: |
+          # This is temporary until there are full releases of numpy 2 and matplotlib supporting numpy 2
+          python -m pip install --pre --upgrade --no-deps --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib
+          python -m pip install --upgrade --pre numpy
+
       - name: Smoke test
         run: |
           python -m pip list


### PR DESCRIPTION
Test the standard matrix of CI runs against numpy 2 pre-release. This is temporary, until the full release of numpy 2.0.0. Also need to install matplotlib nightly wheels, until there is a release or pre-release that supports numpy 2.