### PR TITLE
Use numpy 2 compatible matplotlib 3.8.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,54 +92,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #os: [ubuntu-latest, macos-latest, macos-14, windows-latest]  # macos-14 is M1
-        os: [ubuntu-latest, macos-latest]  # macos-14 is M1
+        os: [ubuntu-latest, macos-latest, macos-14, windows-latest]  # macos-14 is M1
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         name: ["Test"]
         short-name: ["test"]
-        #exclude:
+        exclude:
           # M1 mac setup-python doesn't yet have python 3.9
           # https://github.com/actions/setup-python/issues/808
-        #  - os: macos-14
-        #    python-version: "3.9"
-        include:
-          # macos-14 runs exclude image tests as matplotlib nightly wheel has incompatible tag
           - os: macos-14
-            python-version: "3.10"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
-          - os: macos-14
-            python-version: "3.11"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
-          - os: macos-14
-            python-version: "3.12"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
-          # windows run exclude image tests
-          - os: windows-latest
             python-version: "3.9"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
-          - os: windows-latest
-            python-version: "3.10"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
-          - os: windows-latest
-            python-version: "3.11"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
-          - os: windows-latest
-            python-version: "3.12"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
+        include:
           # Debug build including Python and C++ coverage.
           - os: ubuntu-latest
             python-version: "3.11"
@@ -308,8 +270,7 @@ jobs:
         run: |
           if [[ "${{ matrix.short-name }}" == "test" ]]
           then
-            # This is temporary until there are full releases of numpy 2 and matplotlib supporting numpy 2
-            python -m pip install --pre --upgrade --no-deps --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib
+            # This is temporary until there are full releases of numpy 2
             python -m pip install --pre --upgrade --no-deps numpy
           fi
 


### PR DESCRIPTION
With the release of Matplotlib 3.8.4 we can test against that rather than having to use Matplotlib nightly wheels to obtain support for NumPy 2.