### PR TITLE
Test against nightly wheels on macos and windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,16 @@ jobs:
             name: "Nightly wheels"
             short-name: "test-nightlies"
             nightly-wheels: true
+          - os: macos-latest
+            python-version: "3.12"
+            name: "Nightly wheels"
+            short-name: "test-nightlies"
+            nightly-wheels: true
+          - os: windows-latest
+            python-version: "3.12"
+            name: "Nightly wheels"
+            short-name: "test-nightlies"
+            nightly-wheels: true
 
     steps:
       - name: Checkout source

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,6 +163,7 @@ jobs:
             name: "Nightly wheels"
             short-name: "test-nightlies"
             nightly-wheels: true
+            test-no-images: true
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
Add CI runs against NumPy and Matplotlib nightly wheels on macOS and Windows. Already doing so on Linux.