### PR TITLE
Update github runners

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,23 +24,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             arch: aarch64
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             arch: ppc64le
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             arch: s390x
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             arch: x86_64
 
-          - os: macOS-11
+          - os: macOS-14
             arch: arm64
-          - os: macOS-11
+          - os: macOS-13
             arch: x86_64
 
-          - os: windows-2019
+          - os: windows-latest
             arch: AMD64
-          - os: windows-2019
+          - os: windows-latest
             arch: x86
 
     steps:
@@ -68,7 +68,7 @@ jobs:
           rm /c/Program\ Files/Git/usr/bin/link.EXE
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-14, windows-latest]  # macos-14 is M1
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]  # macos-14 is ARM
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         name: ["Test"]
         short-name: ["test"]
@@ -153,7 +153,7 @@ jobs:
             name: "Nightly wheels"
             short-name: "test-nightlies"
             nightly-wheels: true
-          - os: macos-latest
+          - os: macos-13
             python-version: "3.12"
             name: "Nightly wheels"
             short-name: "test-nightlies"


### PR DESCRIPTION
Update github runners, in particular use `macos-14` to build macos ARM wheels.