### PR TITLE
Update benchmarks for Python 3.12.3 and g++ 13.2.0

### DIFF
--- a/benchmarks/plot_benchmarks.py
+++ b/benchmarks/plot_benchmarks.py
@@ -127,13 +127,13 @@ def by_name_and_type(loader: Loader, filled: bool, dataset: str, render: bool, n
 
         if filled and not render:
             if dataset == "random":
-                ax.set_ylim(0, 2.65)
+                ax.set_ylim(0, 3.3)
             else:
-                ax.set_ylim(0, 0.3)
+                ax.set_ylim(0, 0.27)
         elif filled and render and dataset == "simple":
-            ax.set_ylim(0, 0.425)
+            ax.set_ylim(0, 0.41)
         elif not filled and render and dataset == "simple":
-            ax.set_ylim(0, 0.4)
+            ax.set_ylim(0, 0.38)
         else:
             ax.set_ylim(0, ax.get_ylim()[1]*1.1)  # Magic number.
 
@@ -284,7 +284,7 @@ def comparison_two_benchmarks(
             in_bar_label(ax, rect, f" {value}")
 
         if dataset == "random":
-            ymax = 2.0 if filled else 1.43
+            ymax = 1.9 if filled else 1.4
         elif varying == "thread_count":
             ymax = ax.get_ylim()[1]*1.32
         else:

--- a/docs/_static/chunk_filled_random_dark.svg
+++ b/docs/_static/chunk_filled_random_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:08.968137</dc:date>
+    <dc:date>2024-05-06T19:15:04.544606</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m3d0c190f32" d="M 0 0 
+       <path id="ma72a0d6457" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3d0c190f32" x="114.422987" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma72a0d6457" x="114.422987" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -250,7 +250,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m3d0c190f32" x="199.697792" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma72a0d6457" x="199.697792" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -330,7 +330,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m3d0c190f32" x="284.972597" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma72a0d6457" x="284.972597" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -490,7 +490,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3d0c190f32" x="370.247403" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma72a0d6457" x="370.247403" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -527,7 +527,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m3d0c190f32" x="455.522208" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma72a0d6457" x="455.522208" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -571,7 +571,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m3d0c190f32" x="540.797013" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma72a0d6457" x="540.797013" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -620,16 +620,16 @@ z
      <g id="line2d_7">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#p0a6edefd64)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pdb2f056a16)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="md8574a4d04" d="M 0 0 
+       <path id="m3015152fa7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md8574a4d04" x="54.02" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3015152fa7" x="54.02" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -674,18 +674,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 54.02 326.347 
-L 601.2 326.347 
-" clip-path="url(#p0a6edefd64)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 324.095368 
+L 601.2 324.095368 
+" clip-path="url(#pdb2f056a16)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#md8574a4d04" x="54.02" y="326.347" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3015152fa7" x="54.02" y="324.095368" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.25 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 330.146219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 327.894587) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -746,18 +746,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 54.02 283.566 
-L 601.2 283.566 
-" clip-path="url(#p0a6edefd64)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 279.062737 
+L 601.2 279.062737 
+" clip-path="url(#pdb2f056a16)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#md8574a4d04" x="54.02" y="283.566" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3015152fa7" x="54.02" y="279.062737" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.50 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 287.365219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 282.861956) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -767,18 +767,18 @@ L 601.2 283.566
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 54.02 240.785 
-L 601.2 240.785 
-" clip-path="url(#p0a6edefd64)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 234.030105 
+L 601.2 234.030105 
+" clip-path="url(#pdb2f056a16)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md8574a4d04" x="54.02" y="240.785" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3015152fa7" x="54.02" y="234.030105" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.75 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 244.584219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 237.829324) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -800,18 +800,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 54.02 198.004 
-L 601.2 198.004 
-" clip-path="url(#p0a6edefd64)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 188.997474 
+L 601.2 188.997474 
+" clip-path="url(#pdb2f056a16)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md8574a4d04" x="54.02" y="198.004" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3015152fa7" x="54.02" y="188.997474" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.00 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 201.803219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 192.796692) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -837,18 +837,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 54.02 155.223 
-L 601.2 155.223 
-" clip-path="url(#p0a6edefd64)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 143.964842 
+L 601.2 143.964842 
+" clip-path="url(#pdb2f056a16)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md8574a4d04" x="54.02" y="155.223" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3015152fa7" x="54.02" y="143.964842" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.25 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 159.022219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 147.764061) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -858,18 +858,18 @@ L 601.2 155.223
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 54.02 112.442 
-L 601.2 112.442 
-" clip-path="url(#p0a6edefd64)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 98.932211 
+L 601.2 98.932211 
+" clip-path="url(#pdb2f056a16)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md8574a4d04" x="54.02" y="112.442" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3015152fa7" x="54.02" y="98.932211" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.50 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 116.241219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 102.731429) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -879,18 +879,18 @@ L 601.2 112.442
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 54.02 69.661 
-L 601.2 69.661 
-" clip-path="url(#p0a6edefd64)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 53.899579 
+L 601.2 53.899579 
+" clip-path="url(#pdb2f056a16)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md8574a4d04" x="54.02" y="69.661" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3015152fa7" x="54.02" y="53.899579" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 1.75 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 73.460219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 57.698798) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-37" x="95.410156"/>
@@ -898,28 +898,7 @@ L 601.2 69.661
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_23">
-      <path d="M 54.02 26.88 
-L 601.2 26.88 
-" clip-path="url(#p0a6edefd64)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_24">
-      <g>
-       <use xlink:href="#md8574a4d04" x="54.02" y="26.88" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 2.00 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 30.679219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_16">
+    <g id="text_15">
      <!-- Time (seconds) -->
      <g style="fill: #ffffff" transform="translate(18.674688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1023,65 +1002,54 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 78.891818 369.128 
 L 93.104286 369.128 
-L 93.104286 78.730956 
-L 78.891818 78.730956 
+L 93.104286 70.274099 
+L 78.891818 70.274099 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 164.166623 369.128 
 L 178.379091 369.128 
-L 178.379091 86.403449 
-L 164.166623 86.403449 
+L 178.379091 76.156959 
+L 164.166623 76.156959 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 249.441429 369.128 
 L 263.653896 369.128 
-L 263.653896 218.26077 
-L 249.441429 218.26077 
+L 263.653896 216.711246 
+L 249.441429 216.711246 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 334.716234 369.128 
 L 348.928701 369.128 
-L 348.928701 218.658674 
-L 334.716234 218.658674 
+L 348.928701 217.455272 
+L 334.716234 217.455272 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 419.991039 369.128 
 L 434.203506 369.128 
-L 434.203506 209.60767 
-L 419.991039 209.60767 
+L 434.203506 210.52073 
+L 419.991039 210.52073 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 505.265844 369.128 
 L 519.478312 369.128 
-L 519.478312 210.476029 
-L 505.265844 210.476029 
+L 519.478312 210.801386 
+L 505.265844 210.801386 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_17">
-    <!-- 1.70 s -->
-    <g style="fill: #ffffff" transform="translate(88.757427 73.730956) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 1.65 s -->
-    <g style="fill: #ffffff" transform="translate(174.032232 81.403449) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_16">
+    <!-- 1.66 s -->
+    <g style="fill: #ffffff" transform="translate(88.757427 65.274099) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1117,14 +1085,59 @@ z
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_19">
-    <!-- 882 ms -->
-    <g style="fill: #ffffff" transform="translate(259.307037 213.26077) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_17">
+    <!-- 1.63 s -->
+    <g style="fill: #ffffff" transform="translate(174.032232 71.156959) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 846 ms -->
+    <g style="fill: #ffffff" transform="translate(259.307037 211.711246) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1165,9 +1178,39 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 842 ms -->
+    <g style="fill: #ffffff" transform="translate(344.581843 212.455272) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1175,8 +1218,19 @@ z
     </g>
    </g>
    <g id="text_20">
+    <!-- 881 ms -->
+    <g style="fill: #ffffff" transform="translate(429.856648 205.52073) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_21">
     <!-- 879 ms -->
-    <g style="fill: #ffffff" transform="translate(344.581843 213.658674) rotate(-90) scale(0.1 -0.1)">
+    <g style="fill: #ffffff" transform="translate(515.131453 205.801386) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1217,98 +1271,42 @@ z
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_21">
-    <!-- 932 ms -->
-    <g style="fill: #ffffff" transform="translate(429.856648 204.60767) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
    <g id="text_22">
-    <!-- 927 ms -->
-    <g style="fill: #ffffff" transform="translate(515.131453 205.476029) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
     <!--  1 -->
     <g transform="translate(88.757427 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_24">
+   <g id="text_23">
     <!--  1 -->
     <g transform="translate(174.032232 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_25">
+   <g id="text_24">
     <!--  1 -->
     <g transform="translate(259.307037 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_26">
+   <g id="text_25">
     <!--  1 -->
     <g transform="translate(344.581843 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_27">
+   <g id="text_26">
     <!--  1 -->
     <g transform="translate(429.856648 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_28">
+   <g id="text_27">
     <!--  1 -->
     <g transform="translate(515.131453 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1318,472 +1316,385 @@ z
    <g id="patch_13">
     <path d="M 93.104286 369.128 
 L 107.316753 369.128 
-L 107.316753 75.435067 
-L 93.104286 75.435067 
+L 107.316753 73.122368 
+L 93.104286 73.122368 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 107.316753 369.128 
 L 121.529221 369.128 
-L 121.529221 75.400043 
-L 107.316753 75.400043 
+L 121.529221 73.149463 
+L 107.316753 73.149463 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 121.529221 369.128 
 L 135.741688 369.128 
-L 135.741688 74.470274 
-L 121.529221 74.470274 
+L 135.741688 69.853128 
+L 121.529221 69.853128 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 135.741688 369.128 
 L 149.954156 369.128 
-L 149.954156 68.068281 
-L 135.741688 68.068281 
+L 149.954156 62.867218 
+L 135.741688 62.867218 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 178.379091 369.128 
 L 192.591558 369.128 
-L 192.591558 84.827695 
-L 178.379091 84.827695 
+L 192.591558 75.82696 
+L 178.379091 75.82696 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 192.591558 369.128 
 L 206.804026 369.128 
-L 206.804026 85.189644 
-L 192.591558 85.189644 
+L 206.804026 78.12423 
+L 192.591558 78.12423 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 206.804026 369.128 
 L 221.016494 369.128 
-L 221.016494 81.493207 
-L 206.804026 81.493207 
+L 221.016494 73.416381 
+L 206.804026 73.416381 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 221.016494 369.128 
 L 235.228961 369.128 
-L 235.228961 75.257653 
-L 221.016494 75.257653 
+L 235.228961 68.422243 
+L 221.016494 68.422243 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 263.653896 369.128 
 L 277.866364 369.128 
-L 277.866364 207.193399 
-L 263.653896 207.193399 
+L 277.866364 210.411509 
+L 263.653896 210.411509 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 277.866364 369.128 
 L 292.078831 369.128 
-L 292.078831 200.40409 
-L 277.866364 200.40409 
+L 292.078831 200.764482 
+L 277.866364 200.764482 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 292.078831 369.128 
 L 306.291299 369.128 
-L 306.291299 200.140133 
-L 292.078831 200.140133 
+L 306.291299 201.469355 
+L 292.078831 201.469355 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 306.291299 369.128 
 L 320.503766 369.128 
-L 320.503766 196.823532 
-L 306.291299 196.823532 
+L 320.503766 195.988211 
+L 306.291299 195.988211 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 348.928701 369.128 
 L 363.141169 369.128 
-L 363.141169 209.394422 
-L 348.928701 209.394422 
+L 363.141169 212.09328 
+L 348.928701 212.09328 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 363.141169 369.128 
 L 377.353636 369.128 
-L 377.353636 201.546563 
-L 363.141169 201.546563 
+L 377.353636 202.200656 
+L 363.141169 202.200656 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 377.353636 369.128 
 L 391.566104 369.128 
-L 391.566104 200.625341 
-L 377.353636 200.625341 
+L 391.566104 200.550826 
+L 377.353636 200.550826 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 391.566104 369.128 
 L 405.778571 369.128 
-L 405.778571 197.427138 
-L 391.566104 197.427138 
+L 405.778571 214.771128 
+L 391.566104 214.771128 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 434.203506 369.128 
 L 448.415974 369.128 
-L 448.415974 199.043014 
-L 434.203506 199.043014 
+L 448.415974 206.122556 
+L 434.203506 206.122556 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 448.415974 369.128 
 L 462.628442 369.128 
-L 462.628442 192.71392 
-L 448.415974 192.71392 
+L 462.628442 194.954902 
+L 448.415974 194.954902 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 462.628442 369.128 
 L 476.840909 369.128 
-L 476.840909 191.469542 
-L 462.628442 191.469542 
+L 476.840909 197.485792 
+L 462.628442 197.485792 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 476.840909 369.128 
 L 491.053377 369.128 
-L 491.053377 203.234752 
-L 476.840909 203.234752 
+L 491.053377 209.241486 
+L 476.840909 209.241486 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 519.478312 369.128 
 L 533.690779 369.128 
-L 533.690779 200.910337 
-L 519.478312 200.910337 
+L 533.690779 207.008482 
+L 519.478312 207.008482 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 533.690779 369.128 
 L 547.903247 369.128 
-L 547.903247 193.648508 
-L 533.690779 193.648508 
+L 547.903247 196.353616 
+L 533.690779 196.353616 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 547.903247 369.128 
 L 562.115714 369.128 
-L 562.115714 192.264054 
-L 547.903247 192.264054 
+L 562.115714 196.639928 
+L 547.903247 196.639928 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 562.115714 369.128 
 L 576.328182 369.128 
-L 576.328182 203.612374 
-L 562.115714 203.612374 
+L 576.328182 210.971228 
+L 562.115714 210.971228 
 z
-" clip-path="url(#p0a6edefd64)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pdb2f056a16)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_29">
-    <!-- 1.72 s -->
-    <g style="fill: #ffffff" transform="translate(102.969894 70.435067) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_28">
+    <!-- 1.64 s -->
+    <g style="fill: #ffffff" transform="translate(102.969894 68.122368) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 1.64 s -->
+    <g style="fill: #ffffff" transform="translate(117.182362 68.149463) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 1.72 s -->
-    <g style="fill: #ffffff" transform="translate(117.182362 70.400043) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.66 s -->
+    <g style="fill: #ffffff" transform="translate(131.39483 64.853128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 1.72 s -->
-    <g style="fill: #ffffff" transform="translate(131.39483 69.470274) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.70 s -->
+    <g style="fill: #ffffff" transform="translate(145.607297 57.867218) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 1.76 s -->
-    <g style="fill: #ffffff" transform="translate(145.607297 63.068281) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.63 s -->
+    <g style="fill: #ffffff" transform="translate(188.2447 70.82696) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 1.66 s -->
-    <g style="fill: #ffffff" transform="translate(188.2447 79.827695) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.62 s -->
+    <g style="fill: #ffffff" transform="translate(202.457167 73.12423) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- 1.66 s -->
-    <g style="fill: #ffffff" transform="translate(202.457167 80.189644) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 1.68 s -->
-    <g style="fill: #ffffff" transform="translate(216.669635 76.493207) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 1.72 s -->
-    <g style="fill: #ffffff" transform="translate(230.882102 70.257653) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
      <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_37">
-    <!-- 946 ms -->
-    <g style="fill: #ffffff" transform="translate(273.519505 202.193399) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- 986 ms -->
-    <g style="fill: #ffffff" transform="translate(287.731972 195.40409) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- 988 ms -->
-    <g style="fill: #ffffff" transform="translate(301.94444 195.140133) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- 1.01 s -->
-    <g style="fill: #ffffff" transform="translate(316.156907 191.823532) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_34">
+    <!-- 1.64 s -->
+    <g style="fill: #ffffff" transform="translate(216.669635 68.416381) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_41">
-    <!-- 933 ms -->
-    <g style="fill: #ffffff" transform="translate(358.79431 204.394422) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_35">
+    <!-- 1.67 s -->
+    <g style="fill: #ffffff" transform="translate(230.882102 63.422243) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 881 ms -->
+    <g style="fill: #ffffff" transform="translate(273.519505 205.411509) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- 935 ms -->
+    <g style="fill: #ffffff" transform="translate(287.731972 195.764482) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_42">
-    <!-- 979 ms -->
-    <g style="fill: #ffffff" transform="translate(373.006778 196.546563) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- 985 ms -->
-    <g style="fill: #ffffff" transform="translate(387.219245 195.625341) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
+   <g id="text_38">
+    <!-- 931 ms -->
+    <g style="fill: #ffffff" transform="translate(301.94444 196.469355) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- 961 ms -->
+    <g style="fill: #ffffff" transform="translate(316.156907 190.988211) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- 872 ms -->
+    <g style="fill: #ffffff" transform="translate(358.79431 207.09328) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- 927 ms -->
+    <g style="fill: #ffffff" transform="translate(373.006778 197.200656) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_42">
+    <!-- 936 ms -->
+    <g style="fill: #ffffff" transform="translate(387.219245 195.550826) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- 857 ms -->
+    <g style="fill: #ffffff" transform="translate(401.431713 209.771128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
    <g id="text_44">
-    <!-- 1.00 s -->
-    <g style="fill: #ffffff" transform="translate(401.431713 192.427138) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    <!-- 905 ms -->
+    <g style="fill: #ffffff" transform="translate(444.069115 201.122556) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- 994 ms -->
-    <g style="fill: #ffffff" transform="translate(444.069115 194.043014) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_46">
-    <!-- 1.03 s -->
-    <g style="fill: #ffffff" transform="translate(458.281583 187.71392) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_47">
-    <!-- 1.04 s -->
-    <g style="fill: #ffffff" transform="translate(472.49405 186.469542) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_48">
-    <!-- 969 ms -->
-    <g style="fill: #ffffff" transform="translate(486.706518 198.234752) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_49">
-    <!-- 983 ms -->
-    <g style="fill: #ffffff" transform="translate(529.34392 195.910337) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_50">
-    <!-- 1.03 s -->
-    <g style="fill: #ffffff" transform="translate(543.556388 188.648508) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_51">
-    <!-- 1.03 s -->
-    <g style="fill: #ffffff" transform="translate(557.768856 187.264054) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_52">
     <!-- 967 ms -->
-    <g style="fill: #ffffff" transform="translate(571.981323 198.612374) rotate(-90) scale(0.1 -0.1)">
+    <g style="fill: #ffffff" transform="translate(458.281583 189.954902) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
@@ -1792,14 +1703,80 @@ z
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_53">
+   <g id="text_46">
+    <!-- 953 ms -->
+    <g style="fill: #ffffff" transform="translate(472.49405 192.485792) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_47">
+    <!-- 888 ms -->
+    <g style="fill: #ffffff" transform="translate(486.706518 204.241486) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_48">
+    <!-- 900 ms -->
+    <g style="fill: #ffffff" transform="translate(529.34392 202.008482) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_49">
+    <!-- 959 ms -->
+    <g style="fill: #ffffff" transform="translate(543.556388 191.353616) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_50">
+    <!-- 958 ms -->
+    <g style="fill: #ffffff" transform="translate(557.768856 191.639928) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_51">
+    <!-- 878 ms -->
+    <g style="fill: #ffffff" transform="translate(571.981323 205.971228) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_52">
     <!--  4 -->
     <g transform="translate(102.969894 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_54">
+   <g id="text_53">
     <!--  12 -->
     <g transform="translate(117.182362 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1807,7 +1784,7 @@ z
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_55">
+   <g id="text_54">
     <!--  40 -->
     <g transform="translate(131.39483 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1815,7 +1792,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_56">
+   <g id="text_55">
     <!--  120 -->
     <g transform="translate(145.607297 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1824,14 +1801,14 @@ z
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_57">
+   <g id="text_56">
     <!--  4 -->
     <g transform="translate(188.2447 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_58">
+   <g id="text_57">
     <!--  12 -->
     <g transform="translate(202.457167 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1839,7 +1816,7 @@ z
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_59">
+   <g id="text_58">
     <!--  40 -->
     <g transform="translate(216.669635 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1847,7 +1824,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_60">
+   <g id="text_59">
     <!--  120 -->
     <g transform="translate(230.882102 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1856,14 +1833,14 @@ z
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_61">
+   <g id="text_60">
     <!--  4 -->
     <g transform="translate(273.519505 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_62">
+   <g id="text_61">
     <!--  12 -->
     <g transform="translate(287.731972 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1871,7 +1848,7 @@ z
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_63">
+   <g id="text_62">
     <!--  40 -->
     <g transform="translate(301.94444 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1879,7 +1856,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_64">
+   <g id="text_63">
     <!--  120 -->
     <g transform="translate(316.156907 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1888,14 +1865,14 @@ z
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_65">
+   <g id="text_64">
     <!--  4 -->
     <g transform="translate(358.79431 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_66">
+   <g id="text_65">
     <!--  12 -->
     <g transform="translate(373.006778 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1903,7 +1880,7 @@ z
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_67">
+   <g id="text_66">
     <!--  40 -->
     <g transform="translate(387.219245 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1911,7 +1888,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_68">
+   <g id="text_67">
     <!--  120 -->
     <g transform="translate(401.431713 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1920,14 +1897,14 @@ z
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_69">
+   <g id="text_68">
     <!--  4 -->
     <g transform="translate(444.069115 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_70">
+   <g id="text_69">
     <!--  12 -->
     <g transform="translate(458.281583 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1935,7 +1912,7 @@ z
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_71">
+   <g id="text_70">
     <!--  40 -->
     <g transform="translate(472.49405 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1943,7 +1920,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_72">
+   <g id="text_71">
     <!--  120 -->
     <g transform="translate(486.706518 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1952,14 +1929,14 @@ z
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_73">
+   <g id="text_72">
     <!--  4 -->
     <g transform="translate(529.34392 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_74">
+   <g id="text_73">
     <!--  12 -->
     <g transform="translate(543.556388 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1967,7 +1944,7 @@ z
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_75">
+   <g id="text_74">
     <!--  40 -->
     <g transform="translate(557.768856 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1975,7 +1952,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_76">
+   <g id="text_75">
     <!--  120 -->
     <g transform="translate(571.981323 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1984,7 +1961,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_77">
+   <g id="text_76">
     <!-- filled random n=1000 -->
     <g style="fill: #ffffff" transform="translate(261.811563 20.88) scale(0.12 -0.12)">
      <defs>
@@ -2086,7 +2063,7 @@ L 348.146875 43.117187
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_78">
+    <g id="text_77">
      <!-- serial no mask -->
      <g style="fill: #ffffff" transform="translate(376.146875 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2172,7 +2149,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p0a6edefd64">
+  <clipPath id="pdb2f056a16">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>

--- a/docs/_static/chunk_filled_random_light.svg
+++ b/docs/_static/chunk_filled_random_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:08.759364</dc:date>
+    <dc:date>2024-05-06T19:15:04.346823</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="meee8a1272a" d="M 0 0 
+       <path id="m86afaf2088" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#meee8a1272a" x="114.422987" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m86afaf2088" x="114.422987" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -250,7 +250,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#meee8a1272a" x="199.697792" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m86afaf2088" x="199.697792" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -330,7 +330,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#meee8a1272a" x="284.972597" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m86afaf2088" x="284.972597" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -490,7 +490,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#meee8a1272a" x="370.247403" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m86afaf2088" x="370.247403" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -527,7 +527,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#meee8a1272a" x="455.522208" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m86afaf2088" x="455.522208" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -571,7 +571,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#meee8a1272a" x="540.797013" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m86afaf2088" x="540.797013" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -620,16 +620,16 @@ z
      <g id="line2d_7">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#p92548de582)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p5d6266541e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="mc0ae36d53a" d="M 0 0 
+       <path id="ma57b5b94a1" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc0ae36d53a" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma57b5b94a1" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -674,18 +674,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 54.02 326.347 
-L 601.2 326.347 
-" clip-path="url(#p92548de582)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 324.095368 
+L 601.2 324.095368 
+" clip-path="url(#p5d6266541e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc0ae36d53a" x="54.02" y="326.347" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma57b5b94a1" x="54.02" y="324.095368" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 330.146219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 327.894587) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -746,18 +746,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 54.02 283.566 
-L 601.2 283.566 
-" clip-path="url(#p92548de582)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 279.062737 
+L 601.2 279.062737 
+" clip-path="url(#p5d6266541e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc0ae36d53a" x="54.02" y="283.566" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma57b5b94a1" x="54.02" y="279.062737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.50 -->
-      <g transform="translate(24.754375 287.365219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 282.861956) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -767,18 +767,18 @@ L 601.2 283.566
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 54.02 240.785 
-L 601.2 240.785 
-" clip-path="url(#p92548de582)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 234.030105 
+L 601.2 234.030105 
+" clip-path="url(#p5d6266541e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc0ae36d53a" x="54.02" y="240.785" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma57b5b94a1" x="54.02" y="234.030105" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.75 -->
-      <g transform="translate(24.754375 244.584219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 237.829324) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -800,18 +800,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 54.02 198.004 
-L 601.2 198.004 
-" clip-path="url(#p92548de582)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 188.997474 
+L 601.2 188.997474 
+" clip-path="url(#p5d6266541e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc0ae36d53a" x="54.02" y="198.004" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma57b5b94a1" x="54.02" y="188.997474" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.00 -->
-      <g transform="translate(24.754375 201.803219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 192.796692) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -837,18 +837,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 54.02 155.223 
-L 601.2 155.223 
-" clip-path="url(#p92548de582)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 143.964842 
+L 601.2 143.964842 
+" clip-path="url(#p5d6266541e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc0ae36d53a" x="54.02" y="155.223" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma57b5b94a1" x="54.02" y="143.964842" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.25 -->
-      <g transform="translate(24.754375 159.022219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 147.764061) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -858,18 +858,18 @@ L 601.2 155.223
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 54.02 112.442 
-L 601.2 112.442 
-" clip-path="url(#p92548de582)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 98.932211 
+L 601.2 98.932211 
+" clip-path="url(#p5d6266541e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc0ae36d53a" x="54.02" y="112.442" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma57b5b94a1" x="54.02" y="98.932211" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.50 -->
-      <g transform="translate(24.754375 116.241219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 102.731429) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -879,18 +879,18 @@ L 601.2 112.442
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 54.02 69.661 
-L 601.2 69.661 
-" clip-path="url(#p92548de582)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 53.899579 
+L 601.2 53.899579 
+" clip-path="url(#p5d6266541e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc0ae36d53a" x="54.02" y="69.661" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma57b5b94a1" x="54.02" y="53.899579" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 1.75 -->
-      <g transform="translate(24.754375 73.460219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 57.698798) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-37" x="95.410156"/>
@@ -898,28 +898,7 @@ L 601.2 69.661
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_23">
-      <path d="M 54.02 26.88 
-L 601.2 26.88 
-" clip-path="url(#p92548de582)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_24">
-      <g>
-       <use xlink:href="#mc0ae36d53a" x="54.02" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 2.00 -->
-      <g transform="translate(24.754375 30.679219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_16">
+    <g id="text_15">
      <!-- Time (seconds) -->
      <g transform="translate(18.674688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1023,65 +1002,54 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 78.891818 369.128 
 L 93.104286 369.128 
-L 93.104286 78.730956 
-L 78.891818 78.730956 
+L 93.104286 70.274099 
+L 78.891818 70.274099 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 164.166623 369.128 
 L 178.379091 369.128 
-L 178.379091 86.403449 
-L 164.166623 86.403449 
+L 178.379091 76.156959 
+L 164.166623 76.156959 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 249.441429 369.128 
 L 263.653896 369.128 
-L 263.653896 218.26077 
-L 249.441429 218.26077 
+L 263.653896 216.711246 
+L 249.441429 216.711246 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 334.716234 369.128 
 L 348.928701 369.128 
-L 348.928701 218.658674 
-L 334.716234 218.658674 
+L 348.928701 217.455272 
+L 334.716234 217.455272 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 419.991039 369.128 
 L 434.203506 369.128 
-L 434.203506 209.60767 
-L 419.991039 209.60767 
+L 434.203506 210.52073 
+L 419.991039 210.52073 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 505.265844 369.128 
 L 519.478312 369.128 
-L 519.478312 210.476029 
-L 505.265844 210.476029 
+L 519.478312 210.801386 
+L 505.265844 210.801386 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_17">
-    <!-- 1.70 s -->
-    <g transform="translate(88.757427 73.730956) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 1.65 s -->
-    <g transform="translate(174.032232 81.403449) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_16">
+    <!-- 1.66 s -->
+    <g transform="translate(88.757427 65.274099) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1117,14 +1085,59 @@ z
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_19">
-    <!-- 882 ms -->
-    <g transform="translate(259.307037 213.26077) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_17">
+    <!-- 1.63 s -->
+    <g transform="translate(174.032232 71.156959) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 846 ms -->
+    <g transform="translate(259.307037 211.711246) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1165,9 +1178,39 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 842 ms -->
+    <g transform="translate(344.581843 212.455272) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1175,8 +1218,19 @@ z
     </g>
    </g>
    <g id="text_20">
+    <!-- 881 ms -->
+    <g transform="translate(429.856648 205.52073) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_21">
     <!-- 879 ms -->
-    <g transform="translate(344.581843 213.658674) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(515.131453 205.801386) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1217,98 +1271,42 @@ z
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_21">
-    <!-- 932 ms -->
-    <g transform="translate(429.856648 204.60767) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
    <g id="text_22">
-    <!-- 927 ms -->
-    <g transform="translate(515.131453 205.476029) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
     <!--  1 -->
     <g transform="translate(88.757427 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_24">
+   <g id="text_23">
     <!--  1 -->
     <g transform="translate(174.032232 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_25">
+   <g id="text_24">
     <!--  1 -->
     <g transform="translate(259.307037 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_26">
+   <g id="text_25">
     <!--  1 -->
     <g transform="translate(344.581843 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_27">
+   <g id="text_26">
     <!--  1 -->
     <g transform="translate(429.856648 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_28">
+   <g id="text_27">
     <!--  1 -->
     <g transform="translate(515.131453 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1318,472 +1316,385 @@ z
    <g id="patch_13">
     <path d="M 93.104286 369.128 
 L 107.316753 369.128 
-L 107.316753 75.435067 
-L 93.104286 75.435067 
+L 107.316753 73.122368 
+L 93.104286 73.122368 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 107.316753 369.128 
 L 121.529221 369.128 
-L 121.529221 75.400043 
-L 107.316753 75.400043 
+L 121.529221 73.149463 
+L 107.316753 73.149463 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 121.529221 369.128 
 L 135.741688 369.128 
-L 135.741688 74.470274 
-L 121.529221 74.470274 
+L 135.741688 69.853128 
+L 121.529221 69.853128 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 135.741688 369.128 
 L 149.954156 369.128 
-L 149.954156 68.068281 
-L 135.741688 68.068281 
+L 149.954156 62.867218 
+L 135.741688 62.867218 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 178.379091 369.128 
 L 192.591558 369.128 
-L 192.591558 84.827695 
-L 178.379091 84.827695 
+L 192.591558 75.82696 
+L 178.379091 75.82696 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 192.591558 369.128 
 L 206.804026 369.128 
-L 206.804026 85.189644 
-L 192.591558 85.189644 
+L 206.804026 78.12423 
+L 192.591558 78.12423 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 206.804026 369.128 
 L 221.016494 369.128 
-L 221.016494 81.493207 
-L 206.804026 81.493207 
+L 221.016494 73.416381 
+L 206.804026 73.416381 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 221.016494 369.128 
 L 235.228961 369.128 
-L 235.228961 75.257653 
-L 221.016494 75.257653 
+L 235.228961 68.422243 
+L 221.016494 68.422243 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 263.653896 369.128 
 L 277.866364 369.128 
-L 277.866364 207.193399 
-L 263.653896 207.193399 
+L 277.866364 210.411509 
+L 263.653896 210.411509 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 277.866364 369.128 
 L 292.078831 369.128 
-L 292.078831 200.40409 
-L 277.866364 200.40409 
+L 292.078831 200.764482 
+L 277.866364 200.764482 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 292.078831 369.128 
 L 306.291299 369.128 
-L 306.291299 200.140133 
-L 292.078831 200.140133 
+L 306.291299 201.469355 
+L 292.078831 201.469355 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 306.291299 369.128 
 L 320.503766 369.128 
-L 320.503766 196.823532 
-L 306.291299 196.823532 
+L 320.503766 195.988211 
+L 306.291299 195.988211 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 348.928701 369.128 
 L 363.141169 369.128 
-L 363.141169 209.394422 
-L 348.928701 209.394422 
+L 363.141169 212.09328 
+L 348.928701 212.09328 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 363.141169 369.128 
 L 377.353636 369.128 
-L 377.353636 201.546563 
-L 363.141169 201.546563 
+L 377.353636 202.200656 
+L 363.141169 202.200656 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 377.353636 369.128 
 L 391.566104 369.128 
-L 391.566104 200.625341 
-L 377.353636 200.625341 
+L 391.566104 200.550826 
+L 377.353636 200.550826 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 391.566104 369.128 
 L 405.778571 369.128 
-L 405.778571 197.427138 
-L 391.566104 197.427138 
+L 405.778571 214.771128 
+L 391.566104 214.771128 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 434.203506 369.128 
 L 448.415974 369.128 
-L 448.415974 199.043014 
-L 434.203506 199.043014 
+L 448.415974 206.122556 
+L 434.203506 206.122556 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 448.415974 369.128 
 L 462.628442 369.128 
-L 462.628442 192.71392 
-L 448.415974 192.71392 
+L 462.628442 194.954902 
+L 448.415974 194.954902 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 462.628442 369.128 
 L 476.840909 369.128 
-L 476.840909 191.469542 
-L 462.628442 191.469542 
+L 476.840909 197.485792 
+L 462.628442 197.485792 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 476.840909 369.128 
 L 491.053377 369.128 
-L 491.053377 203.234752 
-L 476.840909 203.234752 
+L 491.053377 209.241486 
+L 476.840909 209.241486 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 519.478312 369.128 
 L 533.690779 369.128 
-L 533.690779 200.910337 
-L 519.478312 200.910337 
+L 533.690779 207.008482 
+L 519.478312 207.008482 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 533.690779 369.128 
 L 547.903247 369.128 
-L 547.903247 193.648508 
-L 533.690779 193.648508 
+L 547.903247 196.353616 
+L 533.690779 196.353616 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 547.903247 369.128 
 L 562.115714 369.128 
-L 562.115714 192.264054 
-L 547.903247 192.264054 
+L 562.115714 196.639928 
+L 547.903247 196.639928 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 562.115714 369.128 
 L 576.328182 369.128 
-L 576.328182 203.612374 
-L 562.115714 203.612374 
+L 576.328182 210.971228 
+L 562.115714 210.971228 
 z
-" clip-path="url(#p92548de582)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p5d6266541e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_29">
-    <!-- 1.72 s -->
-    <g transform="translate(102.969894 70.435067) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_28">
+    <!-- 1.64 s -->
+    <g transform="translate(102.969894 68.122368) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 1.64 s -->
+    <g transform="translate(117.182362 68.149463) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 1.72 s -->
-    <g transform="translate(117.182362 70.400043) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.66 s -->
+    <g transform="translate(131.39483 64.853128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 1.72 s -->
-    <g transform="translate(131.39483 69.470274) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.70 s -->
+    <g transform="translate(145.607297 57.867218) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 1.76 s -->
-    <g transform="translate(145.607297 63.068281) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.63 s -->
+    <g transform="translate(188.2447 70.82696) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 1.66 s -->
-    <g transform="translate(188.2447 79.827695) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.62 s -->
+    <g transform="translate(202.457167 73.12423) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- 1.66 s -->
-    <g transform="translate(202.457167 80.189644) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 1.68 s -->
-    <g transform="translate(216.669635 76.493207) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 1.72 s -->
-    <g transform="translate(230.882102 70.257653) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
      <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_37">
-    <!-- 946 ms -->
-    <g transform="translate(273.519505 202.193399) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- 986 ms -->
-    <g transform="translate(287.731972 195.40409) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- 988 ms -->
-    <g transform="translate(301.94444 195.140133) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- 1.01 s -->
-    <g transform="translate(316.156907 191.823532) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_34">
+    <!-- 1.64 s -->
+    <g transform="translate(216.669635 68.416381) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_41">
-    <!-- 933 ms -->
-    <g transform="translate(358.79431 204.394422) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_35">
+    <!-- 1.67 s -->
+    <g transform="translate(230.882102 63.422243) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 881 ms -->
+    <g transform="translate(273.519505 205.411509) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- 935 ms -->
+    <g transform="translate(287.731972 195.764482) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_42">
-    <!-- 979 ms -->
-    <g transform="translate(373.006778 196.546563) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- 985 ms -->
-    <g transform="translate(387.219245 195.625341) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
+   <g id="text_38">
+    <!-- 931 ms -->
+    <g transform="translate(301.94444 196.469355) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- 961 ms -->
+    <g transform="translate(316.156907 190.988211) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- 872 ms -->
+    <g transform="translate(358.79431 207.09328) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- 927 ms -->
+    <g transform="translate(373.006778 197.200656) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_42">
+    <!-- 936 ms -->
+    <g transform="translate(387.219245 195.550826) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- 857 ms -->
+    <g transform="translate(401.431713 209.771128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
    <g id="text_44">
-    <!-- 1.00 s -->
-    <g transform="translate(401.431713 192.427138) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    <!-- 905 ms -->
+    <g transform="translate(444.069115 201.122556) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- 994 ms -->
-    <g transform="translate(444.069115 194.043014) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_46">
-    <!-- 1.03 s -->
-    <g transform="translate(458.281583 187.71392) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_47">
-    <!-- 1.04 s -->
-    <g transform="translate(472.49405 186.469542) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_48">
-    <!-- 969 ms -->
-    <g transform="translate(486.706518 198.234752) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_49">
-    <!-- 983 ms -->
-    <g transform="translate(529.34392 195.910337) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_50">
-    <!-- 1.03 s -->
-    <g transform="translate(543.556388 188.648508) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_51">
-    <!-- 1.03 s -->
-    <g transform="translate(557.768856 187.264054) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_52">
     <!-- 967 ms -->
-    <g transform="translate(571.981323 198.612374) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(458.281583 189.954902) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
@@ -1792,14 +1703,80 @@ z
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_53">
+   <g id="text_46">
+    <!-- 953 ms -->
+    <g transform="translate(472.49405 192.485792) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_47">
+    <!-- 888 ms -->
+    <g transform="translate(486.706518 204.241486) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_48">
+    <!-- 900 ms -->
+    <g transform="translate(529.34392 202.008482) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_49">
+    <!-- 959 ms -->
+    <g transform="translate(543.556388 191.353616) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_50">
+    <!-- 958 ms -->
+    <g transform="translate(557.768856 191.639928) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_51">
+    <!-- 878 ms -->
+    <g transform="translate(571.981323 205.971228) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_52">
     <!--  4 -->
     <g transform="translate(102.969894 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_54">
+   <g id="text_53">
     <!--  12 -->
     <g transform="translate(117.182362 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1807,7 +1784,7 @@ z
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_55">
+   <g id="text_54">
     <!--  40 -->
     <g transform="translate(131.39483 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1815,7 +1792,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_56">
+   <g id="text_55">
     <!--  120 -->
     <g transform="translate(145.607297 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1824,14 +1801,14 @@ z
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_57">
+   <g id="text_56">
     <!--  4 -->
     <g transform="translate(188.2447 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_58">
+   <g id="text_57">
     <!--  12 -->
     <g transform="translate(202.457167 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1839,7 +1816,7 @@ z
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_59">
+   <g id="text_58">
     <!--  40 -->
     <g transform="translate(216.669635 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1847,7 +1824,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_60">
+   <g id="text_59">
     <!--  120 -->
     <g transform="translate(230.882102 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1856,14 +1833,14 @@ z
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_61">
+   <g id="text_60">
     <!--  4 -->
     <g transform="translate(273.519505 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_62">
+   <g id="text_61">
     <!--  12 -->
     <g transform="translate(287.731972 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1871,7 +1848,7 @@ z
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_63">
+   <g id="text_62">
     <!--  40 -->
     <g transform="translate(301.94444 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1879,7 +1856,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_64">
+   <g id="text_63">
     <!--  120 -->
     <g transform="translate(316.156907 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1888,14 +1865,14 @@ z
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_65">
+   <g id="text_64">
     <!--  4 -->
     <g transform="translate(358.79431 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_66">
+   <g id="text_65">
     <!--  12 -->
     <g transform="translate(373.006778 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1903,7 +1880,7 @@ z
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_67">
+   <g id="text_66">
     <!--  40 -->
     <g transform="translate(387.219245 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1911,7 +1888,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_68">
+   <g id="text_67">
     <!--  120 -->
     <g transform="translate(401.431713 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1920,14 +1897,14 @@ z
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_69">
+   <g id="text_68">
     <!--  4 -->
     <g transform="translate(444.069115 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_70">
+   <g id="text_69">
     <!--  12 -->
     <g transform="translate(458.281583 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1935,7 +1912,7 @@ z
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_71">
+   <g id="text_70">
     <!--  40 -->
     <g transform="translate(472.49405 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1943,7 +1920,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_72">
+   <g id="text_71">
     <!--  120 -->
     <g transform="translate(486.706518 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1952,14 +1929,14 @@ z
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_73">
+   <g id="text_72">
     <!--  4 -->
     <g transform="translate(529.34392 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_74">
+   <g id="text_73">
     <!--  12 -->
     <g transform="translate(543.556388 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1967,7 +1944,7 @@ z
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_75">
+   <g id="text_74">
     <!--  40 -->
     <g transform="translate(557.768856 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1975,7 +1952,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_76">
+   <g id="text_75">
     <!--  120 -->
     <g transform="translate(571.981323 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
@@ -1984,7 +1961,7 @@ z
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_77">
+   <g id="text_76">
     <!-- filled random n=1000 -->
     <g transform="translate(261.811563 20.88) scale(0.12 -0.12)">
      <defs>
@@ -2086,7 +2063,7 @@ L 348.146875 43.117187
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_78">
+    <g id="text_77">
      <!-- serial no mask -->
      <g transform="translate(376.146875 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2172,7 +2149,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p92548de582">
+  <clipPath id="p5d6266541e">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>

--- a/docs/_static/chunk_filled_simple_dark.svg
+++ b/docs/_static/chunk_filled_simple_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:08.550206</dc:date>
+    <dc:date>2024-05-06T19:15:04.145771</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -31,11 +31,11 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 54.11 369.128 
+    <path d="M 54.02 369.128 
 L 601.2 369.128 
 L 601.2 26.88 
-L 54.11 26.88 
-L 54.11 369.128 
+L 54.02 26.88 
+L 54.02 369.128 
 z
 " style="fill: none"/>
    </g>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mf22503e1a2" d="M 0 0 
+       <path id="m3fce1c404a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf22503e1a2" x="114.503052" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3fce1c404a" x="114.422987" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Outer -->
-      <g style="fill: #ffffff" transform="translate(100.306177 383.726438) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(100.226112 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -169,7 +169,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g style="fill: #ffffff" transform="translate(101.701489 394.92425) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(101.621425 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -250,12 +250,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mf22503e1a2" x="199.763831" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3fce1c404a" x="199.697792" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Outer -->
-      <g style="fill: #ffffff" transform="translate(185.566956 383.726438) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(185.500917 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -263,7 +263,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Offset -->
-      <g style="fill: #ffffff" transform="translate(184.666175 394.92425) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(184.600136 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -330,12 +330,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mf22503e1a2" x="285.02461" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3fce1c404a" x="284.972597" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g style="fill: #ffffff" transform="translate(269.131642 383.726438) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(269.079629 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -397,7 +397,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g style="fill: #ffffff" transform="translate(259.620704 394.92425) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(259.568691 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -479,7 +479,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g style="fill: #ffffff" transform="translate(272.223048 406.122063) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(272.171035 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -490,12 +490,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf22503e1a2" x="370.28539" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3fce1c404a" x="370.247403" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g style="fill: #ffffff" transform="translate(354.392421 383.726438) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(354.354434 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -503,7 +503,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g style="fill: #ffffff" transform="translate(344.881483 394.92425) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(344.843496 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -514,7 +514,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g style="fill: #ffffff" transform="translate(355.187733 406.122063) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(355.149746 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -527,12 +527,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mf22503e1a2" x="455.546169" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3fce1c404a" x="455.522208" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Chunk -->
-      <g style="fill: #ffffff" transform="translate(439.6532 383.726438) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(439.629239 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -540,7 +540,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g style="fill: #ffffff" transform="translate(430.142263 394.92425) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(430.118302 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -551,14 +551,14 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g style="fill: #ffffff" transform="translate(442.744606 406.122063) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(442.720645 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
        <use xlink:href="#DejaVuSans-65" x="194.482422"/>
       </g>
       <!-- Offset -->
-      <g style="fill: #ffffff" transform="translate(440.448513 417.319875) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(440.424552 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -571,12 +571,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf22503e1a2" x="540.806948" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m3fce1c404a" x="540.797013" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Chunk -->
-      <g style="fill: #ffffff" transform="translate(524.913979 383.726438) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(524.904044 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -584,7 +584,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g style="fill: #ffffff" transform="translate(515.403042 394.92425) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(515.393107 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -595,7 +595,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g style="fill: #ffffff" transform="translate(525.709292 406.122063) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(525.699357 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -604,7 +604,7 @@ z
        <use xlink:href="#DejaVuSans-74" x="262.744141"/>
       </g>
       <!-- Offset -->
-      <g style="fill: #ffffff" transform="translate(525.709292 417.319875) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(525.699357 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -618,23 +618,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_7">
-      <path d="M 54.11 369.128 
+      <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#pbfea83172a)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pfc438d4a34)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="mce07979523" d="M 0 0 
+       <path id="mbaaa462e6d" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mce07979523" x="54.11" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaa462e6d" x="54.02" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.00 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 372.927219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 372.927219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -674,18 +674,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 54.11 330.899653 
-L 601.2 330.899653 
-" clip-path="url(#pbfea83172a)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 325.357975 
+L 601.2 325.357975 
+" clip-path="url(#pfc438d4a34)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mce07979523" x="54.11" y="330.899653" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaa462e6d" x="54.02" y="325.357975" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.02 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 334.698872) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 329.157194) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -721,18 +721,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 54.11 292.671307 
-L 601.2 292.671307 
-" clip-path="url(#pbfea83172a)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 281.58795 
+L 601.2 281.58795 
+" clip-path="url(#pfc438d4a34)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mce07979523" x="54.11" y="292.671307" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaa462e6d" x="54.02" y="281.58795" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.04 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 296.470526) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 285.387169) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -763,18 +763,18 @@ z
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 54.11 254.44296 
-L 601.2 254.44296 
-" clip-path="url(#pbfea83172a)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 237.817926 
+L 601.2 237.817926 
+" clip-path="url(#pfc438d4a34)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mce07979523" x="54.11" y="254.44296" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaa462e6d" x="54.02" y="237.817926" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.06 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 258.242179) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 241.617144) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -816,18 +816,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 54.11 216.214614 
-L 601.2 216.214614 
-" clip-path="url(#pbfea83172a)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 194.047901 
+L 601.2 194.047901 
+" clip-path="url(#pfc438d4a34)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mce07979523" x="54.11" y="216.214614" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaa462e6d" x="54.02" y="194.047901" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.08 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 220.013833) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 197.84712) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -878,18 +878,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 54.11 177.986267 
-L 601.2 177.986267 
-" clip-path="url(#pbfea83172a)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 150.277876 
+L 601.2 150.277876 
+" clip-path="url(#pfc438d4a34)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mce07979523" x="54.11" y="177.986267" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaa462e6d" x="54.02" y="150.277876" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.10 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 181.785486) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 154.077095) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -915,18 +915,18 @@ z
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 54.11 139.757921 
-L 601.2 139.757921 
-" clip-path="url(#pbfea83172a)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 106.507851 
+L 601.2 106.507851 
+" clip-path="url(#pfc438d4a34)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mce07979523" x="54.11" y="139.757921" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaa462e6d" x="54.02" y="106.507851" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.12 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 143.55714) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 110.30707) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -936,18 +936,18 @@ L 601.2 139.757921
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 54.11 101.529574 
-L 601.2 101.529574 
-" clip-path="url(#pbfea83172a)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 62.737827 
+L 601.2 62.737827 
+" clip-path="url(#pfc438d4a34)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mce07979523" x="54.11" y="101.529574" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaa462e6d" x="54.02" y="62.737827" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.14 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 105.328793) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 66.537045) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -955,30 +955,9 @@ L 601.2 101.529574
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_23">
-      <path d="M 54.11 63.301228 
-L 601.2 63.301228 
-" clip-path="url(#pbfea83172a)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_24">
-      <g>
-       <use xlink:href="#mce07979523" x="54.11" y="63.301228" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 0.16 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 67.100446) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_16">
+    <g id="text_15">
      <!-- Time (seconds) -->
-     <g style="fill: #ffffff" transform="translate(18.764688 236.165719) rotate(-90) scale(0.1 -0.1)">
+     <g style="fill: #ffffff" transform="translate(18.674688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1058,8 +1037,8 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 54.11 369.128 
-L 54.11 26.88 
+    <path d="M 54.02 369.128 
+L 54.02 26.88 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
@@ -1068,99 +1047,367 @@ L 601.2 26.88
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 54.11 369.128 
+    <path d="M 54.02 369.128 
 L 601.2 369.128 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 54.11 26.88 
+    <path d="M 54.02 26.88 
 L 601.2 26.88 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 78.977727 369.128 
-L 93.187857 369.128 
-L 93.187857 110.511791 
-L 78.977727 110.511791 
+    <path d="M 78.891818 369.128 
+L 93.104286 369.128 
+L 93.104286 115.94896 
+L 78.891818 115.94896 
 z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 164.238506 369.128 
-L 178.448636 369.128 
-L 178.448636 110.658572 
-L 164.238506 110.658572 
+    <path d="M 164.166623 369.128 
+L 178.379091 369.128 
+L 178.379091 115.340784 
+L 164.166623 115.340784 
 z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 249.499286 369.128 
-L 263.709416 369.128 
-L 263.709416 110.614021 
-L 249.499286 110.614021 
+    <path d="M 249.441429 369.128 
+L 263.653896 369.128 
+L 263.653896 111.513852 
+L 249.441429 111.513852 
 z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 334.760065 369.128 
-L 348.970195 369.128 
-L 348.970195 110.166428 
-L 334.760065 110.166428 
+    <path d="M 334.716234 369.128 
+L 348.928701 369.128 
+L 348.928701 111.904273 
+L 334.716234 111.904273 
 z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 420.020844 369.128 
-L 434.230974 369.128 
-L 434.230974 110.154627 
-L 420.020844 110.154627 
+    <path d="M 419.991039 369.128 
+L 434.203506 369.128 
+L 434.203506 111.075904 
+L 419.991039 111.075904 
 z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 505.281623 369.128 
-L 519.491753 369.128 
-L 519.491753 110.569335 
-L 505.281623 110.569335 
+    <path d="M 505.265844 369.128 
+L 519.478312 369.128 
+L 519.478312 110.983026 
+L 505.265844 110.983026 
 z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_16">
+    <!-- 116 ms -->
+    <g style="fill: #ffffff" transform="translate(88.757427 110.94896) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
    </g>
    <g id="text_17">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(88.842167 105.511791) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
+    <!-- 116 ms -->
+    <g style="fill: #ffffff" transform="translate(174.032232 110.340784) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(259.307037 106.513852) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(344.581843 106.904273) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(429.856648 106.075904) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(515.131453 105.983026) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!--  1 -->
+    <g transform="translate(88.757427 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!--  1 -->
+    <g transform="translate(174.032232 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!--  1 -->
+    <g transform="translate(259.307037 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!--  1 -->
+    <g transform="translate(344.581843 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!--  1 -->
+    <g transform="translate(429.856648 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!--  1 -->
+    <g transform="translate(515.131453 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="patch_13">
+    <path d="M 93.104286 369.128 
+L 107.316753 369.128 
+L 107.316753 118.049512 
+L 93.104286 118.049512 
 z
-" transform="scale(0.015625)"/>
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 107.316753 369.128 
+L 121.529221 369.128 
+L 121.529221 116.755493 
+L 107.316753 116.755493 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 121.529221 369.128 
+L 135.741688 369.128 
+L 135.741688 111.510731 
+L 121.529221 111.510731 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 135.741688 369.128 
+L 149.954156 369.128 
+L 149.954156 109.160405 
+L 135.741688 109.160405 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 178.379091 369.128 
+L 192.591558 369.128 
+L 192.591558 118.042632 
+L 178.379091 118.042632 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 192.591558 369.128 
+L 206.804026 369.128 
+L 206.804026 116.792123 
+L 192.591558 116.792123 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 206.804026 369.128 
+L 221.016494 369.128 
+L 221.016494 111.249544 
+L 206.804026 111.249544 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 221.016494 369.128 
+L 235.228961 369.128 
+L 235.228961 108.367619 
+L 221.016494 108.367619 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 263.653896 369.128 
+L 277.866364 369.128 
+L 277.866364 119.808738 
+L 263.653896 119.808738 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 277.866364 369.128 
+L 292.078831 369.128 
+L 292.078831 117.624984 
+L 277.866364 117.624984 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 292.078831 369.128 
+L 306.291299 369.128 
+L 306.291299 113.133408 
+L 292.078831 113.133408 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 306.291299 369.128 
+L 320.503766 369.128 
+L 320.503766 110.372763 
+L 306.291299 110.372763 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 348.928701 369.128 
+L 363.141169 369.128 
+L 363.141169 114.305072 
+L 348.928701 114.305072 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 363.141169 369.128 
+L 377.353636 369.128 
+L 377.353636 116.286586 
+L 363.141169 116.286586 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 377.353636 369.128 
+L 391.566104 369.128 
+L 391.566104 111.05026 
+L 377.353636 111.05026 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 391.566104 369.128 
+L 405.778571 369.128 
+L 405.778571 109.841838 
+L 391.566104 109.841838 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 434.203506 369.128 
+L 448.415974 369.128 
+L 448.415974 120.200462 
+L 434.203506 120.200462 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 448.415974 369.128 
+L 462.628442 369.128 
+L 462.628442 117.825148 
+L 448.415974 117.825148 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 462.628442 369.128 
+L 476.840909 369.128 
+L 476.840909 111.898096 
+L 462.628442 111.898096 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 476.840909 369.128 
+L 491.053377 369.128 
+L 491.053377 108.845052 
+L 476.840909 108.845052 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 519.478312 369.128 
+L 533.690779 369.128 
+L 533.690779 114.643722 
+L 519.478312 114.643722 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 533.690779 369.128 
+L 547.903247 369.128 
+L 547.903247 118.059033 
+L 533.690779 118.059033 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 547.903247 369.128 
+L 562.115714 369.128 
+L 562.115714 112.839884 
+L 547.903247 112.839884 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 562.115714 369.128 
+L 576.328182 369.128 
+L 576.328182 110.352143 
+L 562.115714 110.352143 
+z
+" clip-path="url(#pfc438d4a34)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_28">
+    <!-- 115 ms -->
+    <g style="fill: #ffffff" transform="translate(102.969894 113.049512) rotate(-90) scale(0.1 -0.1)">
+     <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
 L 3169 4134 
@@ -1188,340 +1435,83 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
-   </g>
-   <g id="text_18">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(174.102946 105.658572) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(259.363726 105.614021) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(344.624505 105.166428) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(429.885284 105.154627) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(515.146063 105.569335) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!--  1 -->
-    <g transform="translate(88.842167 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!--  1 -->
-    <g transform="translate(174.102946 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!--  1 -->
-    <g transform="translate(259.363726 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!--  1 -->
-    <g transform="translate(344.624505 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!--  1 -->
-    <g transform="translate(429.885284 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!--  1 -->
-    <g transform="translate(515.146063 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="patch_13">
-    <path d="M 93.187857 369.128 
-L 107.397987 369.128 
-L 107.397987 114.197477 
-L 93.187857 114.197477 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 107.397987 369.128 
-L 121.608117 369.128 
-L 121.608117 118.025424 
-L 107.397987 118.025424 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 121.608117 369.128 
-L 135.818247 369.128 
-L 135.818247 113.934135 
-L 121.608117 113.934135 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 135.818247 369.128 
-L 150.028377 369.128 
-L 150.028377 110.606442 
-L 135.818247 110.606442 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 178.448636 369.128 
-L 192.658766 369.128 
-L 192.658766 113.809594 
-L 178.448636 113.809594 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 192.658766 369.128 
-L 206.868896 369.128 
-L 206.868896 114.821692 
-L 192.658766 114.821692 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 206.868896 369.128 
-L 221.079026 369.128 
-L 221.079026 112.290248 
-L 206.868896 112.290248 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 221.079026 369.128 
-L 235.289156 369.128 
-L 235.289156 108.367619 
-L 221.079026 108.367619 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 263.709416 369.128 
-L 277.919545 369.128 
-L 277.919545 114.590097 
-L 263.709416 114.590097 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_22">
-    <path d="M 277.919545 369.128 
-L 292.129675 369.128 
-L 292.129675 119.058892 
-L 277.919545 119.058892 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_23">
-    <path d="M 292.129675 369.128 
-L 306.339805 369.128 
-L 306.339805 116.095831 
-L 292.129675 116.095831 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 306.339805 369.128 
-L 320.549935 369.128 
-L 320.549935 111.64685 
-L 306.339805 111.64685 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 348.970195 369.128 
-L 363.180325 369.128 
-L 363.180325 114.62634 
-L 348.970195 114.62634 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 363.180325 369.128 
-L 377.390455 369.128 
-L 377.390455 115.741428 
-L 363.180325 115.741428 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 377.390455 369.128 
-L 391.600584 369.128 
-L 391.600584 113.668183 
-L 377.390455 113.668183 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 391.600584 369.128 
-L 405.810714 369.128 
-L 405.810714 111.991311 
-L 391.600584 111.991311 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_29">
-    <path d="M 434.230974 369.128 
-L 448.441104 369.128 
-L 448.441104 114.290469 
-L 434.230974 114.290469 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_30">
-    <path d="M 448.441104 369.128 
-L 462.651234 369.128 
-L 462.651234 118.938679 
-L 448.441104 118.938679 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_31">
-    <path d="M 462.651234 369.128 
-L 476.861364 369.128 
-L 476.861364 115.177519 
-L 462.651234 115.177519 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_32">
-    <path d="M 476.861364 369.128 
-L 491.071494 369.128 
-L 491.071494 111.075577 
-L 476.861364 111.075577 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_33">
-    <path d="M 519.491753 369.128 
-L 533.701883 369.128 
-L 533.701883 114.594933 
-L 519.491753 114.594933 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_34">
-    <path d="M 533.701883 369.128 
-L 547.912013 369.128 
-L 547.912013 115.744716 
-L 533.701883 115.744716 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_35">
-    <path d="M 547.912013 369.128 
-L 562.122143 369.128 
-L 562.122143 114.846183 
-L 547.912013 114.846183 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_36">
-    <path d="M 562.122143 369.128 
-L 576.332273 369.128 
-L 576.332273 110.89942 
-L 562.122143 110.89942 
-z
-" clip-path="url(#pbfea83172a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_29">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(103.052297 109.197477) rotate(-90) scale(0.1 -0.1)">
+    <!-- 115 ms -->
+    <g style="fill: #ffffff" transform="translate(117.182362 111.755493) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 131 ms -->
-    <g style="fill: #ffffff" transform="translate(117.262427 113.025424) rotate(-90) scale(0.1 -0.1)">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(131.39483 106.510731) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 134 ms -->
-    <g style="fill: #ffffff" transform="translate(131.472557 108.934135) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(145.607297 104.160405) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(145.682687 105.606442) rotate(-90) scale(0.1 -0.1)">
+    <!-- 115 ms -->
+    <g style="fill: #ffffff" transform="translate(188.2447 113.042632) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1529,420 +1519,421 @@ z
     </g>
    </g>
    <g id="text_33">
-    <!-- 134 ms -->
-    <g style="fill: #ffffff" transform="translate(188.313076 108.809594) rotate(-90) scale(0.1 -0.1)">
+    <!-- 115 ms -->
+    <g style="fill: #ffffff" transform="translate(202.457167 111.792123) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(202.523206 109.821692) rotate(-90) scale(0.1 -0.1)">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(216.669635 106.249544) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 134 ms -->
-    <g style="fill: #ffffff" transform="translate(216.733336 107.290248) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(230.882102 103.367619) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 136 ms -->
-    <g style="fill: #ffffff" transform="translate(230.943466 103.367619) rotate(-90) scale(0.1 -0.1)">
+    <!-- 114 ms -->
+    <g style="fill: #ffffff" transform="translate(273.519505 114.808738) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(273.573856 109.590097) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- 131 ms -->
-    <g style="fill: #ffffff" transform="translate(287.783985 114.058892) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- 132 ms -->
-    <g style="fill: #ffffff" transform="translate(301.994115 111.095831) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(316.204245 106.64685) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_41">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(358.834635 109.62634) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_42">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(373.044765 110.741428) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- 134 ms -->
-    <g style="fill: #ffffff" transform="translate(387.254894 108.668183) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_44">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(401.465024 106.991311) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_37">
+    <!-- 115 ms -->
+    <g style="fill: #ffffff" transform="translate(287.731972 112.624984) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- 117 ms -->
+    <g style="fill: #ffffff" transform="translate(301.94444 108.133408) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(316.156907 105.372763) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- 116 ms -->
+    <g style="fill: #ffffff" transform="translate(358.79431 109.305072) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- 116 ms -->
+    <g style="fill: #ffffff" transform="translate(373.006778 111.286586) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_42">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(387.219245 106.05026) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(401.431713 104.841838) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_44">
+    <!-- 114 ms -->
+    <g style="fill: #ffffff" transform="translate(444.069115 115.200462) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(444.095414 109.290469) rotate(-90) scale(0.1 -0.1)">
+    <!-- 115 ms -->
+    <g style="fill: #ffffff" transform="translate(458.281583 112.825148) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_46">
-    <!-- 131 ms -->
-    <g style="fill: #ffffff" transform="translate(458.305544 113.938679) rotate(-90) scale(0.1 -0.1)">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(472.49405 106.898096) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_47">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(472.515674 110.177519) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(486.706518 103.845052) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_48">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(486.725804 106.075577) rotate(-90) scale(0.1 -0.1)">
+    <!-- 116 ms -->
+    <g style="fill: #ffffff" transform="translate(529.34392 109.643722) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(529.356193 109.594933) rotate(-90) scale(0.1 -0.1)">
+    <!-- 115 ms -->
+    <g style="fill: #ffffff" transform="translate(543.556388 113.059033) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_50">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(543.566323 110.744716) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_51">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(557.776453 109.846183) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_52">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(571.986583 105.89942) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_53">
+   <g id="text_50">
+    <!-- 117 ms -->
+    <g style="fill: #ffffff" transform="translate(557.768856 107.839884) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_51">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(571.981323 105.352143) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_52">
     <!--  4 -->
-    <g transform="translate(103.052297 369.128) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(102.969894 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_53">
+    <!--  12 -->
+    <g transform="translate(117.182362 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_54">
-    <!--  12 -->
-    <g transform="translate(117.262427 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(131.39483 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_55">
-    <!--  40 -->
-    <g transform="translate(131.472557 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(145.607297 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_56">
-    <!--  120 -->
-    <g transform="translate(145.682687 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(188.2447 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_57">
-    <!--  4 -->
-    <g transform="translate(188.313076 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(202.457167 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_58">
-    <!--  12 -->
-    <g transform="translate(202.523206 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(216.669635 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_59">
-    <!--  40 -->
-    <g transform="translate(216.733336 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(230.882102 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_60">
-    <!--  120 -->
-    <g transform="translate(230.943466 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(273.519505 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_61">
-    <!--  4 -->
-    <g transform="translate(273.573856 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(287.731972 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_62">
-    <!--  12 -->
-    <g transform="translate(287.783985 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(301.94444 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_63">
-    <!--  40 -->
-    <g transform="translate(301.994115 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(316.156907 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_64">
-    <!--  120 -->
-    <g transform="translate(316.204245 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(358.79431 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_65">
-    <!--  4 -->
-    <g transform="translate(358.834635 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(373.006778 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_66">
-    <!--  12 -->
-    <g transform="translate(373.044765 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(387.219245 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_67">
-    <!--  40 -->
-    <g transform="translate(387.254894 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(401.431713 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_68">
-    <!--  120 -->
-    <g transform="translate(401.465024 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(444.069115 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_69">
-    <!--  4 -->
-    <g transform="translate(444.095414 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(458.281583 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_70">
-    <!--  12 -->
-    <g transform="translate(458.305544 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(472.49405 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_71">
-    <!--  40 -->
-    <g transform="translate(472.515674 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(486.706518 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_72">
-    <!--  120 -->
-    <g transform="translate(486.725804 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-    </g>
-   </g>
-   <g id="text_73">
     <!--  4 -->
-    <g transform="translate(529.356193 369.128) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(529.34392 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_74">
+   <g id="text_73">
     <!--  12 -->
-    <g transform="translate(543.566323 369.128) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(543.556388 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_75">
+   <g id="text_74">
     <!--  40 -->
-    <g transform="translate(557.776453 369.128) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(557.768856 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_76">
+   <g id="text_75">
     <!--  120 -->
-    <g transform="translate(571.986583 369.128) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(571.981323 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_77">
+   <g id="text_76">
     <!-- filled simple n=1000 -->
-    <g style="fill: #ffffff" transform="translate(265.3225 20.88) scale(0.12 -0.12)">
+    <g style="fill: #ffffff" transform="translate(265.2775 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -2035,7 +2026,7 @@ L 348.146875 43.117187
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_78">
+    <g id="text_77">
      <!-- serial no mask -->
      <g style="fill: #ffffff" transform="translate(376.146875 43.478437) scale(0.1 -0.1)">
       <defs>
@@ -2156,8 +2147,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pbfea83172a">
-   <rect x="54.11" y="26.88" width="547.09" height="342.248"/>
+  <clipPath id="pfc438d4a34">
+   <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/_static/chunk_filled_simple_light.svg
+++ b/docs/_static/chunk_filled_simple_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:08.344406</dc:date>
+    <dc:date>2024-05-06T19:15:03.912915</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -31,11 +31,11 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 54.11 369.128 
+    <path d="M 54.02 369.128 
 L 601.2 369.128 
 L 601.2 26.88 
-L 54.11 26.88 
-L 54.11 369.128 
+L 54.02 26.88 
+L 54.02 369.128 
 z
 " style="fill: none"/>
    </g>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="md533ac4191" d="M 0 0 
+       <path id="mcfd951fb89" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md533ac4191" x="114.503052" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcfd951fb89" x="114.422987" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Outer -->
-      <g transform="translate(100.306177 383.726438) scale(0.1 -0.1)">
+      <g transform="translate(100.226112 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -169,7 +169,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(101.701489 394.92425) scale(0.1 -0.1)">
+      <g transform="translate(101.621425 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -250,12 +250,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#md533ac4191" x="199.763831" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcfd951fb89" x="199.697792" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Outer -->
-      <g transform="translate(185.566956 383.726438) scale(0.1 -0.1)">
+      <g transform="translate(185.500917 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -263,7 +263,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(184.666175 394.92425) scale(0.1 -0.1)">
+      <g transform="translate(184.600136 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -330,12 +330,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#md533ac4191" x="285.02461" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcfd951fb89" x="284.972597" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g transform="translate(269.131642 383.726438) scale(0.1 -0.1)">
+      <g transform="translate(269.079629 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -397,7 +397,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(259.620704 394.92425) scale(0.1 -0.1)">
+      <g transform="translate(259.568691 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -479,7 +479,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(272.223048 406.122063) scale(0.1 -0.1)">
+      <g transform="translate(272.171035 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -490,12 +490,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md533ac4191" x="370.28539" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcfd951fb89" x="370.247403" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g transform="translate(354.392421 383.726438) scale(0.1 -0.1)">
+      <g transform="translate(354.354434 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -503,7 +503,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(344.881483 394.92425) scale(0.1 -0.1)">
+      <g transform="translate(344.843496 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -514,7 +514,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(355.187733 406.122063) scale(0.1 -0.1)">
+      <g transform="translate(355.149746 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -527,12 +527,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#md533ac4191" x="455.546169" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcfd951fb89" x="455.522208" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Chunk -->
-      <g transform="translate(439.6532 383.726438) scale(0.1 -0.1)">
+      <g transform="translate(439.629239 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -540,7 +540,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(430.142263 394.92425) scale(0.1 -0.1)">
+      <g transform="translate(430.118302 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -551,14 +551,14 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(442.744606 406.122063) scale(0.1 -0.1)">
+      <g transform="translate(442.720645 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
        <use xlink:href="#DejaVuSans-65" x="194.482422"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(440.448513 417.319875) scale(0.1 -0.1)">
+      <g transform="translate(440.424552 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -571,12 +571,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#md533ac4191" x="540.806948" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcfd951fb89" x="540.797013" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Chunk -->
-      <g transform="translate(524.913979 383.726438) scale(0.1 -0.1)">
+      <g transform="translate(524.904044 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -584,7 +584,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(515.403042 394.92425) scale(0.1 -0.1)">
+      <g transform="translate(515.393107 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -595,7 +595,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(525.709292 406.122063) scale(0.1 -0.1)">
+      <g transform="translate(525.699357 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -604,7 +604,7 @@ z
        <use xlink:href="#DejaVuSans-74" x="262.744141"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(525.709292 417.319875) scale(0.1 -0.1)">
+      <g transform="translate(525.699357 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -618,23 +618,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_7">
-      <path d="M 54.11 369.128 
+      <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#pded18973f4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2273ee1575)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="m314c23bc06" d="M 0 0 
+       <path id="m69dee957a0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m314c23bc06" x="54.11" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69dee957a0" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.00 -->
-      <g transform="translate(24.844375 372.927219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 372.927219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -674,18 +674,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 54.11 330.899653 
-L 601.2 330.899653 
-" clip-path="url(#pded18973f4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 325.357975 
+L 601.2 325.357975 
+" clip-path="url(#p2273ee1575)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m314c23bc06" x="54.11" y="330.899653" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69dee957a0" x="54.02" y="325.357975" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.02 -->
-      <g transform="translate(24.844375 334.698872) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 329.157194) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -721,18 +721,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 54.11 292.671307 
-L 601.2 292.671307 
-" clip-path="url(#pded18973f4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 281.58795 
+L 601.2 281.58795 
+" clip-path="url(#p2273ee1575)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m314c23bc06" x="54.11" y="292.671307" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69dee957a0" x="54.02" y="281.58795" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.04 -->
-      <g transform="translate(24.844375 296.470526) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 285.387169) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -763,18 +763,18 @@ z
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 54.11 254.44296 
-L 601.2 254.44296 
-" clip-path="url(#pded18973f4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 237.817926 
+L 601.2 237.817926 
+" clip-path="url(#p2273ee1575)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m314c23bc06" x="54.11" y="254.44296" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69dee957a0" x="54.02" y="237.817926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.06 -->
-      <g transform="translate(24.844375 258.242179) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 241.617144) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -816,18 +816,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 54.11 216.214614 
-L 601.2 216.214614 
-" clip-path="url(#pded18973f4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 194.047901 
+L 601.2 194.047901 
+" clip-path="url(#p2273ee1575)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m314c23bc06" x="54.11" y="216.214614" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69dee957a0" x="54.02" y="194.047901" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.08 -->
-      <g transform="translate(24.844375 220.013833) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 197.84712) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -878,18 +878,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 54.11 177.986267 
-L 601.2 177.986267 
-" clip-path="url(#pded18973f4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 150.277876 
+L 601.2 150.277876 
+" clip-path="url(#p2273ee1575)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m314c23bc06" x="54.11" y="177.986267" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69dee957a0" x="54.02" y="150.277876" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.10 -->
-      <g transform="translate(24.844375 181.785486) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 154.077095) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -915,18 +915,18 @@ z
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 54.11 139.757921 
-L 601.2 139.757921 
-" clip-path="url(#pded18973f4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 106.507851 
+L 601.2 106.507851 
+" clip-path="url(#p2273ee1575)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m314c23bc06" x="54.11" y="139.757921" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69dee957a0" x="54.02" y="106.507851" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.12 -->
-      <g transform="translate(24.844375 143.55714) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 110.30707) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -936,18 +936,18 @@ L 601.2 139.757921
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 54.11 101.529574 
-L 601.2 101.529574 
-" clip-path="url(#pded18973f4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 62.737827 
+L 601.2 62.737827 
+" clip-path="url(#p2273ee1575)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m314c23bc06" x="54.11" y="101.529574" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69dee957a0" x="54.02" y="62.737827" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.14 -->
-      <g transform="translate(24.844375 105.328793) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 66.537045) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -955,30 +955,9 @@ L 601.2 101.529574
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_23">
-      <path d="M 54.11 63.301228 
-L 601.2 63.301228 
-" clip-path="url(#pded18973f4)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_24">
-      <g>
-       <use xlink:href="#m314c23bc06" x="54.11" y="63.301228" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 0.16 -->
-      <g transform="translate(24.844375 67.100446) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_16">
+    <g id="text_15">
      <!-- Time (seconds) -->
-     <g transform="translate(18.764688 236.165719) rotate(-90) scale(0.1 -0.1)">
+     <g transform="translate(18.674688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1058,8 +1037,8 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 54.11 369.128 
-L 54.11 26.88 
+    <path d="M 54.02 369.128 
+L 54.02 26.88 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
@@ -1068,99 +1047,367 @@ L 601.2 26.88
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 54.11 369.128 
+    <path d="M 54.02 369.128 
 L 601.2 369.128 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 54.11 26.88 
+    <path d="M 54.02 26.88 
 L 601.2 26.88 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 78.977727 369.128 
-L 93.187857 369.128 
-L 93.187857 110.511791 
-L 78.977727 110.511791 
+    <path d="M 78.891818 369.128 
+L 93.104286 369.128 
+L 93.104286 115.94896 
+L 78.891818 115.94896 
 z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 164.238506 369.128 
-L 178.448636 369.128 
-L 178.448636 110.658572 
-L 164.238506 110.658572 
+    <path d="M 164.166623 369.128 
+L 178.379091 369.128 
+L 178.379091 115.340784 
+L 164.166623 115.340784 
 z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 249.499286 369.128 
-L 263.709416 369.128 
-L 263.709416 110.614021 
-L 249.499286 110.614021 
+    <path d="M 249.441429 369.128 
+L 263.653896 369.128 
+L 263.653896 111.513852 
+L 249.441429 111.513852 
 z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 334.760065 369.128 
-L 348.970195 369.128 
-L 348.970195 110.166428 
-L 334.760065 110.166428 
+    <path d="M 334.716234 369.128 
+L 348.928701 369.128 
+L 348.928701 111.904273 
+L 334.716234 111.904273 
 z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 420.020844 369.128 
-L 434.230974 369.128 
-L 434.230974 110.154627 
-L 420.020844 110.154627 
+    <path d="M 419.991039 369.128 
+L 434.203506 369.128 
+L 434.203506 111.075904 
+L 419.991039 111.075904 
 z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 505.281623 369.128 
-L 519.491753 369.128 
-L 519.491753 110.569335 
-L 505.281623 110.569335 
+    <path d="M 505.265844 369.128 
+L 519.478312 369.128 
+L 519.478312 110.983026 
+L 505.265844 110.983026 
 z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_16">
+    <!-- 116 ms -->
+    <g transform="translate(88.757427 110.94896) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
    </g>
    <g id="text_17">
-    <!-- 135 ms -->
-    <g transform="translate(88.842167 105.511791) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
+    <!-- 116 ms -->
+    <g transform="translate(174.032232 110.340784) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 118 ms -->
+    <g transform="translate(259.307037 106.513852) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 118 ms -->
+    <g transform="translate(344.581843 106.904273) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 118 ms -->
+    <g transform="translate(429.856648 106.075904) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 118 ms -->
+    <g transform="translate(515.131453 105.983026) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!--  1 -->
+    <g transform="translate(88.757427 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!--  1 -->
+    <g transform="translate(174.032232 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!--  1 -->
+    <g transform="translate(259.307037 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!--  1 -->
+    <g transform="translate(344.581843 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!--  1 -->
+    <g transform="translate(429.856648 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!--  1 -->
+    <g transform="translate(515.131453 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="patch_13">
+    <path d="M 93.104286 369.128 
+L 107.316753 369.128 
+L 107.316753 118.049512 
+L 93.104286 118.049512 
 z
-" transform="scale(0.015625)"/>
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 107.316753 369.128 
+L 121.529221 369.128 
+L 121.529221 116.755493 
+L 107.316753 116.755493 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 121.529221 369.128 
+L 135.741688 369.128 
+L 135.741688 111.510731 
+L 121.529221 111.510731 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 135.741688 369.128 
+L 149.954156 369.128 
+L 149.954156 109.160405 
+L 135.741688 109.160405 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 178.379091 369.128 
+L 192.591558 369.128 
+L 192.591558 118.042632 
+L 178.379091 118.042632 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 192.591558 369.128 
+L 206.804026 369.128 
+L 206.804026 116.792123 
+L 192.591558 116.792123 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 206.804026 369.128 
+L 221.016494 369.128 
+L 221.016494 111.249544 
+L 206.804026 111.249544 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 221.016494 369.128 
+L 235.228961 369.128 
+L 235.228961 108.367619 
+L 221.016494 108.367619 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 263.653896 369.128 
+L 277.866364 369.128 
+L 277.866364 119.808738 
+L 263.653896 119.808738 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 277.866364 369.128 
+L 292.078831 369.128 
+L 292.078831 117.624984 
+L 277.866364 117.624984 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 292.078831 369.128 
+L 306.291299 369.128 
+L 306.291299 113.133408 
+L 292.078831 113.133408 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 306.291299 369.128 
+L 320.503766 369.128 
+L 320.503766 110.372763 
+L 306.291299 110.372763 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 348.928701 369.128 
+L 363.141169 369.128 
+L 363.141169 114.305072 
+L 348.928701 114.305072 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 363.141169 369.128 
+L 377.353636 369.128 
+L 377.353636 116.286586 
+L 363.141169 116.286586 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 377.353636 369.128 
+L 391.566104 369.128 
+L 391.566104 111.05026 
+L 377.353636 111.05026 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 391.566104 369.128 
+L 405.778571 369.128 
+L 405.778571 109.841838 
+L 391.566104 109.841838 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 434.203506 369.128 
+L 448.415974 369.128 
+L 448.415974 120.200462 
+L 434.203506 120.200462 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 448.415974 369.128 
+L 462.628442 369.128 
+L 462.628442 117.825148 
+L 448.415974 117.825148 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 462.628442 369.128 
+L 476.840909 369.128 
+L 476.840909 111.898096 
+L 462.628442 111.898096 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 476.840909 369.128 
+L 491.053377 369.128 
+L 491.053377 108.845052 
+L 476.840909 108.845052 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 519.478312 369.128 
+L 533.690779 369.128 
+L 533.690779 114.643722 
+L 519.478312 114.643722 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 533.690779 369.128 
+L 547.903247 369.128 
+L 547.903247 118.059033 
+L 533.690779 118.059033 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 547.903247 369.128 
+L 562.115714 369.128 
+L 562.115714 112.839884 
+L 547.903247 112.839884 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 562.115714 369.128 
+L 576.328182 369.128 
+L 576.328182 110.352143 
+L 562.115714 110.352143 
+z
+" clip-path="url(#p2273ee1575)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_28">
+    <!-- 115 ms -->
+    <g transform="translate(102.969894 113.049512) rotate(-90) scale(0.1 -0.1)">
+     <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
 L 3169 4134 
@@ -1188,340 +1435,83 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
-   </g>
-   <g id="text_18">
-    <!-- 135 ms -->
-    <g transform="translate(174.102946 105.658572) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 135 ms -->
-    <g transform="translate(259.363726 105.614021) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 135 ms -->
-    <g transform="translate(344.624505 105.166428) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 135 ms -->
-    <g transform="translate(429.885284 105.154627) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 135 ms -->
-    <g transform="translate(515.146063 105.569335) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!--  1 -->
-    <g transform="translate(88.842167 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!--  1 -->
-    <g transform="translate(174.102946 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!--  1 -->
-    <g transform="translate(259.363726 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!--  1 -->
-    <g transform="translate(344.624505 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!--  1 -->
-    <g transform="translate(429.885284 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!--  1 -->
-    <g transform="translate(515.146063 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="patch_13">
-    <path d="M 93.187857 369.128 
-L 107.397987 369.128 
-L 107.397987 114.197477 
-L 93.187857 114.197477 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 107.397987 369.128 
-L 121.608117 369.128 
-L 121.608117 118.025424 
-L 107.397987 118.025424 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 121.608117 369.128 
-L 135.818247 369.128 
-L 135.818247 113.934135 
-L 121.608117 113.934135 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 135.818247 369.128 
-L 150.028377 369.128 
-L 150.028377 110.606442 
-L 135.818247 110.606442 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 178.448636 369.128 
-L 192.658766 369.128 
-L 192.658766 113.809594 
-L 178.448636 113.809594 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 192.658766 369.128 
-L 206.868896 369.128 
-L 206.868896 114.821692 
-L 192.658766 114.821692 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 206.868896 369.128 
-L 221.079026 369.128 
-L 221.079026 112.290248 
-L 206.868896 112.290248 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 221.079026 369.128 
-L 235.289156 369.128 
-L 235.289156 108.367619 
-L 221.079026 108.367619 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 263.709416 369.128 
-L 277.919545 369.128 
-L 277.919545 114.590097 
-L 263.709416 114.590097 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_22">
-    <path d="M 277.919545 369.128 
-L 292.129675 369.128 
-L 292.129675 119.058892 
-L 277.919545 119.058892 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_23">
-    <path d="M 292.129675 369.128 
-L 306.339805 369.128 
-L 306.339805 116.095831 
-L 292.129675 116.095831 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 306.339805 369.128 
-L 320.549935 369.128 
-L 320.549935 111.64685 
-L 306.339805 111.64685 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 348.970195 369.128 
-L 363.180325 369.128 
-L 363.180325 114.62634 
-L 348.970195 114.62634 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 363.180325 369.128 
-L 377.390455 369.128 
-L 377.390455 115.741428 
-L 363.180325 115.741428 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 377.390455 369.128 
-L 391.600584 369.128 
-L 391.600584 113.668183 
-L 377.390455 113.668183 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 391.600584 369.128 
-L 405.810714 369.128 
-L 405.810714 111.991311 
-L 391.600584 111.991311 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_29">
-    <path d="M 434.230974 369.128 
-L 448.441104 369.128 
-L 448.441104 114.290469 
-L 434.230974 114.290469 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_30">
-    <path d="M 448.441104 369.128 
-L 462.651234 369.128 
-L 462.651234 118.938679 
-L 448.441104 118.938679 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_31">
-    <path d="M 462.651234 369.128 
-L 476.861364 369.128 
-L 476.861364 115.177519 
-L 462.651234 115.177519 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_32">
-    <path d="M 476.861364 369.128 
-L 491.071494 369.128 
-L 491.071494 111.075577 
-L 476.861364 111.075577 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_33">
-    <path d="M 519.491753 369.128 
-L 533.701883 369.128 
-L 533.701883 114.594933 
-L 519.491753 114.594933 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_34">
-    <path d="M 533.701883 369.128 
-L 547.912013 369.128 
-L 547.912013 115.744716 
-L 533.701883 115.744716 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_35">
-    <path d="M 547.912013 369.128 
-L 562.122143 369.128 
-L 562.122143 114.846183 
-L 547.912013 114.846183 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_36">
-    <path d="M 562.122143 369.128 
-L 576.332273 369.128 
-L 576.332273 110.89942 
-L 562.122143 110.89942 
-z
-" clip-path="url(#pded18973f4)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_29">
-    <!-- 133 ms -->
-    <g transform="translate(103.052297 109.197477) rotate(-90) scale(0.1 -0.1)">
+    <!-- 115 ms -->
+    <g transform="translate(117.182362 111.755493) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 131 ms -->
-    <g transform="translate(117.262427 113.025424) rotate(-90) scale(0.1 -0.1)">
+    <!-- 118 ms -->
+    <g transform="translate(131.39483 106.510731) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 134 ms -->
-    <g transform="translate(131.472557 108.934135) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g transform="translate(145.607297 104.160405) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 135 ms -->
-    <g transform="translate(145.682687 105.606442) rotate(-90) scale(0.1 -0.1)">
+    <!-- 115 ms -->
+    <g transform="translate(188.2447 113.042632) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1529,420 +1519,421 @@ z
     </g>
    </g>
    <g id="text_33">
-    <!-- 134 ms -->
-    <g transform="translate(188.313076 108.809594) rotate(-90) scale(0.1 -0.1)">
+    <!-- 115 ms -->
+    <g transform="translate(202.457167 111.792123) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 133 ms -->
-    <g transform="translate(202.523206 109.821692) rotate(-90) scale(0.1 -0.1)">
+    <!-- 118 ms -->
+    <g transform="translate(216.669635 106.249544) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 134 ms -->
-    <g transform="translate(216.733336 107.290248) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g transform="translate(230.882102 103.367619) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 136 ms -->
-    <g transform="translate(230.943466 103.367619) rotate(-90) scale(0.1 -0.1)">
+    <!-- 114 ms -->
+    <g transform="translate(273.519505 114.808738) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- 133 ms -->
-    <g transform="translate(273.573856 109.590097) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- 131 ms -->
-    <g transform="translate(287.783985 114.058892) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- 132 ms -->
-    <g transform="translate(301.994115 111.095831) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- 135 ms -->
-    <g transform="translate(316.204245 106.64685) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_41">
-    <!-- 133 ms -->
-    <g transform="translate(358.834635 109.62634) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_42">
-    <!-- 133 ms -->
-    <g transform="translate(373.044765 110.741428) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- 134 ms -->
-    <g transform="translate(387.254894 108.668183) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_44">
-    <!-- 135 ms -->
-    <g transform="translate(401.465024 106.991311) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_37">
+    <!-- 115 ms -->
+    <g transform="translate(287.731972 112.624984) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- 117 ms -->
+    <g transform="translate(301.94444 108.133408) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- 118 ms -->
+    <g transform="translate(316.156907 105.372763) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- 116 ms -->
+    <g transform="translate(358.79431 109.305072) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- 116 ms -->
+    <g transform="translate(373.006778 111.286586) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_42">
+    <!-- 118 ms -->
+    <g transform="translate(387.219245 106.05026) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- 118 ms -->
+    <g transform="translate(401.431713 104.841838) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_44">
+    <!-- 114 ms -->
+    <g transform="translate(444.069115 115.200462) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- 133 ms -->
-    <g transform="translate(444.095414 109.290469) rotate(-90) scale(0.1 -0.1)">
+    <!-- 115 ms -->
+    <g transform="translate(458.281583 112.825148) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_46">
-    <!-- 131 ms -->
-    <g transform="translate(458.305544 113.938679) rotate(-90) scale(0.1 -0.1)">
+    <!-- 118 ms -->
+    <g transform="translate(472.49405 106.898096) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_47">
-    <!-- 133 ms -->
-    <g transform="translate(472.515674 110.177519) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g transform="translate(486.706518 103.845052) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_48">
-    <!-- 135 ms -->
-    <g transform="translate(486.725804 106.075577) rotate(-90) scale(0.1 -0.1)">
+    <!-- 116 ms -->
+    <g transform="translate(529.34392 109.643722) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- 133 ms -->
-    <g transform="translate(529.356193 109.594933) rotate(-90) scale(0.1 -0.1)">
+    <!-- 115 ms -->
+    <g transform="translate(543.556388 113.059033) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_50">
-    <!-- 133 ms -->
-    <g transform="translate(543.566323 110.744716) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_51">
-    <!-- 133 ms -->
-    <g transform="translate(557.776453 109.846183) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_52">
-    <!-- 135 ms -->
-    <g transform="translate(571.986583 105.89942) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_53">
+   <g id="text_50">
+    <!-- 117 ms -->
+    <g transform="translate(557.768856 107.839884) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_51">
+    <!-- 118 ms -->
+    <g transform="translate(571.981323 105.352143) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_52">
     <!--  4 -->
-    <g transform="translate(103.052297 369.128) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(102.969894 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_53">
+    <!--  12 -->
+    <g transform="translate(117.182362 369.128) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_54">
-    <!--  12 -->
-    <g transform="translate(117.262427 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(131.39483 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_55">
-    <!--  40 -->
-    <g transform="translate(131.472557 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(145.607297 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_56">
-    <!--  120 -->
-    <g transform="translate(145.682687 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(188.2447 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_57">
-    <!--  4 -->
-    <g transform="translate(188.313076 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(202.457167 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_58">
-    <!--  12 -->
-    <g transform="translate(202.523206 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(216.669635 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_59">
-    <!--  40 -->
-    <g transform="translate(216.733336 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(230.882102 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_60">
-    <!--  120 -->
-    <g transform="translate(230.943466 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(273.519505 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_61">
-    <!--  4 -->
-    <g transform="translate(273.573856 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(287.731972 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_62">
-    <!--  12 -->
-    <g transform="translate(287.783985 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(301.94444 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_63">
-    <!--  40 -->
-    <g transform="translate(301.994115 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(316.156907 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_64">
-    <!--  120 -->
-    <g transform="translate(316.204245 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(358.79431 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_65">
-    <!--  4 -->
-    <g transform="translate(358.834635 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(373.006778 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_66">
-    <!--  12 -->
-    <g transform="translate(373.044765 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(387.219245 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_67">
-    <!--  40 -->
-    <g transform="translate(387.254894 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(401.431713 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_68">
-    <!--  120 -->
-    <g transform="translate(401.465024 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(444.069115 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_69">
-    <!--  4 -->
-    <g transform="translate(444.095414 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(458.281583 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_70">
-    <!--  12 -->
-    <g transform="translate(458.305544 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(472.49405 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_71">
-    <!--  40 -->
-    <g transform="translate(472.515674 369.128) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(486.706518 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_72">
-    <!--  120 -->
-    <g transform="translate(486.725804 369.128) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-    </g>
-   </g>
-   <g id="text_73">
     <!--  4 -->
-    <g transform="translate(529.356193 369.128) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(529.34392 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_74">
+   <g id="text_73">
     <!--  12 -->
-    <g transform="translate(543.566323 369.128) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(543.556388 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_75">
+   <g id="text_74">
     <!--  40 -->
-    <g transform="translate(557.776453 369.128) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(557.768856 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_76">
+   <g id="text_75">
     <!--  120 -->
-    <g transform="translate(571.986583 369.128) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(571.981323 369.128) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_77">
+   <g id="text_76">
     <!-- filled simple n=1000 -->
-    <g transform="translate(265.3225 20.88) scale(0.12 -0.12)">
+    <g transform="translate(265.2775 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -2035,7 +2026,7 @@ L 348.146875 43.117187
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_78">
+    <g id="text_77">
      <!-- serial no mask -->
      <g transform="translate(376.146875 43.478437) scale(0.1 -0.1)">
       <defs>
@@ -2156,8 +2147,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pded18973f4">
-   <rect x="54.11" y="26.88" width="547.09" height="342.248"/>
+  <clipPath id="p2273ee1575">
+   <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/_static/chunk_lines_random_dark.svg
+++ b/docs/_static/chunk_lines_random_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:08.143075</dc:date>
+    <dc:date>2024-05-06T19:15:03.722280</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m20018addab" d="M 0 0 
+       <path id="mf7b0f2102c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m20018addab" x="116.254357" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf7b0f2102c" x="116.254357" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -223,7 +223,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m20018addab" x="220.357179" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf7b0f2102c" x="220.357179" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -320,7 +320,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m20018addab" x="324.46" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf7b0f2102c" x="324.46" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -502,7 +502,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m20018addab" x="428.562821" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf7b0f2102c" x="428.562821" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -614,7 +614,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m20018addab" x="532.665643" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf7b0f2102c" x="532.665643" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -666,16 +666,16 @@ z
      <g id="line2d_6">
       <path d="M 47.72 380.792 
 L 601.2 380.792 
-" clip-path="url(#p8bd9095ca3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p83923083ae)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="ma4e2312e56" d="M 0 0 
+       <path id="m42699c0427" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma4e2312e56" x="47.72" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m42699c0427" x="47.72" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -719,18 +719,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_8">
-      <path d="M 47.72 331.293818 
-L 601.2 331.293818 
-" clip-path="url(#p8bd9095ca3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 330.233143 
+L 601.2 330.233143 
+" clip-path="url(#p83923083ae)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#ma4e2312e56" x="47.72" y="331.293818" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m42699c0427" x="47.72" y="330.233143" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.2 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 335.093037) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 334.032362) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -765,18 +765,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_10">
-      <path d="M 47.72 281.795636 
-L 601.2 281.795636 
-" clip-path="url(#p8bd9095ca3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 279.674286 
+L 601.2 279.674286 
+" clip-path="url(#p83923083ae)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#ma4e2312e56" x="47.72" y="281.795636" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m42699c0427" x="47.72" y="279.674286" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.4 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 285.594855) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 283.473504) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -806,18 +806,18 @@ z
     </g>
     <g id="ytick_4">
      <g id="line2d_12">
-      <path d="M 47.72 232.297455 
-L 601.2 232.297455 
-" clip-path="url(#p8bd9095ca3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 229.115429 
+L 601.2 229.115429 
+" clip-path="url(#p83923083ae)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#ma4e2312e56" x="47.72" y="232.297455" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m42699c0427" x="47.72" y="229.115429" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.6 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 236.096673) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 232.914647) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -858,18 +858,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_14">
-      <path d="M 47.72 182.799273 
-L 601.2 182.799273 
-" clip-path="url(#p8bd9095ca3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 178.556571 
+L 601.2 178.556571 
+" clip-path="url(#p83923083ae)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#ma4e2312e56" x="47.72" y="182.799273" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m42699c0427" x="47.72" y="178.556571" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.8 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 186.598491) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 182.35579) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -919,18 +919,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_16">
-      <path d="M 47.72 133.301091 
-L 601.2 133.301091 
-" clip-path="url(#p8bd9095ca3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 127.997714 
+L 601.2 127.997714 
+" clip-path="url(#p83923083ae)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#ma4e2312e56" x="47.72" y="133.301091" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m42699c0427" x="47.72" y="127.997714" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.0 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 137.10031) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 131.796933) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -955,18 +955,18 @@ z
     </g>
     <g id="ytick_7">
      <g id="line2d_18">
-      <path d="M 47.72 83.802909 
-L 601.2 83.802909 
-" clip-path="url(#p8bd9095ca3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 77.438857 
+L 601.2 77.438857 
+" clip-path="url(#p83923083ae)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#ma4e2312e56" x="47.72" y="83.802909" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m42699c0427" x="47.72" y="77.438857" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.2 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 87.602128) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 81.238076) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -975,18 +975,18 @@ L 601.2 83.802909
     </g>
     <g id="ytick_8">
      <g id="line2d_20">
-      <path d="M 47.72 34.304727 
-L 601.2 34.304727 
-" clip-path="url(#p8bd9095ca3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 26.88 
+L 601.2 26.88 
+" clip-path="url(#p83923083ae)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#ma4e2312e56" x="47.72" y="34.304727" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m42699c0427" x="47.72" y="26.88" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.4 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 38.103946) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 30.679219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -1097,94 +1097,47 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 72.878182 380.792 
 L 90.228652 380.792 
-L 90.228652 171.500028 
-L 72.878182 171.500028 
+L 90.228652 172.784361 
+L 72.878182 172.784361 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 176.981003 380.792 
 L 194.331473 380.792 
-L 194.331473 82.102349 
-L 176.981003 82.102349 
+L 194.331473 80.092917 
+L 176.981003 80.092917 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 281.083824 380.792 
 L 298.434295 380.792 
-L 298.434295 256.274243 
-L 281.083824 256.274243 
+L 298.434295 258.348304 
+L 281.083824 258.348304 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 385.186646 380.792 
 L 402.537116 380.792 
-L 402.537116 258.153165 
-L 385.186646 258.153165 
+L 402.537116 259.221444 
+L 385.186646 259.221444 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 489.289467 380.792 
 L 506.639937 380.792 
-L 506.639937 257.775305 
-L 489.289467 257.775305 
+L 506.639937 258.435398 
+L 489.289467 258.435398 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_15">
-    <!-- 846 ms -->
-    <g style="fill: #ffffff" transform="translate(84.312792 166.500028) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_16">
-    <!-- 1.21 s -->
-    <g style="fill: #ffffff" transform="translate(188.415613 77.102349) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_17">
-    <!-- 503 ms -->
-    <g style="fill: #ffffff" transform="translate(292.518435 251.274243) rotate(-90) scale(0.1 -0.1)">
+    <!-- 823 ms -->
+    <g style="fill: #ffffff" transform="translate(84.312792 167.784361) rotate(-90) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1218,17 +1171,17 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_18">
-    <!-- 496 ms -->
-    <g style="fill: #ffffff" transform="translate(396.621256 253.153165) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_16">
+    <!-- 1.19 s -->
+    <g style="fill: #ffffff" transform="translate(188.415613 75.092917) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1261,32 +1214,42 @@ Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 484 ms -->
+    <g style="fill: #ffffff" transform="translate(292.518435 253.348304) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 481 ms -->
+    <g style="fill: #ffffff" transform="translate(396.621256 254.221444) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_19">
-    <!-- 497 ms -->
-    <g style="fill: #ffffff" transform="translate(500.724077 252.775305) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 484 ms -->
+    <g style="fill: #ffffff" transform="translate(500.724077 253.435398) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1330,210 +1293,271 @@ z
    <g id="patch_12">
     <path d="M 90.228652 380.792 
 L 107.579122 380.792 
-L 107.579122 172.040655 
-L 90.228652 172.040655 
+L 107.579122 171.269831 
+L 90.228652 171.269831 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 107.579122 380.792 
 L 124.929592 380.792 
-L 124.929592 171.455098 
-L 107.579122 171.455098 
+L 124.929592 171.154902 
+L 107.579122 171.154902 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 124.929592 380.792 
 L 142.280063 380.792 
-L 142.280063 169.083402 
-L 124.929592 169.083402 
+L 142.280063 169.127807 
+L 124.929592 169.127807 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 142.280063 380.792 
 L 159.630533 380.792 
-L 159.630533 164.438839 
-L 142.280063 164.438839 
+L 159.630533 165.866582 
+L 142.280063 165.866582 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 194.331473 380.792 
 L 211.681944 380.792 
-L 211.681944 82.515261 
-L 194.331473 82.515261 
+L 211.681944 78.237249 
+L 194.331473 78.237249 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 211.681944 380.792 
 L 229.032414 380.792 
-L 229.032414 79.252703 
-L 211.681944 79.252703 
+L 229.032414 78.218526 
+L 211.681944 78.218526 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 229.032414 380.792 
 L 246.382884 380.792 
-L 246.382884 74.00737 
-L 229.032414 74.00737 
+L 246.382884 74.728487 
+L 229.032414 74.728487 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 246.382884 380.792 
 L 263.733354 380.792 
-L 263.733354 68.593911 
-L 246.382884 68.593911 
+L 263.733354 69.866443 
+L 246.382884 69.866443 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 298.434295 380.792 
 L 315.784765 380.792 
-L 315.784765 245.006849 
-L 298.434295 245.006849 
+L 315.784765 247.696038 
+L 298.434295 247.696038 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 315.784765 380.792 
 L 333.135235 380.792 
-L 333.135235 245.198077 
-L 315.784765 245.198077 
+L 333.135235 247.16817 
+L 315.784765 247.16817 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 333.135235 380.792 
 L 350.485705 380.792 
-L 350.485705 244.953088 
-L 333.135235 244.953088 
+L 350.485705 246.967525 
+L 333.135235 246.967525 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 350.485705 380.792 
 L 367.836176 380.792 
-L 367.836176 243.100863 
-L 350.485705 243.100863 
+L 367.836176 251.582871 
+L 350.485705 251.582871 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 402.537116 380.792 
 L 419.887586 380.792 
-L 419.887586 249.565468 
-L 402.537116 249.565468 
+L 419.887586 249.028761 
+L 402.537116 249.028761 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 419.887586 380.792 
 L 437.238056 380.792 
-L 437.238056 249.078713 
-L 419.887586 249.078713 
+L 437.238056 248.670785 
+L 419.887586 248.670785 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 437.238056 380.792 
 L 454.588527 380.792 
-L 454.588527 248.749249 
-L 437.238056 248.749249 
+L 454.588527 248.370683 
+L 437.238056 248.370683 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 454.588527 380.792 
 L 471.938997 380.792 
-L 471.938997 246.775503 
-L 454.588527 246.775503 
+L 471.938997 259.125719 
+L 454.588527 259.125719 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 506.639937 380.792 
 L 523.990408 380.792 
-L 523.990408 248.063599 
-L 506.639937 248.063599 
+L 523.990408 250.91932 
+L 506.639937 250.91932 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 523.990408 380.792 
 L 541.340878 380.792 
-L 541.340878 245.722544 
-L 523.990408 245.722544 
+L 541.340878 246.98438 
+L 523.990408 246.98438 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 541.340878 380.792 
 L 558.691348 380.792 
-L 558.691348 245.09308 
-L 541.340878 245.09308 
+L 558.691348 247.099142 
+L 541.340878 247.099142 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 558.691348 380.792 
 L 576.041818 380.792 
-L 576.041818 244.01814 
-L 558.691348 244.01814 
+L 576.041818 247.470218 
+L 558.691348 247.470218 
 z
-" clip-path="url(#p8bd9095ca3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p83923083ae)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_25">
-    <!-- 843 ms -->
-    <g style="fill: #ffffff" transform="translate(101.663262 167.040655) rotate(-90) scale(0.1 -0.1)">
+    <!-- 829 ms -->
+    <g style="fill: #ffffff" transform="translate(101.663262 166.269831) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 846 ms -->
-    <g style="fill: #ffffff" transform="translate(119.013732 166.455098) rotate(-90) scale(0.1 -0.1)">
+    <!-- 829 ms -->
+    <g style="fill: #ffffff" transform="translate(119.013732 166.154902) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- 855 ms -->
-    <g style="fill: #ffffff" transform="translate(136.364203 164.083402) rotate(-90) scale(0.1 -0.1)">
+    <!-- 837 ms -->
+    <g style="fill: #ffffff" transform="translate(136.364203 164.127807) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 874 ms -->
-    <g style="fill: #ffffff" transform="translate(153.714673 159.438839) rotate(-90) scale(0.1 -0.1)">
+    <!-- 850 ms -->
+    <g style="fill: #ffffff" transform="translate(153.714673 160.866582) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
+    <!-- 1.20 s -->
+    <g style="fill: #ffffff" transform="translate(205.766083 73.237249) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 1.20 s -->
+    <g style="fill: #ffffff" transform="translate(223.116554 73.218526) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_31">
     <!-- 1.21 s -->
-    <g style="fill: #ffffff" transform="translate(205.766083 77.515261) rotate(-90) scale(0.1 -0.1)">
+    <g style="fill: #ffffff" transform="translate(240.467024 69.728487) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1542,66 +1566,44 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_30">
-    <!-- 1.22 s -->
-    <g style="fill: #ffffff" transform="translate(223.116554 74.252703) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 1.24 s -->
-    <g style="fill: #ffffff" transform="translate(240.467024 69.00737) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
    <g id="text_32">
-    <!-- 1.26 s -->
-    <g style="fill: #ffffff" transform="translate(257.817494 63.593911) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.23 s -->
+    <g style="fill: #ffffff" transform="translate(257.817494 64.866443) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 549 ms -->
-    <g style="fill: #ffffff" transform="translate(309.868905 240.006849) rotate(-90) scale(0.1 -0.1)">
+    <!-- 526 ms -->
+    <g style="fill: #ffffff" transform="translate(309.868905 242.696038) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 548 ms -->
-    <g style="fill: #ffffff" transform="translate(327.219375 240.198077) rotate(-90) scale(0.1 -0.1)">
+    <!-- 529 ms -->
+    <g style="fill: #ffffff" transform="translate(327.219375 242.16817) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 549 ms -->
-    <g style="fill: #ffffff" transform="translate(344.569845 239.953088) rotate(-90) scale(0.1 -0.1)">
+    <!-- 529 ms -->
+    <g style="fill: #ffffff" transform="translate(344.569845 241.967525) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1609,43 +1611,43 @@ z
     </g>
    </g>
    <g id="text_36">
-    <!-- 556 ms -->
-    <g style="fill: #ffffff" transform="translate(361.920315 238.100863) rotate(-90) scale(0.1 -0.1)">
+    <!-- 511 ms -->
+    <g style="fill: #ffffff" transform="translate(361.920315 246.582871) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 530 ms -->
-    <g style="fill: #ffffff" transform="translate(413.971726 244.565468) rotate(-90) scale(0.1 -0.1)">
+    <!-- 521 ms -->
+    <g style="fill: #ffffff" transform="translate(413.971726 244.028761) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 532 ms -->
-    <g style="fill: #ffffff" transform="translate(431.322196 244.078713) rotate(-90) scale(0.1 -0.1)">
+    <!-- 523 ms -->
+    <g style="fill: #ffffff" transform="translate(431.322196 243.670785) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 534 ms -->
-    <g style="fill: #ffffff" transform="translate(448.672667 243.749249) rotate(-90) scale(0.1 -0.1)">
+    <!-- 524 ms -->
+    <g style="fill: #ffffff" transform="translate(448.672667 243.370683) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1653,55 +1655,55 @@ z
     </g>
    </g>
    <g id="text_40">
-    <!-- 542 ms -->
-    <g style="fill: #ffffff" transform="translate(466.023137 241.775503) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+    <!-- 481 ms -->
+    <g style="fill: #ffffff" transform="translate(466.023137 254.125719) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- 536 ms -->
-    <g style="fill: #ffffff" transform="translate(518.074547 243.063599) rotate(-90) scale(0.1 -0.1)">
+    <!-- 514 ms -->
+    <g style="fill: #ffffff" transform="translate(518.074547 245.91932) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_42">
-    <!-- 546 ms -->
-    <g style="fill: #ffffff" transform="translate(535.425018 240.722544) rotate(-90) scale(0.1 -0.1)">
+    <!-- 529 ms -->
+    <g style="fill: #ffffff" transform="translate(535.425018 241.98438) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_43">
-    <!-- 548 ms -->
-    <g style="fill: #ffffff" transform="translate(552.775488 240.09308) rotate(-90) scale(0.1 -0.1)">
+    <!-- 529 ms -->
+    <g style="fill: #ffffff" transform="translate(552.775488 242.099142) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- 553 ms -->
-    <g style="fill: #ffffff" transform="translate(570.125958 239.01814) rotate(-90) scale(0.1 -0.1)">
+    <!-- 527 ms -->
+    <g style="fill: #ffffff" transform="translate(570.125958 242.470218) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -2021,7 +2023,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p8bd9095ca3">
+  <clipPath id="p83923083ae">
    <rect x="47.72" y="26.88" width="553.48" height="353.912"/>
   </clipPath>
  </defs>

--- a/docs/_static/chunk_lines_random_light.svg
+++ b/docs/_static/chunk_lines_random_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:07.785738</dc:date>
+    <dc:date>2024-05-06T19:15:03.541007</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="ma2fad7c7bf" d="M 0 0 
+       <path id="m6156c710ee" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma2fad7c7bf" x="116.254357" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6156c710ee" x="116.254357" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -223,7 +223,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#ma2fad7c7bf" x="220.357179" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6156c710ee" x="220.357179" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -320,7 +320,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#ma2fad7c7bf" x="324.46" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6156c710ee" x="324.46" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -502,7 +502,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma2fad7c7bf" x="428.562821" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6156c710ee" x="428.562821" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -614,7 +614,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#ma2fad7c7bf" x="532.665643" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6156c710ee" x="532.665643" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -666,16 +666,16 @@ z
      <g id="line2d_6">
       <path d="M 47.72 380.792 
 L 601.2 380.792 
-" clip-path="url(#pc6f8d9d5d7)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p7e83713833)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="m1365f9ec6a" d="M 0 0 
+       <path id="ma18dee5e1c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1365f9ec6a" x="47.72" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma18dee5e1c" x="47.72" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -719,18 +719,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_8">
-      <path d="M 47.72 331.293818 
-L 601.2 331.293818 
-" clip-path="url(#pc6f8d9d5d7)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 330.233143 
+L 601.2 330.233143 
+" clip-path="url(#p7e83713833)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m1365f9ec6a" x="47.72" y="331.293818" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma18dee5e1c" x="47.72" y="330.233143" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.2 -->
-      <g transform="translate(24.816875 335.093037) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 334.032362) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -765,18 +765,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_10">
-      <path d="M 47.72 281.795636 
-L 601.2 281.795636 
-" clip-path="url(#pc6f8d9d5d7)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 279.674286 
+L 601.2 279.674286 
+" clip-path="url(#p7e83713833)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m1365f9ec6a" x="47.72" y="281.795636" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma18dee5e1c" x="47.72" y="279.674286" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.4 -->
-      <g transform="translate(24.816875 285.594855) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 283.473504) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -806,18 +806,18 @@ z
     </g>
     <g id="ytick_4">
      <g id="line2d_12">
-      <path d="M 47.72 232.297455 
-L 601.2 232.297455 
-" clip-path="url(#pc6f8d9d5d7)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 229.115429 
+L 601.2 229.115429 
+" clip-path="url(#p7e83713833)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m1365f9ec6a" x="47.72" y="232.297455" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma18dee5e1c" x="47.72" y="229.115429" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.6 -->
-      <g transform="translate(24.816875 236.096673) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 232.914647) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -858,18 +858,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_14">
-      <path d="M 47.72 182.799273 
-L 601.2 182.799273 
-" clip-path="url(#pc6f8d9d5d7)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 178.556571 
+L 601.2 178.556571 
+" clip-path="url(#p7e83713833)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m1365f9ec6a" x="47.72" y="182.799273" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma18dee5e1c" x="47.72" y="178.556571" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.8 -->
-      <g transform="translate(24.816875 186.598491) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 182.35579) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -919,18 +919,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_16">
-      <path d="M 47.72 133.301091 
-L 601.2 133.301091 
-" clip-path="url(#pc6f8d9d5d7)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 127.997714 
+L 601.2 127.997714 
+" clip-path="url(#p7e83713833)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m1365f9ec6a" x="47.72" y="133.301091" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma18dee5e1c" x="47.72" y="127.997714" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.0 -->
-      <g transform="translate(24.816875 137.10031) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 131.796933) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -955,18 +955,18 @@ z
     </g>
     <g id="ytick_7">
      <g id="line2d_18">
-      <path d="M 47.72 83.802909 
-L 601.2 83.802909 
-" clip-path="url(#pc6f8d9d5d7)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 77.438857 
+L 601.2 77.438857 
+" clip-path="url(#p7e83713833)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m1365f9ec6a" x="47.72" y="83.802909" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma18dee5e1c" x="47.72" y="77.438857" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.2 -->
-      <g transform="translate(24.816875 87.602128) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 81.238076) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -975,18 +975,18 @@ L 601.2 83.802909
     </g>
     <g id="ytick_8">
      <g id="line2d_20">
-      <path d="M 47.72 34.304727 
-L 601.2 34.304727 
-" clip-path="url(#pc6f8d9d5d7)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 26.88 
+L 601.2 26.88 
+" clip-path="url(#p7e83713833)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m1365f9ec6a" x="47.72" y="34.304727" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma18dee5e1c" x="47.72" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.4 -->
-      <g transform="translate(24.816875 38.103946) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 30.679219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -1097,94 +1097,47 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 72.878182 380.792 
 L 90.228652 380.792 
-L 90.228652 171.500028 
-L 72.878182 171.500028 
+L 90.228652 172.784361 
+L 72.878182 172.784361 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 176.981003 380.792 
 L 194.331473 380.792 
-L 194.331473 82.102349 
-L 176.981003 82.102349 
+L 194.331473 80.092917 
+L 176.981003 80.092917 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 281.083824 380.792 
 L 298.434295 380.792 
-L 298.434295 256.274243 
-L 281.083824 256.274243 
+L 298.434295 258.348304 
+L 281.083824 258.348304 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 385.186646 380.792 
 L 402.537116 380.792 
-L 402.537116 258.153165 
-L 385.186646 258.153165 
+L 402.537116 259.221444 
+L 385.186646 259.221444 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 489.289467 380.792 
 L 506.639937 380.792 
-L 506.639937 257.775305 
-L 489.289467 257.775305 
+L 506.639937 258.435398 
+L 489.289467 258.435398 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_15">
-    <!-- 846 ms -->
-    <g transform="translate(84.312792 166.500028) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_16">
-    <!-- 1.21 s -->
-    <g transform="translate(188.415613 77.102349) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_17">
-    <!-- 503 ms -->
-    <g transform="translate(292.518435 251.274243) rotate(-90) scale(0.1 -0.1)">
+    <!-- 823 ms -->
+    <g transform="translate(84.312792 167.784361) rotate(-90) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1218,17 +1171,17 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_18">
-    <!-- 496 ms -->
-    <g transform="translate(396.621256 253.153165) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_16">
+    <!-- 1.19 s -->
+    <g transform="translate(188.415613 75.092917) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1261,32 +1214,42 @@ Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 484 ms -->
+    <g transform="translate(292.518435 253.348304) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 481 ms -->
+    <g transform="translate(396.621256 254.221444) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_19">
-    <!-- 497 ms -->
-    <g transform="translate(500.724077 252.775305) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 484 ms -->
+    <g transform="translate(500.724077 253.435398) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1330,210 +1293,271 @@ z
    <g id="patch_12">
     <path d="M 90.228652 380.792 
 L 107.579122 380.792 
-L 107.579122 172.040655 
-L 90.228652 172.040655 
+L 107.579122 171.269831 
+L 90.228652 171.269831 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 107.579122 380.792 
 L 124.929592 380.792 
-L 124.929592 171.455098 
-L 107.579122 171.455098 
+L 124.929592 171.154902 
+L 107.579122 171.154902 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 124.929592 380.792 
 L 142.280063 380.792 
-L 142.280063 169.083402 
-L 124.929592 169.083402 
+L 142.280063 169.127807 
+L 124.929592 169.127807 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 142.280063 380.792 
 L 159.630533 380.792 
-L 159.630533 164.438839 
-L 142.280063 164.438839 
+L 159.630533 165.866582 
+L 142.280063 165.866582 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 194.331473 380.792 
 L 211.681944 380.792 
-L 211.681944 82.515261 
-L 194.331473 82.515261 
+L 211.681944 78.237249 
+L 194.331473 78.237249 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 211.681944 380.792 
 L 229.032414 380.792 
-L 229.032414 79.252703 
-L 211.681944 79.252703 
+L 229.032414 78.218526 
+L 211.681944 78.218526 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 229.032414 380.792 
 L 246.382884 380.792 
-L 246.382884 74.00737 
-L 229.032414 74.00737 
+L 246.382884 74.728487 
+L 229.032414 74.728487 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 246.382884 380.792 
 L 263.733354 380.792 
-L 263.733354 68.593911 
-L 246.382884 68.593911 
+L 263.733354 69.866443 
+L 246.382884 69.866443 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 298.434295 380.792 
 L 315.784765 380.792 
-L 315.784765 245.006849 
-L 298.434295 245.006849 
+L 315.784765 247.696038 
+L 298.434295 247.696038 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 315.784765 380.792 
 L 333.135235 380.792 
-L 333.135235 245.198077 
-L 315.784765 245.198077 
+L 333.135235 247.16817 
+L 315.784765 247.16817 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 333.135235 380.792 
 L 350.485705 380.792 
-L 350.485705 244.953088 
-L 333.135235 244.953088 
+L 350.485705 246.967525 
+L 333.135235 246.967525 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 350.485705 380.792 
 L 367.836176 380.792 
-L 367.836176 243.100863 
-L 350.485705 243.100863 
+L 367.836176 251.582871 
+L 350.485705 251.582871 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 402.537116 380.792 
 L 419.887586 380.792 
-L 419.887586 249.565468 
-L 402.537116 249.565468 
+L 419.887586 249.028761 
+L 402.537116 249.028761 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 419.887586 380.792 
 L 437.238056 380.792 
-L 437.238056 249.078713 
-L 419.887586 249.078713 
+L 437.238056 248.670785 
+L 419.887586 248.670785 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 437.238056 380.792 
 L 454.588527 380.792 
-L 454.588527 248.749249 
-L 437.238056 248.749249 
+L 454.588527 248.370683 
+L 437.238056 248.370683 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 454.588527 380.792 
 L 471.938997 380.792 
-L 471.938997 246.775503 
-L 454.588527 246.775503 
+L 471.938997 259.125719 
+L 454.588527 259.125719 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 506.639937 380.792 
 L 523.990408 380.792 
-L 523.990408 248.063599 
-L 506.639937 248.063599 
+L 523.990408 250.91932 
+L 506.639937 250.91932 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 523.990408 380.792 
 L 541.340878 380.792 
-L 541.340878 245.722544 
-L 523.990408 245.722544 
+L 541.340878 246.98438 
+L 523.990408 246.98438 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 541.340878 380.792 
 L 558.691348 380.792 
-L 558.691348 245.09308 
-L 541.340878 245.09308 
+L 558.691348 247.099142 
+L 541.340878 247.099142 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 558.691348 380.792 
 L 576.041818 380.792 
-L 576.041818 244.01814 
-L 558.691348 244.01814 
+L 576.041818 247.470218 
+L 558.691348 247.470218 
 z
-" clip-path="url(#pc6f8d9d5d7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p7e83713833)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_25">
-    <!-- 843 ms -->
-    <g transform="translate(101.663262 167.040655) rotate(-90) scale(0.1 -0.1)">
+    <!-- 829 ms -->
+    <g transform="translate(101.663262 166.269831) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 846 ms -->
-    <g transform="translate(119.013732 166.455098) rotate(-90) scale(0.1 -0.1)">
+    <!-- 829 ms -->
+    <g transform="translate(119.013732 166.154902) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- 855 ms -->
-    <g transform="translate(136.364203 164.083402) rotate(-90) scale(0.1 -0.1)">
+    <!-- 837 ms -->
+    <g transform="translate(136.364203 164.127807) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 874 ms -->
-    <g transform="translate(153.714673 159.438839) rotate(-90) scale(0.1 -0.1)">
+    <!-- 850 ms -->
+    <g transform="translate(153.714673 160.866582) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
+    <!-- 1.20 s -->
+    <g transform="translate(205.766083 73.237249) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 1.20 s -->
+    <g transform="translate(223.116554 73.218526) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_31">
     <!-- 1.21 s -->
-    <g transform="translate(205.766083 77.515261) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(240.467024 69.728487) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1542,66 +1566,44 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_30">
-    <!-- 1.22 s -->
-    <g transform="translate(223.116554 74.252703) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 1.24 s -->
-    <g transform="translate(240.467024 69.00737) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
    <g id="text_32">
-    <!-- 1.26 s -->
-    <g transform="translate(257.817494 63.593911) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.23 s -->
+    <g transform="translate(257.817494 64.866443) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 549 ms -->
-    <g transform="translate(309.868905 240.006849) rotate(-90) scale(0.1 -0.1)">
+    <!-- 526 ms -->
+    <g transform="translate(309.868905 242.696038) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 548 ms -->
-    <g transform="translate(327.219375 240.198077) rotate(-90) scale(0.1 -0.1)">
+    <!-- 529 ms -->
+    <g transform="translate(327.219375 242.16817) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 549 ms -->
-    <g transform="translate(344.569845 239.953088) rotate(-90) scale(0.1 -0.1)">
+    <!-- 529 ms -->
+    <g transform="translate(344.569845 241.967525) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1609,43 +1611,43 @@ z
     </g>
    </g>
    <g id="text_36">
-    <!-- 556 ms -->
-    <g transform="translate(361.920315 238.100863) rotate(-90) scale(0.1 -0.1)">
+    <!-- 511 ms -->
+    <g transform="translate(361.920315 246.582871) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 530 ms -->
-    <g transform="translate(413.971726 244.565468) rotate(-90) scale(0.1 -0.1)">
+    <!-- 521 ms -->
+    <g transform="translate(413.971726 244.028761) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 532 ms -->
-    <g transform="translate(431.322196 244.078713) rotate(-90) scale(0.1 -0.1)">
+    <!-- 523 ms -->
+    <g transform="translate(431.322196 243.670785) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 534 ms -->
-    <g transform="translate(448.672667 243.749249) rotate(-90) scale(0.1 -0.1)">
+    <!-- 524 ms -->
+    <g transform="translate(448.672667 243.370683) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1653,55 +1655,55 @@ z
     </g>
    </g>
    <g id="text_40">
-    <!-- 542 ms -->
-    <g transform="translate(466.023137 241.775503) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+    <!-- 481 ms -->
+    <g transform="translate(466.023137 254.125719) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- 536 ms -->
-    <g transform="translate(518.074547 243.063599) rotate(-90) scale(0.1 -0.1)">
+    <!-- 514 ms -->
+    <g transform="translate(518.074547 245.91932) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_42">
-    <!-- 546 ms -->
-    <g transform="translate(535.425018 240.722544) rotate(-90) scale(0.1 -0.1)">
+    <!-- 529 ms -->
+    <g transform="translate(535.425018 241.98438) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_43">
-    <!-- 548 ms -->
-    <g transform="translate(552.775488 240.09308) rotate(-90) scale(0.1 -0.1)">
+    <!-- 529 ms -->
+    <g transform="translate(552.775488 242.099142) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- 553 ms -->
-    <g transform="translate(570.125958 239.01814) rotate(-90) scale(0.1 -0.1)">
+    <!-- 527 ms -->
+    <g transform="translate(570.125958 242.470218) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -2021,7 +2023,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pc6f8d9d5d7">
+  <clipPath id="p7e83713833">
    <rect x="47.72" y="26.88" width="553.48" height="353.912"/>
   </clipPath>
  </defs>

--- a/docs/_static/chunk_lines_simple_dark.svg
+++ b/docs/_static/chunk_lines_simple_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:07.593947</dc:date>
+    <dc:date>2024-05-06T19:15:03.362147</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -31,11 +31,11 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 54.11 380.792 
+    <path d="M 54.02 380.792 
 L 601.2 380.792 
 L 601.2 26.88 
-L 54.11 26.88 
-L 54.11 380.792 
+L 54.02 26.88 
+L 54.02 380.792 
 z
 " style="fill: none"/>
    </g>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7e63513b32" d="M 0 0 
+       <path id="m0a79c131ca" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7e63513b32" x="121.853119" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0a79c131ca" x="121.774263" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Separate -->
-      <g style="fill: #ffffff" transform="translate(99.207807 395.390437) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(99.128951 395.390437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
@@ -223,12 +223,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7e63513b32" x="224.75406" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0a79c131ca" x="224.692132" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Separate -->
-      <g style="fill: #ffffff" transform="translate(202.108747 395.390437) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(202.046819 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -239,7 +239,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g style="fill: #ffffff" transform="translate(211.952497 406.58825) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(211.890569 406.58825) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -320,12 +320,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7e63513b32" x="327.655" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0a79c131ca" x="327.61" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g style="fill: #ffffff" transform="translate(311.762031 395.390437) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(311.717031 395.390437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -409,7 +409,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g style="fill: #ffffff" transform="translate(302.251094 406.58825) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(302.206094 406.58825) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -491,7 +491,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g style="fill: #ffffff" transform="translate(314.853438 417.786062) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(314.808438 417.786062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -502,12 +502,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7e63513b32" x="430.55594" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0a79c131ca" x="430.527868" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g style="fill: #ffffff" transform="translate(414.662972 395.390437) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(414.6349 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -515,7 +515,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g style="fill: #ffffff" transform="translate(405.152034 406.58825) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(405.123962 406.58825) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -526,7 +526,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g style="fill: #ffffff" transform="translate(415.458284 417.786062) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(415.430212 417.786062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -614,12 +614,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7e63513b32" x="533.456881" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0a79c131ca" x="533.445737" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Chunk -->
-      <g style="fill: #ffffff" transform="translate(517.563912 395.390437) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(517.552768 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -627,7 +627,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g style="fill: #ffffff" transform="translate(508.052975 406.58825) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(508.04183 406.58825) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -638,7 +638,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Nan -->
-      <g style="fill: #ffffff" transform="translate(523.483443 417.786062) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(523.472299 417.786062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4e" d="M 628 4666 
 L 1478 4666 
@@ -664,23 +664,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_6">
-      <path d="M 54.11 380.792 
+      <path d="M 54.02 380.792 
 L 601.2 380.792 
-" clip-path="url(#p11ab3c67ec)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p75e73168d9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="ma7453532d2" d="M 0 0 
+       <path id="m2c26fb983a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma7453532d2" x="54.11" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2c26fb983a" x="54.02" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 0.00 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 384.591219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 384.591219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -720,18 +720,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_8">
-      <path d="M 54.11 337.887195 
-L 601.2 337.887195 
-" clip-path="url(#p11ab3c67ec)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 336.096677 
+L 601.2 336.096677 
+" clip-path="url(#p75e73168d9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#ma7453532d2" x="54.11" y="337.887195" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2c26fb983a" x="54.02" y="336.096677" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.02 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 341.686413) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 339.895896) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -767,18 +767,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_10">
-      <path d="M 54.11 294.982389 
-L 601.2 294.982389 
-" clip-path="url(#p11ab3c67ec)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 291.401355 
+L 601.2 291.401355 
+" clip-path="url(#p75e73168d9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#ma7453532d2" x="54.11" y="294.982389" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2c26fb983a" x="54.02" y="291.401355" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.04 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 298.781608) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 295.200573) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -809,18 +809,18 @@ z
     </g>
     <g id="ytick_4">
      <g id="line2d_12">
-      <path d="M 54.11 252.077584 
-L 601.2 252.077584 
-" clip-path="url(#p11ab3c67ec)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 246.706032 
+L 601.2 246.706032 
+" clip-path="url(#p75e73168d9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#ma7453532d2" x="54.11" y="252.077584" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2c26fb983a" x="54.02" y="246.706032" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.06 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 255.876803) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 250.505251) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -862,18 +862,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_14">
-      <path d="M 54.11 209.172778 
-L 601.2 209.172778 
-" clip-path="url(#p11ab3c67ec)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 202.010709 
+L 601.2 202.010709 
+" clip-path="url(#p75e73168d9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#ma7453532d2" x="54.11" y="209.172778" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2c26fb983a" x="54.02" y="202.010709" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.08 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 212.971997) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 205.809928) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -924,18 +924,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_16">
-      <path d="M 54.11 166.267973 
-L 601.2 166.267973 
-" clip-path="url(#p11ab3c67ec)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 157.315387 
+L 601.2 157.315387 
+" clip-path="url(#p75e73168d9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#ma7453532d2" x="54.11" y="166.267973" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2c26fb983a" x="54.02" y="157.315387" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.10 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 170.067192) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 161.114605) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -961,18 +961,18 @@ z
     </g>
     <g id="ytick_7">
      <g id="line2d_18">
-      <path d="M 54.11 123.363168 
-L 601.2 123.363168 
-" clip-path="url(#p11ab3c67ec)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 112.620064 
+L 601.2 112.620064 
+" clip-path="url(#p75e73168d9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#ma7453532d2" x="54.11" y="123.363168" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2c26fb983a" x="54.02" y="112.620064" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.12 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 127.162386) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 116.419283) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -982,18 +982,18 @@ L 601.2 123.363168
     </g>
     <g id="ytick_8">
      <g id="line2d_20">
-      <path d="M 54.11 80.458362 
-L 601.2 80.458362 
-" clip-path="url(#p11ab3c67ec)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 67.924741 
+L 601.2 67.924741 
+" clip-path="url(#p75e73168d9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#ma7453532d2" x="54.11" y="80.458362" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2c26fb983a" x="54.02" y="67.924741" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.14 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 84.257581) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 71.72396) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1001,30 +1001,9 @@ L 601.2 80.458362
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_22">
-      <path d="M 54.11 37.553557 
-L 601.2 37.553557 
-" clip-path="url(#p11ab3c67ec)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_23">
-      <g>
-       <use xlink:href="#ma7453532d2" x="54.11" y="37.553557" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_14">
-      <!-- 0.16 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 41.352776) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_15">
+    <g id="text_14">
      <!-- Time (seconds) -->
-     <g style="fill: #ffffff" transform="translate(18.764688 241.997719) rotate(-90) scale(0.1 -0.1)">
+     <g style="fill: #ffffff" transform="translate(18.674688 241.997719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1104,8 +1083,8 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 54.11 380.792 
-L 54.11 26.88 
+    <path d="M 54.02 380.792 
+L 54.02 26.88 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
@@ -1114,749 +1093,732 @@ L 601.2 26.88
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 54.11 380.792 
+    <path d="M 54.02 380.792 
 L 601.2 380.792 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 54.11 26.88 
+    <path d="M 54.02 26.88 
 L 601.2 26.88 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 78.977727 380.792 
-L 96.127884 380.792 
-L 96.127884 114.329107 
-L 78.977727 114.329107 
+    <path d="M 78.891818 380.792 
+L 96.044796 380.792 
+L 96.044796 113.463594 
+L 78.891818 113.463594 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 181.878668 380.792 
-L 199.028824 380.792 
-L 199.028824 114.457782 
-L 181.878668 114.457782 
+    <path d="M 181.809687 380.792 
+L 198.962665 380.792 
+L 198.962665 117.830837 
+L 181.809687 117.830837 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 284.779608 380.792 
-L 301.929765 380.792 
-L 301.929765 113.57765 
-L 284.779608 113.57765 
+    <path d="M 284.727555 380.792 
+L 301.880533 380.792 
+L 301.880533 113.895232 
+L 284.727555 113.895232 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 387.680549 380.792 
-L 404.830705 380.792 
-L 404.830705 115.229027 
-L 387.680549 115.229027 
+    <path d="M 387.645423 380.792 
+L 404.798401 380.792 
+L 404.798401 113.626349 
+L 387.645423 113.626349 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 490.581489 380.792 
-L 507.731646 380.792 
-L 507.731646 114.457207 
-L 490.581489 114.457207 
+    <path d="M 490.563292 380.792 
+L 507.71627 380.792 
+L 507.71627 114.232108 
+L 490.563292 114.232108 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_16">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(90.312181 109.329107) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_15">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(90.227682 108.463594) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(193.145551 112.830837) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_17">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(193.213121 109.457782) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(296.063419 108.895232) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_18">
-    <!-- 125 ms -->
-    <g style="fill: #ffffff" transform="translate(296.114062 108.57765) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(398.981287 108.626349) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_19">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(399.015002 110.229027) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(501.899156 109.232108) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(501.915942 109.457207) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    <!--  1 -->
+    <g transform="translate(90.227682 380.792) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_21">
     <!--  1 -->
-    <g transform="translate(90.312181 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(193.145551 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_22">
     <!--  1 -->
-    <g transform="translate(193.213121 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(296.063419 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_23">
     <!--  1 -->
-    <g transform="translate(296.114062 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(398.981287 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_24">
     <!--  1 -->
-    <g transform="translate(399.015002 380.792) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!--  1 -->
-    <g transform="translate(501.915942 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(501.899156 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="patch_12">
-    <path d="M 96.127884 380.792 
-L 113.278041 380.792 
-L 113.278041 115.949237 
-L 96.127884 115.949237 
+    <path d="M 96.044796 380.792 
+L 113.197774 380.792 
+L 113.197774 116.202351 
+L 96.044796 116.202351 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 113.278041 380.792 
-L 130.428197 380.792 
-L 130.428197 115.4112 
-L 113.278041 115.4112 
+    <path d="M 113.197774 380.792 
+L 130.350752 380.792 
+L 130.350752 117.639788 
+L 113.197774 117.639788 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 130.428197 380.792 
-L 147.578354 380.792 
-L 147.578354 111.706493 
-L 130.428197 111.706493 
+    <path d="M 130.350752 380.792 
+L 147.50373 380.792 
+L 147.50373 111.412623 
+L 130.350752 111.412623 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 147.578354 380.792 
-L 164.728511 380.792 
-L 164.728511 112.542642 
-L 147.578354 112.542642 
+    <path d="M 147.50373 380.792 
+L 164.656708 380.792 
+L 164.656708 111.485985 
+L 147.50373 111.485985 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 199.028824 380.792 
-L 216.178981 380.792 
-L 216.178981 116.097227 
-L 199.028824 116.097227 
+    <path d="M 198.962665 380.792 
+L 216.115643 380.792 
+L 216.115643 120.471025 
+L 198.962665 120.471025 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 216.178981 380.792 
-L 233.329138 380.792 
-L 233.329138 113.021289 
-L 216.178981 113.021289 
+    <path d="M 216.115643 380.792 
+L 233.268621 380.792 
+L 233.268621 118.28467 
+L 216.115643 118.28467 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 233.329138 380.792 
-L 250.479295 380.792 
-L 250.479295 111.144762 
-L 233.329138 111.144762 
+    <path d="M 233.268621 380.792 
+L 250.421599 380.792 
+L 250.421599 113.189992 
+L 233.268621 113.189992 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 250.479295 380.792 
-L 267.629451 380.792 
-L 267.629451 112.791722 
-L 250.479295 112.791722 
+    <path d="M 250.421599 380.792 
+L 267.574577 380.792 
+L 267.574577 112.230722 
+L 250.421599 112.230722 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 301.929765 380.792 
-L 319.079922 380.792 
-L 319.079922 116.818363 
-L 301.929765 116.818363 
+    <path d="M 301.880533 380.792 
+L 319.033511 380.792 
+L 319.033511 119.884875 
+L 301.880533 119.884875 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 319.079922 380.792 
-L 336.230078 380.792 
-L 336.230078 118.110981 
-L 319.079922 118.110981 
+    <path d="M 319.033511 380.792 
+L 336.186489 380.792 
+L 336.186489 114.070066 
+L 319.033511 114.070066 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 336.230078 380.792 
-L 353.380235 380.792 
-L 353.380235 114.094874 
-L 336.230078 114.094874 
+    <path d="M 336.186489 380.792 
+L 353.339467 380.792 
+L 353.339467 113.911853 
+L 336.186489 113.911853 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 353.380235 380.792 
-L 370.530392 380.792 
-L 370.530392 112.493026 
-L 353.380235 112.493026 
+    <path d="M 353.339467 380.792 
+L 370.492445 380.792 
+L 370.492445 111.901317 
+L 353.339467 111.901317 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 404.830705 380.792 
-L 421.980862 380.792 
-L 421.980862 116.232398 
-L 404.830705 116.232398 
+    <path d="M 404.798401 380.792 
+L 421.951379 380.792 
+L 421.951379 116.111189 
+L 404.798401 116.111189 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 421.980862 380.792 
-L 439.131019 380.792 
-L 439.131019 115.104331 
-L 421.980862 115.104331 
+    <path d="M 421.951379 380.792 
+L 439.104357 380.792 
+L 439.104357 113.945911 
+L 421.951379 113.945911 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 439.131019 380.792 
-L 456.281176 380.792 
-L 456.281176 113.237022 
-L 439.131019 113.237022 
+    <path d="M 439.104357 380.792 
+L 456.257335 380.792 
+L 456.257335 113.459227 
+L 439.104357 113.459227 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 456.281176 380.792 
-L 473.431332 380.792 
-L 473.431332 113.068814 
-L 456.281176 113.068814 
+    <path d="M 456.257335 380.792 
+L 473.410313 380.792 
+L 473.410313 111.639471 
+L 456.257335 111.639471 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 507.731646 380.792 
-L 524.881803 380.792 
-L 524.881803 117.024479 
-L 507.731646 117.024479 
+    <path d="M 507.71627 380.792 
+L 524.869248 380.792 
+L 524.869248 116.217778 
+L 507.71627 116.217778 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
-    <path d="M 524.881803 380.792 
-L 542.031959 380.792 
-L 542.031959 114.680531 
-L 524.881803 114.680531 
+    <path d="M 524.869248 380.792 
+L 542.022226 380.792 
+L 542.022226 114.398042 
+L 524.869248 114.398042 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
-    <path d="M 542.031959 380.792 
-L 559.182116 380.792 
-L 559.182116 114.329903 
-L 542.031959 114.329903 
+    <path d="M 542.022226 380.792 
+L 559.175204 380.792 
+L 559.175204 111.144762 
+L 542.022226 111.144762 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
-    <path d="M 559.182116 380.792 
-L 576.332273 380.792 
-L 576.332273 111.784565 
-L 559.182116 111.784565 
+    <path d="M 559.175204 380.792 
+L 576.328182 380.792 
+L 576.328182 111.893976 
+L 559.175204 111.893976 
 z
-" clip-path="url(#p11ab3c67ec)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p75e73168d9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_25">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(107.38066 111.202351) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
    </g>
    <g id="text_26">
-    <!-- 123 ms -->
-    <g style="fill: #ffffff" transform="translate(107.462337 110.949237) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(124.533638 112.639788) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(124.612494 110.4112) rotate(-90) scale(0.1 -0.1)">
+    <!-- 121 ms -->
+    <g style="fill: #ffffff" transform="translate(141.686616 106.412623) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 125 ms -->
-    <g style="fill: #ffffff" transform="translate(141.762651 106.706493) rotate(-90) scale(0.1 -0.1)">
+    <!-- 121 ms -->
+    <g style="fill: #ffffff" transform="translate(158.839594 106.485985) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 125 ms -->
-    <g style="fill: #ffffff" transform="translate(158.912808 107.542642) rotate(-90) scale(0.1 -0.1)">
+    <!-- 116 ms -->
+    <g style="fill: #ffffff" transform="translate(210.298529 115.471025) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 123 ms -->
-    <g style="fill: #ffffff" transform="translate(210.363278 111.097227) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 125 ms -->
-    <g style="fill: #ffffff" transform="translate(227.513435 108.021289) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 126 ms -->
-    <g style="fill: #ffffff" transform="translate(244.663591 106.144762) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_33">
-    <!-- 125 ms -->
-    <g style="fill: #ffffff" transform="translate(261.813748 107.791722) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_30">
+    <!-- 117 ms -->
+    <g style="fill: #ffffff" transform="translate(227.451507 113.28467) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(244.604485 108.189992) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(261.757463 107.230722) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- 117 ms -->
+    <g style="fill: #ffffff" transform="translate(313.216397 114.884875) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 123 ms -->
-    <g style="fill: #ffffff" transform="translate(313.264218 111.818363) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(330.369375 109.070066) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 122 ms -->
-    <g style="fill: #ffffff" transform="translate(330.414375 113.110981) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(347.522353 108.911853) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(347.564532 109.094874) rotate(-90) scale(0.1 -0.1)">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(364.675331 106.901317) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 125 ms -->
-    <g style="fill: #ffffff" transform="translate(364.714688 107.493026) rotate(-90) scale(0.1 -0.1)">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(416.134265 111.111189) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 123 ms -->
-    <g style="fill: #ffffff" transform="translate(416.165159 111.232398) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(433.287243 108.945911) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(433.315315 110.104331) rotate(-90) scale(0.1 -0.1)">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(450.440221 108.459227) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_40">
-    <!-- 125 ms -->
-    <g style="fill: #ffffff" transform="translate(450.465472 108.237022) rotate(-90) scale(0.1 -0.1)">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(467.593199 106.639471) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- 125 ms -->
-    <g style="fill: #ffffff" transform="translate(467.615629 108.068814) rotate(-90) scale(0.1 -0.1)">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(519.052134 111.217778) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_42">
-    <!-- 123 ms -->
-    <g style="fill: #ffffff" transform="translate(519.066099 112.024479) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(536.205112 109.398042) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_43">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(536.216256 109.680531) rotate(-90) scale(0.1 -0.1)">
+    <!-- 121 ms -->
+    <g style="fill: #ffffff" transform="translate(553.35809 106.144762) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(553.366413 109.329903) rotate(-90) scale(0.1 -0.1)">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(570.511068 106.893976) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- 125 ms -->
-    <g style="fill: #ffffff" transform="translate(570.516569 106.784565) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    <!--  4 -->
+    <g transform="translate(107.38066 380.792) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_46">
-    <!--  4 -->
-    <g transform="translate(107.462337 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(124.533638 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_47">
-    <!--  12 -->
-    <g transform="translate(124.612494 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(141.686616 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_48">
-    <!--  40 -->
-    <g transform="translate(141.762651 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(158.839594 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_49">
-    <!--  120 -->
-    <g transform="translate(158.912808 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(210.298529 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_50">
-    <!--  4 -->
-    <g transform="translate(210.363278 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(227.451507 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_51">
-    <!--  12 -->
-    <g transform="translate(227.513435 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(244.604485 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_52">
-    <!--  40 -->
-    <g transform="translate(244.663591 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(261.757463 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_53">
-    <!--  120 -->
-    <g transform="translate(261.813748 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(313.216397 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_54">
-    <!--  4 -->
-    <g transform="translate(313.264218 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(330.369375 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_55">
-    <!--  12 -->
-    <g transform="translate(330.414375 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(347.522353 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_56">
-    <!--  40 -->
-    <g transform="translate(347.564532 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(364.675331 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_57">
-    <!--  120 -->
-    <g transform="translate(364.714688 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(416.134265 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_58">
-    <!--  4 -->
-    <g transform="translate(416.165159 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(433.287243 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_59">
-    <!--  12 -->
-    <g transform="translate(433.315315 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(450.440221 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_60">
-    <!--  40 -->
-    <g transform="translate(450.465472 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(467.593199 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_61">
-    <!--  120 -->
-    <g transform="translate(467.615629 380.792) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-    </g>
-   </g>
-   <g id="text_62">
     <!--  4 -->
-    <g transform="translate(519.066099 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(519.052134 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_63">
+   <g id="text_62">
     <!--  12 -->
-    <g transform="translate(536.216256 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(536.205112 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_64">
+   <g id="text_63">
     <!--  40 -->
-    <g transform="translate(553.366413 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(553.35809 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_65">
+   <g id="text_64">
     <!--  120 -->
-    <g transform="translate(570.516569 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(570.511068 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_66">
+   <g id="text_65">
     <!-- lines simple n=1000 -->
-    <g style="fill: #ffffff" transform="translate(265.9825 20.88) scale(0.12 -0.12)">
+    <g style="fill: #ffffff" transform="translate(265.9375 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -1922,7 +1884,7 @@ L 348.146875 43.117188
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_67">
+    <g id="text_66">
      <!-- serial no mask -->
      <g style="fill: #ffffff" transform="translate(376.146875 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2008,8 +1970,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p11ab3c67ec">
-   <rect x="54.11" y="26.88" width="547.09" height="353.912"/>
+  <clipPath id="p75e73168d9">
+   <rect x="54.02" y="26.88" width="547.18" height="353.912"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/_static/chunk_lines_simple_light.svg
+++ b/docs/_static/chunk_lines_simple_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:07.403427</dc:date>
+    <dc:date>2024-05-06T19:15:03.185879</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -31,11 +31,11 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 54.11 380.792 
+    <path d="M 54.02 380.792 
 L 601.2 380.792 
 L 601.2 26.88 
-L 54.11 26.88 
-L 54.11 380.792 
+L 54.02 26.88 
+L 54.02 380.792 
 z
 " style="fill: none"/>
    </g>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m269b149878" d="M 0 0 
+       <path id="m37617a7dd4" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m269b149878" x="121.853119" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m37617a7dd4" x="121.774263" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Separate -->
-      <g transform="translate(99.207807 395.390437) scale(0.1 -0.1)">
+      <g transform="translate(99.128951 395.390437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
@@ -223,12 +223,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m269b149878" x="224.75406" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m37617a7dd4" x="224.692132" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Separate -->
-      <g transform="translate(202.108747 395.390437) scale(0.1 -0.1)">
+      <g transform="translate(202.046819 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-65" x="63.476562"/>
        <use xlink:href="#DejaVuSans-70" x="125"/>
@@ -239,7 +239,7 @@ z
        <use xlink:href="#DejaVuSans-65" x="391.357422"/>
       </g>
       <!-- Code -->
-      <g transform="translate(211.952497 406.58825) scale(0.1 -0.1)">
+      <g transform="translate(211.890569 406.58825) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -320,12 +320,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m269b149878" x="327.655" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m37617a7dd4" x="327.61" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g transform="translate(311.762031 395.390437) scale(0.1 -0.1)">
+      <g transform="translate(311.717031 395.390437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -409,7 +409,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(302.251094 406.58825) scale(0.1 -0.1)">
+      <g transform="translate(302.206094 406.58825) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -491,7 +491,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(314.853438 417.786062) scale(0.1 -0.1)">
+      <g transform="translate(314.808438 417.786062) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -502,12 +502,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m269b149878" x="430.55594" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m37617a7dd4" x="430.527868" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g transform="translate(414.662972 395.390437) scale(0.1 -0.1)">
+      <g transform="translate(414.6349 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -515,7 +515,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(405.152034 406.58825) scale(0.1 -0.1)">
+      <g transform="translate(405.123962 406.58825) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -526,7 +526,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(415.458284 417.786062) scale(0.1 -0.1)">
+      <g transform="translate(415.430212 417.786062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -614,12 +614,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m269b149878" x="533.456881" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m37617a7dd4" x="533.445737" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Chunk -->
-      <g transform="translate(517.563912 395.390437) scale(0.1 -0.1)">
+      <g transform="translate(517.552768 395.390437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -627,7 +627,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(508.052975 406.58825) scale(0.1 -0.1)">
+      <g transform="translate(508.04183 406.58825) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -638,7 +638,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Nan -->
-      <g transform="translate(523.483443 417.786062) scale(0.1 -0.1)">
+      <g transform="translate(523.472299 417.786062) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4e" d="M 628 4666 
 L 1478 4666 
@@ -664,23 +664,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_6">
-      <path d="M 54.11 380.792 
+      <path d="M 54.02 380.792 
 L 601.2 380.792 
-" clip-path="url(#p5b389b310c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p9a930eb99a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="m96b0151c1c" d="M 0 0 
+       <path id="m56e52de2af" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m96b0151c1c" x="54.11" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m56e52de2af" x="54.02" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 0.00 -->
-      <g transform="translate(24.844375 384.591219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 384.591219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -720,18 +720,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_8">
-      <path d="M 54.11 337.887195 
-L 601.2 337.887195 
-" clip-path="url(#p5b389b310c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 336.096677 
+L 601.2 336.096677 
+" clip-path="url(#p9a930eb99a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m96b0151c1c" x="54.11" y="337.887195" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m56e52de2af" x="54.02" y="336.096677" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.02 -->
-      <g transform="translate(24.844375 341.686413) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 339.895896) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -767,18 +767,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_10">
-      <path d="M 54.11 294.982389 
-L 601.2 294.982389 
-" clip-path="url(#p5b389b310c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 291.401355 
+L 601.2 291.401355 
+" clip-path="url(#p9a930eb99a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m96b0151c1c" x="54.11" y="294.982389" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m56e52de2af" x="54.02" y="291.401355" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.04 -->
-      <g transform="translate(24.844375 298.781608) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 295.200573) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -809,18 +809,18 @@ z
     </g>
     <g id="ytick_4">
      <g id="line2d_12">
-      <path d="M 54.11 252.077584 
-L 601.2 252.077584 
-" clip-path="url(#p5b389b310c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 246.706032 
+L 601.2 246.706032 
+" clip-path="url(#p9a930eb99a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m96b0151c1c" x="54.11" y="252.077584" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m56e52de2af" x="54.02" y="246.706032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.06 -->
-      <g transform="translate(24.844375 255.876803) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 250.505251) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -862,18 +862,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_14">
-      <path d="M 54.11 209.172778 
-L 601.2 209.172778 
-" clip-path="url(#p5b389b310c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 202.010709 
+L 601.2 202.010709 
+" clip-path="url(#p9a930eb99a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m96b0151c1c" x="54.11" y="209.172778" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m56e52de2af" x="54.02" y="202.010709" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.08 -->
-      <g transform="translate(24.844375 212.971997) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 205.809928) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -924,18 +924,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_16">
-      <path d="M 54.11 166.267973 
-L 601.2 166.267973 
-" clip-path="url(#p5b389b310c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 157.315387 
+L 601.2 157.315387 
+" clip-path="url(#p9a930eb99a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m96b0151c1c" x="54.11" y="166.267973" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m56e52de2af" x="54.02" y="157.315387" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.10 -->
-      <g transform="translate(24.844375 170.067192) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 161.114605) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -961,18 +961,18 @@ z
     </g>
     <g id="ytick_7">
      <g id="line2d_18">
-      <path d="M 54.11 123.363168 
-L 601.2 123.363168 
-" clip-path="url(#p5b389b310c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 112.620064 
+L 601.2 112.620064 
+" clip-path="url(#p9a930eb99a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m96b0151c1c" x="54.11" y="123.363168" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m56e52de2af" x="54.02" y="112.620064" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.12 -->
-      <g transform="translate(24.844375 127.162386) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 116.419283) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -982,18 +982,18 @@ L 601.2 123.363168
     </g>
     <g id="ytick_8">
      <g id="line2d_20">
-      <path d="M 54.11 80.458362 
-L 601.2 80.458362 
-" clip-path="url(#p5b389b310c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 67.924741 
+L 601.2 67.924741 
+" clip-path="url(#p9a930eb99a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m96b0151c1c" x="54.11" y="80.458362" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m56e52de2af" x="54.02" y="67.924741" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.14 -->
-      <g transform="translate(24.844375 84.257581) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 71.72396) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1001,30 +1001,9 @@ L 601.2 80.458362
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_22">
-      <path d="M 54.11 37.553557 
-L 601.2 37.553557 
-" clip-path="url(#p5b389b310c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_23">
-      <g>
-       <use xlink:href="#m96b0151c1c" x="54.11" y="37.553557" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_14">
-      <!-- 0.16 -->
-      <g transform="translate(24.844375 41.352776) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_15">
+    <g id="text_14">
      <!-- Time (seconds) -->
-     <g transform="translate(18.764688 241.997719) rotate(-90) scale(0.1 -0.1)">
+     <g transform="translate(18.674688 241.997719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -1104,8 +1083,8 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 54.11 380.792 
-L 54.11 26.88 
+    <path d="M 54.02 380.792 
+L 54.02 26.88 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
@@ -1114,749 +1093,732 @@ L 601.2 26.88
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 54.11 380.792 
+    <path d="M 54.02 380.792 
 L 601.2 380.792 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 54.11 26.88 
+    <path d="M 54.02 26.88 
 L 601.2 26.88 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 78.977727 380.792 
-L 96.127884 380.792 
-L 96.127884 114.329107 
-L 78.977727 114.329107 
+    <path d="M 78.891818 380.792 
+L 96.044796 380.792 
+L 96.044796 113.463594 
+L 78.891818 113.463594 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 181.878668 380.792 
-L 199.028824 380.792 
-L 199.028824 114.457782 
-L 181.878668 114.457782 
+    <path d="M 181.809687 380.792 
+L 198.962665 380.792 
+L 198.962665 117.830837 
+L 181.809687 117.830837 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 284.779608 380.792 
-L 301.929765 380.792 
-L 301.929765 113.57765 
-L 284.779608 113.57765 
+    <path d="M 284.727555 380.792 
+L 301.880533 380.792 
+L 301.880533 113.895232 
+L 284.727555 113.895232 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 387.680549 380.792 
-L 404.830705 380.792 
-L 404.830705 115.229027 
-L 387.680549 115.229027 
+    <path d="M 387.645423 380.792 
+L 404.798401 380.792 
+L 404.798401 113.626349 
+L 387.645423 113.626349 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 490.581489 380.792 
-L 507.731646 380.792 
-L 507.731646 114.457207 
-L 490.581489 114.457207 
+    <path d="M 490.563292 380.792 
+L 507.71627 380.792 
+L 507.71627 114.232108 
+L 490.563292 114.232108 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_16">
-    <!-- 124 ms -->
-    <g transform="translate(90.312181 109.329107) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_15">
+    <!-- 120 ms -->
+    <g transform="translate(90.227682 108.463594) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 118 ms -->
+    <g transform="translate(193.145551 112.830837) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_17">
-    <!-- 124 ms -->
-    <g transform="translate(193.213121 109.457782) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g transform="translate(296.063419 108.895232) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_18">
-    <!-- 125 ms -->
-    <g transform="translate(296.114062 108.57765) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 120 ms -->
+    <g transform="translate(398.981287 108.626349) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_19">
-    <!-- 124 ms -->
-    <g transform="translate(399.015002 110.229027) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g transform="translate(501.899156 109.232108) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 124 ms -->
-    <g transform="translate(501.915942 109.457207) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    <!--  1 -->
+    <g transform="translate(90.227682 380.792) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_21">
     <!--  1 -->
-    <g transform="translate(90.312181 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(193.145551 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_22">
     <!--  1 -->
-    <g transform="translate(193.213121 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(296.063419 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_23">
     <!--  1 -->
-    <g transform="translate(296.114062 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(398.981287 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_24">
     <!--  1 -->
-    <g transform="translate(399.015002 380.792) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!--  1 -->
-    <g transform="translate(501.915942 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(501.899156 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="patch_12">
-    <path d="M 96.127884 380.792 
-L 113.278041 380.792 
-L 113.278041 115.949237 
-L 96.127884 115.949237 
+    <path d="M 96.044796 380.792 
+L 113.197774 380.792 
+L 113.197774 116.202351 
+L 96.044796 116.202351 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 113.278041 380.792 
-L 130.428197 380.792 
-L 130.428197 115.4112 
-L 113.278041 115.4112 
+    <path d="M 113.197774 380.792 
+L 130.350752 380.792 
+L 130.350752 117.639788 
+L 113.197774 117.639788 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 130.428197 380.792 
-L 147.578354 380.792 
-L 147.578354 111.706493 
-L 130.428197 111.706493 
+    <path d="M 130.350752 380.792 
+L 147.50373 380.792 
+L 147.50373 111.412623 
+L 130.350752 111.412623 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 147.578354 380.792 
-L 164.728511 380.792 
-L 164.728511 112.542642 
-L 147.578354 112.542642 
+    <path d="M 147.50373 380.792 
+L 164.656708 380.792 
+L 164.656708 111.485985 
+L 147.50373 111.485985 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 199.028824 380.792 
-L 216.178981 380.792 
-L 216.178981 116.097227 
-L 199.028824 116.097227 
+    <path d="M 198.962665 380.792 
+L 216.115643 380.792 
+L 216.115643 120.471025 
+L 198.962665 120.471025 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 216.178981 380.792 
-L 233.329138 380.792 
-L 233.329138 113.021289 
-L 216.178981 113.021289 
+    <path d="M 216.115643 380.792 
+L 233.268621 380.792 
+L 233.268621 118.28467 
+L 216.115643 118.28467 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 233.329138 380.792 
-L 250.479295 380.792 
-L 250.479295 111.144762 
-L 233.329138 111.144762 
+    <path d="M 233.268621 380.792 
+L 250.421599 380.792 
+L 250.421599 113.189992 
+L 233.268621 113.189992 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 250.479295 380.792 
-L 267.629451 380.792 
-L 267.629451 112.791722 
-L 250.479295 112.791722 
+    <path d="M 250.421599 380.792 
+L 267.574577 380.792 
+L 267.574577 112.230722 
+L 250.421599 112.230722 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 301.929765 380.792 
-L 319.079922 380.792 
-L 319.079922 116.818363 
-L 301.929765 116.818363 
+    <path d="M 301.880533 380.792 
+L 319.033511 380.792 
+L 319.033511 119.884875 
+L 301.880533 119.884875 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 319.079922 380.792 
-L 336.230078 380.792 
-L 336.230078 118.110981 
-L 319.079922 118.110981 
+    <path d="M 319.033511 380.792 
+L 336.186489 380.792 
+L 336.186489 114.070066 
+L 319.033511 114.070066 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 336.230078 380.792 
-L 353.380235 380.792 
-L 353.380235 114.094874 
-L 336.230078 114.094874 
+    <path d="M 336.186489 380.792 
+L 353.339467 380.792 
+L 353.339467 113.911853 
+L 336.186489 113.911853 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 353.380235 380.792 
-L 370.530392 380.792 
-L 370.530392 112.493026 
-L 353.380235 112.493026 
+    <path d="M 353.339467 380.792 
+L 370.492445 380.792 
+L 370.492445 111.901317 
+L 353.339467 111.901317 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 404.830705 380.792 
-L 421.980862 380.792 
-L 421.980862 116.232398 
-L 404.830705 116.232398 
+    <path d="M 404.798401 380.792 
+L 421.951379 380.792 
+L 421.951379 116.111189 
+L 404.798401 116.111189 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 421.980862 380.792 
-L 439.131019 380.792 
-L 439.131019 115.104331 
-L 421.980862 115.104331 
+    <path d="M 421.951379 380.792 
+L 439.104357 380.792 
+L 439.104357 113.945911 
+L 421.951379 113.945911 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 439.131019 380.792 
-L 456.281176 380.792 
-L 456.281176 113.237022 
-L 439.131019 113.237022 
+    <path d="M 439.104357 380.792 
+L 456.257335 380.792 
+L 456.257335 113.459227 
+L 439.104357 113.459227 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 456.281176 380.792 
-L 473.431332 380.792 
-L 473.431332 113.068814 
-L 456.281176 113.068814 
+    <path d="M 456.257335 380.792 
+L 473.410313 380.792 
+L 473.410313 111.639471 
+L 456.257335 111.639471 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 507.731646 380.792 
-L 524.881803 380.792 
-L 524.881803 117.024479 
-L 507.731646 117.024479 
+    <path d="M 507.71627 380.792 
+L 524.869248 380.792 
+L 524.869248 116.217778 
+L 507.71627 116.217778 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
-    <path d="M 524.881803 380.792 
-L 542.031959 380.792 
-L 542.031959 114.680531 
-L 524.881803 114.680531 
+    <path d="M 524.869248 380.792 
+L 542.022226 380.792 
+L 542.022226 114.398042 
+L 524.869248 114.398042 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
-    <path d="M 542.031959 380.792 
-L 559.182116 380.792 
-L 559.182116 114.329903 
-L 542.031959 114.329903 
+    <path d="M 542.022226 380.792 
+L 559.175204 380.792 
+L 559.175204 111.144762 
+L 542.022226 111.144762 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
-    <path d="M 559.182116 380.792 
-L 576.332273 380.792 
-L 576.332273 111.784565 
-L 559.182116 111.784565 
+    <path d="M 559.175204 380.792 
+L 576.328182 380.792 
+L 576.328182 111.893976 
+L 559.175204 111.893976 
 z
-" clip-path="url(#p5b389b310c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9a930eb99a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_25">
+    <!-- 118 ms -->
+    <g transform="translate(107.38066 111.202351) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
    </g>
    <g id="text_26">
-    <!-- 123 ms -->
-    <g transform="translate(107.462337 110.949237) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 118 ms -->
+    <g transform="translate(124.533638 112.639788) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- 124 ms -->
-    <g transform="translate(124.612494 110.4112) rotate(-90) scale(0.1 -0.1)">
+    <!-- 121 ms -->
+    <g transform="translate(141.686616 106.412623) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 125 ms -->
-    <g transform="translate(141.762651 106.706493) rotate(-90) scale(0.1 -0.1)">
+    <!-- 121 ms -->
+    <g transform="translate(158.839594 106.485985) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 125 ms -->
-    <g transform="translate(158.912808 107.542642) rotate(-90) scale(0.1 -0.1)">
+    <!-- 116 ms -->
+    <g transform="translate(210.298529 115.471025) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 123 ms -->
-    <g transform="translate(210.363278 111.097227) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 125 ms -->
-    <g transform="translate(227.513435 108.021289) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 126 ms -->
-    <g transform="translate(244.663591 106.144762) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_33">
-    <!-- 125 ms -->
-    <g transform="translate(261.813748 107.791722) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_30">
+    <!-- 117 ms -->
+    <g transform="translate(227.451507 113.28467) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 120 ms -->
+    <g transform="translate(244.604485 108.189992) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 120 ms -->
+    <g transform="translate(261.757463 107.230722) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- 117 ms -->
+    <g transform="translate(313.216397 114.884875) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 123 ms -->
-    <g transform="translate(313.264218 111.818363) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g transform="translate(330.369375 109.070066) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 122 ms -->
-    <g transform="translate(330.414375 113.110981) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g transform="translate(347.522353 108.911853) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 124 ms -->
-    <g transform="translate(347.564532 109.094874) rotate(-90) scale(0.1 -0.1)">
+    <!-- 120 ms -->
+    <g transform="translate(364.675331 106.901317) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 125 ms -->
-    <g transform="translate(364.714688 107.493026) rotate(-90) scale(0.1 -0.1)">
+    <!-- 118 ms -->
+    <g transform="translate(416.134265 111.111189) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 123 ms -->
-    <g transform="translate(416.165159 111.232398) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g transform="translate(433.287243 108.945911) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 124 ms -->
-    <g transform="translate(433.315315 110.104331) rotate(-90) scale(0.1 -0.1)">
+    <!-- 120 ms -->
+    <g transform="translate(450.440221 108.459227) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_40">
-    <!-- 125 ms -->
-    <g transform="translate(450.465472 108.237022) rotate(-90) scale(0.1 -0.1)">
+    <!-- 120 ms -->
+    <g transform="translate(467.593199 106.639471) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- 125 ms -->
-    <g transform="translate(467.615629 108.068814) rotate(-90) scale(0.1 -0.1)">
+    <!-- 118 ms -->
+    <g transform="translate(519.052134 111.217778) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_42">
-    <!-- 123 ms -->
-    <g transform="translate(519.066099 112.024479) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g transform="translate(536.205112 109.398042) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_43">
-    <!-- 124 ms -->
-    <g transform="translate(536.216256 109.680531) rotate(-90) scale(0.1 -0.1)">
+    <!-- 121 ms -->
+    <g transform="translate(553.35809 106.144762) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- 124 ms -->
-    <g transform="translate(553.366413 109.329903) rotate(-90) scale(0.1 -0.1)">
+    <!-- 120 ms -->
+    <g transform="translate(570.511068 106.893976) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- 125 ms -->
-    <g transform="translate(570.516569 106.784565) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    <!--  4 -->
+    <g transform="translate(107.38066 380.792) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_46">
-    <!--  4 -->
-    <g transform="translate(107.462337 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(124.533638 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_47">
-    <!--  12 -->
-    <g transform="translate(124.612494 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(141.686616 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_48">
-    <!--  40 -->
-    <g transform="translate(141.762651 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(158.839594 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_49">
-    <!--  120 -->
-    <g transform="translate(158.912808 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(210.298529 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_50">
-    <!--  4 -->
-    <g transform="translate(210.363278 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(227.451507 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_51">
-    <!--  12 -->
-    <g transform="translate(227.513435 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(244.604485 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_52">
-    <!--  40 -->
-    <g transform="translate(244.663591 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(261.757463 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_53">
-    <!--  120 -->
-    <g transform="translate(261.813748 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(313.216397 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_54">
-    <!--  4 -->
-    <g transform="translate(313.264218 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(330.369375 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_55">
-    <!--  12 -->
-    <g transform="translate(330.414375 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(347.522353 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_56">
-    <!--  40 -->
-    <g transform="translate(347.564532 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(364.675331 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_57">
-    <!--  120 -->
-    <g transform="translate(364.714688 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(416.134265 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_58">
-    <!--  4 -->
-    <g transform="translate(416.165159 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  12 -->
+    <g transform="translate(433.287243 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
    <g id="text_59">
-    <!--  12 -->
-    <g transform="translate(433.315315 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  40 -->
+    <g transform="translate(450.440221 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
    <g id="text_60">
-    <!--  40 -->
-    <g transform="translate(450.465472 380.792) rotate(-90) scale(0.1 -0.1)">
+    <!--  120 -->
+    <g transform="translate(467.593199 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
    <g id="text_61">
-    <!--  120 -->
-    <g transform="translate(467.615629 380.792) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-    </g>
-   </g>
-   <g id="text_62">
     <!--  4 -->
-    <g transform="translate(519.066099 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(519.052134 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_63">
+   <g id="text_62">
     <!--  12 -->
-    <g transform="translate(536.216256 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(536.205112 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
     </g>
    </g>
-   <g id="text_64">
+   <g id="text_63">
     <!--  40 -->
-    <g transform="translate(553.366413 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(553.35809 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
     </g>
    </g>
-   <g id="text_65">
+   <g id="text_64">
     <!--  120 -->
-    <g transform="translate(570.516569 380.792) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(570.511068 380.792) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
     </g>
    </g>
-   <g id="text_66">
+   <g id="text_65">
     <!-- lines simple n=1000 -->
-    <g transform="translate(265.9825 20.88) scale(0.12 -0.12)">
+    <g transform="translate(265.9375 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -1922,7 +1884,7 @@ L 348.146875 43.117188
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_67">
+    <g id="text_66">
      <!-- serial no mask -->
      <g transform="translate(376.146875 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2008,8 +1970,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p5b389b310c">
-   <rect x="54.11" y="26.88" width="547.09" height="353.912"/>
+  <clipPath id="p9a930eb99a">
+   <rect x="54.02" y="26.88" width="547.18" height="353.912"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/_static/filled_random_1000_dark.svg
+++ b/docs/_static/filled_random_1000_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:05.657543</dc:date>
+    <dc:date>2024-05-06T19:15:01.493783</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m309228cebb" d="M 0 0 
+       <path id="m082871614e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m309228cebb" x="97.224809" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m082871614e" x="97.224809" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -395,7 +395,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m309228cebb" x="162.14915" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m082871614e" x="162.14915" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -464,7 +464,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m309228cebb" x="227.07349" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m082871614e" x="227.07349" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -576,7 +576,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m309228cebb" x="291.99783" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m082871614e" x="291.99783" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -634,7 +634,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m309228cebb" x="356.92217" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m082871614e" x="356.92217" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -760,7 +760,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m309228cebb" x="421.84651" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m082871614e" x="421.84651" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -806,7 +806,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m309228cebb" x="486.77085" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m082871614e" x="486.77085" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -859,7 +859,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m309228cebb" x="551.695191" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m082871614e" x="551.695191" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -917,16 +917,16 @@ z
      <g id="line2d_9">
       <path d="M 47.72 357.464 
 L 601.2 357.464 
-" clip-path="url(#p2ad8bcf4c5)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <defs>
-       <path id="m6b5a536e1c" d="M 0 0 
+       <path id="me6f69e9ed6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6b5a536e1c" x="47.72" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#me6f69e9ed6" x="47.72" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -949,18 +949,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_11">
-      <path d="M 47.72 295.08966 
-L 601.2 295.08966 
-" clip-path="url(#p2ad8bcf4c5)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 307.375515 
+L 601.2 307.375515 
+" clip-path="url(#p97ad7e7cc3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6b5a536e1c" x="47.72" y="295.08966" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#me6f69e9ed6" x="47.72" y="307.375515" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.5 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 298.888879) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 311.174734) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -969,18 +969,18 @@ L 601.2 295.08966
     </g>
     <g id="ytick_3">
      <g id="line2d_13">
-      <path d="M 47.72 232.715321 
-L 601.2 232.715321 
-" clip-path="url(#p2ad8bcf4c5)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 257.28703 
+L 601.2 257.28703 
+" clip-path="url(#p97ad7e7cc3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6b5a536e1c" x="47.72" y="232.715321" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#me6f69e9ed6" x="47.72" y="257.28703" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.0 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 236.51454) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 261.086249) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -989,18 +989,18 @@ L 601.2 232.715321
     </g>
     <g id="ytick_4">
      <g id="line2d_15">
-      <path d="M 47.72 170.340981 
-L 601.2 170.340981 
-" clip-path="url(#p2ad8bcf4c5)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 207.198545 
+L 601.2 207.198545 
+" clip-path="url(#p97ad7e7cc3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m6b5a536e1c" x="47.72" y="170.340981" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#me6f69e9ed6" x="47.72" y="207.198545" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.5 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 174.1402) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 210.997764) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -1009,18 +1009,18 @@ L 601.2 170.340981
     </g>
     <g id="ytick_5">
      <g id="line2d_17">
-      <path d="M 47.72 107.966642 
-L 601.2 107.966642 
-" clip-path="url(#p2ad8bcf4c5)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 157.110061 
+L 601.2 157.110061 
+" clip-path="url(#p97ad7e7cc3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m6b5a536e1c" x="47.72" y="107.966642" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#me6f69e9ed6" x="47.72" y="157.110061" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 2.0 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 111.76586) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 160.909279) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1029,25 +1029,79 @@ L 601.2 107.966642
     </g>
     <g id="ytick_6">
      <g id="line2d_19">
-      <path d="M 47.72 45.592302 
-L 601.2 45.592302 
-" clip-path="url(#p2ad8bcf4c5)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 107.021576 
+L 601.2 107.021576 
+" clip-path="url(#p97ad7e7cc3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m6b5a536e1c" x="47.72" y="45.592302" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#me6f69e9ed6" x="47.72" y="107.021576" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 2.5 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 49.391521) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 110.820795) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
       </g>
      </g>
     </g>
-    <g id="text_15">
+    <g id="ytick_7">
+     <g id="line2d_21">
+      <path d="M 47.72 56.933091 
+L 601.2 56.933091 
+" clip-path="url(#p97ad7e7cc3)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#me6f69e9ed6" x="47.72" y="56.933091" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 3.0 -->
+      <g style="fill: #ffffff" transform="translate(24.816875 60.73231) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
      <!-- Time (seconds) -->
      <g style="fill: #ffffff" transform="translate(18.737188 230.333719) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1131,58 +1185,26 @@ z
    <g id="patch_3">
     <path d="M 72.878182 357.464 
 L 89.109267 357.464 
-L 89.109267 -1039.430088 
-L 72.878182 -1039.430088 
+L 89.109267 -815.297185 
+L 72.878182 -815.297185 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 89.109267 357.464 
 L 105.340352 357.464 
-L 105.340352 96.864562 
-L 89.109267 96.864562 
+L 105.340352 157.013758 
+L 89.109267 157.013758 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#h5dfc76edc5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#hdfd1d365c6); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_16">
-    <!-- 2.09 s -->
-    <g style="fill: #ffffff" transform="translate(99.984184 91.864562) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+   <g id="text_17">
+    <!-- 2.00 s -->
+    <g style="fill: #ffffff" transform="translate(99.984184 152.013758) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1190,211 +1212,14 @@ z
    <g id="patch_5">
     <path d="M 137.802522 357.464 
 L 154.033607 357.464 
-L 154.033607 74.224683 
-L 137.802522 74.224683 
+L 154.033607 67.554055 
+L 137.802522 67.554055 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_17">
-    <!-- 2.27 s -->
-    <g style="fill: #ffffff" transform="translate(148.67744 69.224683) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 154.033607 357.464 
-L 170.264692 357.464 
-L 170.264692 68.42793 
-L 154.033607 68.42793 
-z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#hc47c627cb7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_18">
-    <!-- 2.32 s -->
-    <g style="fill: #ffffff" transform="translate(164.908525 63.42793) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 170.264692 357.464 
-L 186.495777 357.464 
-L 186.495777 75.736806 
-L 170.264692 75.736806 
-z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#h44a290b0ef); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 2.26 s -->
-    <g style="fill: #ffffff" transform="translate(181.13961 70.736806) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 202.726862 357.464 
-L 218.957947 357.464 
-L 218.957947 145.765772 
-L 202.726862 145.765772 
-z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 267.651202 357.464 
-L 283.882287 357.464 
-L 283.882287 151.358987 
-L 267.651202 151.358987 
-z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 332.575543 357.464 
-L 348.806628 357.464 
-L 348.806628 247.482421 
-L 332.575543 247.482421 
-z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 397.499883 357.464 
-L 413.730968 357.464 
-L 413.730968 247.772491 
-L 397.499883 247.772491 
-z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 462.424223 357.464 
-L 478.655308 357.464 
-L 478.655308 241.174348 
-L 462.424223 241.174348 
-z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 527.348563 357.464 
-L 543.579648 357.464 
-L 543.579648 241.807378 
-L 527.348563 241.807378 
-z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 1.70 s -->
-    <g style="fill: #ffffff" transform="translate(213.60178 140.765772) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 1.65 s -->
-    <g style="fill: #ffffff" transform="translate(278.52612 146.358987) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 882 ms -->
-    <g style="fill: #ffffff" transform="translate(343.45046 242.482421) rotate(-90) scale(0.1 -0.1)">
+    <!-- 2.89 s -->
+    <g style="fill: #ffffff" transform="translate(148.67744 62.554055) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1435,18 +1260,233 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 154.033607 357.464 
+L 170.264692 357.464 
+L 170.264692 94.939954 
+L 154.033607 94.939954 
+z
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h904b850648); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 2.62 s -->
+    <g style="fill: #ffffff" transform="translate(164.908525 89.939954) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 170.264692 357.464 
+L 186.495777 357.464 
+L 186.495777 90.999173 
+L 170.264692 90.999173 
+z
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h2235ae397a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 2.66 s -->
+    <g style="fill: #ffffff" transform="translate(181.13961 85.999173) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 202.726862 357.464 
+L 218.957947 357.464 
+L 218.957947 191.260754 
+L 202.726862 191.260754 
+z
+" clip-path="url(#p97ad7e7cc3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 267.651202 357.464 
+L 283.882287 357.464 
+L 283.882287 194.532421 
+L 267.651202 194.532421 
+z
+" clip-path="url(#p97ad7e7cc3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 332.575543 357.464 
+L 348.806628 357.464 
+L 348.806628 272.699641 
+L 332.575543 272.699641 
+z
+" clip-path="url(#p97ad7e7cc3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 397.499883 357.464 
+L 413.730968 357.464 
+L 413.730968 273.113421 
+L 397.499883 273.113421 
+z
+" clip-path="url(#p97ad7e7cc3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 462.424223 357.464 
+L 478.655308 357.464 
+L 478.655308 269.256876 
+L 462.424223 269.256876 
+z
+" clip-path="url(#p97ad7e7cc3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 527.348563 357.464 
+L 543.579648 357.464 
+L 543.579648 269.412959 
+L 527.348563 269.412959 
+z
+" clip-path="url(#p97ad7e7cc3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 1.66 s -->
+    <g style="fill: #ffffff" transform="translate(213.60178 186.260754) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 1.63 s -->
+    <g style="fill: #ffffff" transform="translate(278.52612 189.532421) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 846 ms -->
+    <g style="fill: #ffffff" transform="translate(343.45046 267.699641) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 842 ms -->
+    <g style="fill: #ffffff" transform="translate(408.3748 268.113421) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_23">
+   <g id="text_25">
+    <!-- 881 ms -->
+    <g style="fill: #ffffff" transform="translate(473.29914 264.256876) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_26">
     <!-- 879 ms -->
-    <g style="fill: #ffffff" transform="translate(408.3748 242.772491) rotate(-90) scale(0.1 -0.1)">
+    <g style="fill: #ffffff" transform="translate(538.223481 264.412959) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-37" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
@@ -1455,136 +1495,114 @@ z
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- 932 ms -->
-    <g style="fill: #ffffff" transform="translate(473.29914 236.174348) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 927 ms -->
-    <g style="fill: #ffffff" transform="translate(538.223481 236.807378) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
    <g id="patch_14">
     <path d="M 218.957947 357.464 
 L 235.189032 357.464 
-L 235.189032 132.370282 
-L 218.957947 132.370282 
+L 235.189032 182.681702 
+L 218.957947 182.681702 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#h7fa73de76b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h7f12e9ac61); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 283.882287 357.464 
 L 300.113372 357.464 
-L 300.113372 138.9329 
-L 283.882287 138.9329 
+L 300.113372 184.957858 
+L 283.882287 184.957858 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#h7fa73de76b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h7f12e9ac61); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 348.806628 357.464 
 L 365.037713 357.464 
-L 365.037713 246.882663 
-L 348.806628 246.882663 
+L 365.037713 272.056476 
+L 348.806628 272.056476 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#h7fa73de76b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h7f12e9ac61); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 413.730968 357.464 
 L 429.962053 357.464 
-L 429.962053 247.455344 
-L 413.730968 247.455344 
+L 429.962053 272.816891 
+L 413.730968 272.816891 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#h7fa73de76b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h7f12e9ac61); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 478.655308 357.464 
 L 494.886393 357.464 
-L 494.886393 242.333891 
-L 478.655308 242.333891 
+L 494.886393 269.992953 
+L 478.655308 269.992953 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#h7fa73de76b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h7f12e9ac61); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 543.579648 357.464 
 L 559.810733 357.464 
-L 559.810733 242.768953 
-L 543.579648 242.768953 
+L 559.810733 270.417725 
+L 543.579648 270.417725 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#h7fa73de76b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_26">
-    <!-- 1.80 s -->
-    <g style="fill: #ffffff" transform="translate(229.832865 127.370282) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h7f12e9ac61); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_27">
-    <!-- 1.75 s -->
-    <g style="fill: #ffffff" transform="translate(294.757205 133.9329) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.74 s -->
+    <g style="fill: #ffffff" transform="translate(229.832865 177.681702) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 886 ms -->
-    <g style="fill: #ffffff" transform="translate(359.681545 241.882663) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    <!-- 1.72 s -->
+    <g style="fill: #ffffff" transform="translate(294.757205 179.957858) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 882 ms -->
-    <g style="fill: #ffffff" transform="translate(424.605885 242.455344) rotate(-90) scale(0.1 -0.1)">
+    <!-- 853 ms -->
+    <g style="fill: #ffffff" transform="translate(359.681545 267.056476) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 923 ms -->
-    <g style="fill: #ffffff" transform="translate(489.530225 237.333891) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
+   <g id="text_30">
+    <!-- 845 ms -->
+    <g style="fill: #ffffff" transform="translate(424.605885 267.816891) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
    <g id="text_31">
-    <!-- 919 ms -->
-    <g style="fill: #ffffff" transform="translate(554.454566 237.768953) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+    <!-- 873 ms -->
+    <g style="fill: #ffffff" transform="translate(489.530225 264.992953) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 869 ms -->
+    <g style="fill: #ffffff" transform="translate(554.454566 265.417725) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1594,118 +1612,118 @@ z
    <g id="patch_20">
     <path d="M 235.189032 357.464 
 L 251.420117 357.464 
-L 251.420117 136.324902 
-L 235.189032 136.324902 
+L 251.420117 186.310087 
+L 235.189032 186.310087 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#hbdada4b577); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h98bb3012e5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 300.113372 357.464 
 L 316.344457 357.464 
-L 316.344457 141.948433 
-L 300.113372 141.948433 
+L 316.344457 188.432839 
+L 300.113372 188.432839 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#hbdada4b577); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h98bb3012e5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 365.037713 357.464 
 L 381.268798 357.464 
-L 381.268798 239.758435 
-L 365.037713 239.758435 
+L 381.268798 266.808243 
+L 365.037713 266.808243 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#hbdada4b577); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h98bb3012e5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 429.962053 357.464 
 L 446.193138 357.464 
-L 446.193138 240.30659 
-L 429.962053 240.30659 
+L 446.193138 267.190387 
+L 429.962053 267.190387 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#hbdada4b577); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h98bb3012e5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 494.886393 357.464 
 L 511.117478 357.464 
-L 511.117478 234.762386 
-L 494.886393 234.762386 
+L 511.117478 264.006898 
+L 494.886393 264.006898 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#hbdada4b577); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h98bb3012e5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 559.810733 357.464 
 L 576.041818 357.464 
-L 576.041818 235.138249 
-L 559.810733 235.138249 
+L 576.041818 264.746427 
+L 559.810733 264.746427 
 z
-" clip-path="url(#p2ad8bcf4c5)" style="fill: url(#hbdada4b577); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_32">
-    <!-- 1.77 s -->
-    <g style="fill: #ffffff" transform="translate(246.06395 131.324902) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
+" clip-path="url(#p97ad7e7cc3)" style="fill: url(#h98bb3012e5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_33">
-    <!-- 1.73 s -->
-    <g style="fill: #ffffff" transform="translate(310.98829 136.948433) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.71 s -->
+    <g style="fill: #ffffff" transform="translate(246.06395 181.310087) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 944 ms -->
-    <g style="fill: #ffffff" transform="translate(375.91263 234.758435) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    <!-- 1.69 s -->
+    <g style="fill: #ffffff" transform="translate(310.98829 183.432839) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 939 ms -->
-    <g style="fill: #ffffff" transform="translate(440.83697 235.30659) rotate(-90) scale(0.1 -0.1)">
+    <!-- 905 ms -->
+    <g style="fill: #ffffff" transform="translate(375.91263 261.808243) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 984 ms -->
-    <g style="fill: #ffffff" transform="translate(505.76131 229.762386) rotate(-90) scale(0.1 -0.1)">
+    <!-- 901 ms -->
+    <g style="fill: #ffffff" transform="translate(440.83697 262.190387) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- 981 ms -->
-    <g style="fill: #ffffff" transform="translate(570.685651 230.138249) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
+   <g id="text_37">
+    <!-- 933 ms -->
+    <g style="fill: #ffffff" transform="translate(505.76131 259.006898) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
    <g id="text_38">
+    <!-- 926 ms -->
+    <g style="fill: #ffffff" transform="translate(570.685651 259.746427) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_39">
     <!-- filled random n=1000  -->
     <g style="fill: #ffffff" transform="translate(256.754687 20.88) scale(0.12 -0.12)">
      <defs>
@@ -1788,7 +1806,7 @@ L 419.19375 36.478437
 z
 " style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_39">
+    <g id="text_40">
      <!-- mpl2005 no mask -->
      <g style="fill: #ffffff" transform="translate(447.19375 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1814,9 +1832,9 @@ L 439.19375 58.156563
 L 439.19375 51.156563 
 L 419.19375 51.156563 
 z
-" style="fill: url(#h5dfc76edc5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hdfd1d365c6); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_40">
+    <g id="text_41">
      <!-- mpl2005 corner_mask=False -->
      <g style="fill: #ffffff" transform="translate(447.19375 58.156563) scale(0.1 -0.1)">
       <defs>
@@ -1876,7 +1894,7 @@ L 419.19375 66.112812
 z
 " style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_41">
+    <g id="text_42">
      <!-- mpl2014 no mask -->
      <g style="fill: #ffffff" transform="translate(447.19375 73.112812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1902,9 +1920,9 @@ L 439.19375 87.790937
 L 439.19375 80.790937 
 L 419.19375 80.790937 
 z
-" style="fill: url(#hc47c627cb7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h904b850648); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_42">
+    <g id="text_43">
      <!-- mpl2014 corner_mask=False -->
      <g style="fill: #ffffff" transform="translate(447.19375 87.790937) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1940,9 +1958,9 @@ L 439.19375 102.747187
 L 439.19375 95.747187 
 L 419.19375 95.747187 
 z
-" style="fill: url(#h44a290b0ef); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h2235ae397a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_43">
+    <g id="text_44">
      <!-- mpl2014 corner_mask=True -->
      <g style="fill: #ffffff" transform="translate(447.19375 102.747187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1979,7 +1997,7 @@ L 419.19375 110.703437
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_44">
+    <g id="text_45">
      <!-- serial no mask -->
      <g style="fill: #ffffff" transform="translate(447.19375 117.703437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2004,9 +2022,9 @@ L 439.19375 132.381562
 L 439.19375 125.381562 
 L 419.19375 125.381562 
 z
-" style="fill: url(#h7fa73de76b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h7f12e9ac61); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_45">
+    <g id="text_46">
      <!-- serial corner_mask=False -->
      <g style="fill: #ffffff" transform="translate(447.19375 132.381562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2041,9 +2059,9 @@ L 439.19375 147.337812
 L 439.19375 140.337812 
 L 419.19375 140.337812 
 z
-" style="fill: url(#hbdada4b577); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h98bb3012e5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_46">
+    <g id="text_47">
      <!-- serial corner_mask=True -->
      <g style="fill: #ffffff" transform="translate(447.19375 147.337812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2075,12 +2093,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p2ad8bcf4c5">
+  <clipPath id="p97ad7e7cc3">
    <rect x="47.72" y="26.88" width="553.48" height="330.584"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h5dfc76edc5" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hdfd1d365c6" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2120,7 +2138,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hc47c627cb7" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h904b850648" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2160,7 +2178,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h44a290b0ef" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h2235ae397a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2202,7 +2220,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h7fa73de76b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h7f12e9ac61" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2242,7 +2260,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hbdada4b577" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h98bb3012e5" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/filled_random_1000_light.svg
+++ b/docs/_static/filled_random_1000_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:05.466444</dc:date>
+    <dc:date>2024-05-06T19:15:01.304721</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m9e5abc0762" d="M 0 0 
+       <path id="m2194157824" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9e5abc0762" x="97.224809" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2194157824" x="97.224809" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -395,7 +395,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m9e5abc0762" x="162.14915" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2194157824" x="162.14915" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -464,7 +464,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m9e5abc0762" x="227.07349" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2194157824" x="227.07349" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -576,7 +576,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9e5abc0762" x="291.99783" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2194157824" x="291.99783" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -634,7 +634,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m9e5abc0762" x="356.92217" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2194157824" x="356.92217" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -760,7 +760,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9e5abc0762" x="421.84651" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2194157824" x="421.84651" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -806,7 +806,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m9e5abc0762" x="486.77085" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2194157824" x="486.77085" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -859,7 +859,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9e5abc0762" x="551.695191" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2194157824" x="551.695191" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -917,16 +917,16 @@ z
      <g id="line2d_9">
       <path d="M 47.72 357.464 
 L 601.2 357.464 
-" clip-path="url(#p6851a1668d)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p13df8e9828)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <defs>
-       <path id="m634383ff67" d="M 0 0 
+       <path id="m501d4480f0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m634383ff67" x="47.72" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m501d4480f0" x="47.72" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -949,18 +949,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_11">
-      <path d="M 47.72 295.08966 
-L 601.2 295.08966 
-" clip-path="url(#p6851a1668d)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 307.375515 
+L 601.2 307.375515 
+" clip-path="url(#p13df8e9828)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m634383ff67" x="47.72" y="295.08966" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m501d4480f0" x="47.72" y="307.375515" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.5 -->
-      <g transform="translate(24.816875 298.888879) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 311.174734) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -969,18 +969,18 @@ L 601.2 295.08966
     </g>
     <g id="ytick_3">
      <g id="line2d_13">
-      <path d="M 47.72 232.715321 
-L 601.2 232.715321 
-" clip-path="url(#p6851a1668d)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 257.28703 
+L 601.2 257.28703 
+" clip-path="url(#p13df8e9828)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m634383ff67" x="47.72" y="232.715321" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m501d4480f0" x="47.72" y="257.28703" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.0 -->
-      <g transform="translate(24.816875 236.51454) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 261.086249) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -989,18 +989,18 @@ L 601.2 232.715321
     </g>
     <g id="ytick_4">
      <g id="line2d_15">
-      <path d="M 47.72 170.340981 
-L 601.2 170.340981 
-" clip-path="url(#p6851a1668d)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 207.198545 
+L 601.2 207.198545 
+" clip-path="url(#p13df8e9828)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m634383ff67" x="47.72" y="170.340981" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m501d4480f0" x="47.72" y="207.198545" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.5 -->
-      <g transform="translate(24.816875 174.1402) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 210.997764) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -1009,18 +1009,18 @@ L 601.2 170.340981
     </g>
     <g id="ytick_5">
      <g id="line2d_17">
-      <path d="M 47.72 107.966642 
-L 601.2 107.966642 
-" clip-path="url(#p6851a1668d)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 157.110061 
+L 601.2 157.110061 
+" clip-path="url(#p13df8e9828)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m634383ff67" x="47.72" y="107.966642" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m501d4480f0" x="47.72" y="157.110061" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 2.0 -->
-      <g transform="translate(24.816875 111.76586) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 160.909279) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1029,25 +1029,79 @@ L 601.2 107.966642
     </g>
     <g id="ytick_6">
      <g id="line2d_19">
-      <path d="M 47.72 45.592302 
-L 601.2 45.592302 
-" clip-path="url(#p6851a1668d)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 107.021576 
+L 601.2 107.021576 
+" clip-path="url(#p13df8e9828)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m634383ff67" x="47.72" y="45.592302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m501d4480f0" x="47.72" y="107.021576" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 2.5 -->
-      <g transform="translate(24.816875 49.391521) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 110.820795) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
       </g>
      </g>
     </g>
-    <g id="text_15">
+    <g id="ytick_7">
+     <g id="line2d_21">
+      <path d="M 47.72 56.933091 
+L 601.2 56.933091 
+" clip-path="url(#p13df8e9828)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m501d4480f0" x="47.72" y="56.933091" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 3.0 -->
+      <g transform="translate(24.816875 60.73231) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
      <!-- Time (seconds) -->
      <g transform="translate(18.737188 230.333719) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1131,58 +1185,26 @@ z
    <g id="patch_3">
     <path d="M 72.878182 357.464 
 L 89.109267 357.464 
-L 89.109267 -1039.430088 
-L 72.878182 -1039.430088 
+L 89.109267 -815.297185 
+L 72.878182 -815.297185 
 z
-" clip-path="url(#p6851a1668d)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 89.109267 357.464 
 L 105.340352 357.464 
-L 105.340352 96.864562 
-L 89.109267 96.864562 
+L 105.340352 157.013758 
+L 89.109267 157.013758 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#hbe882ef0be); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h53ce05bdcb); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_16">
-    <!-- 2.09 s -->
-    <g transform="translate(99.984184 91.864562) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+   <g id="text_17">
+    <!-- 2.00 s -->
+    <g transform="translate(99.984184 152.013758) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1190,211 +1212,14 @@ z
    <g id="patch_5">
     <path d="M 137.802522 357.464 
 L 154.033607 357.464 
-L 154.033607 74.224683 
-L 137.802522 74.224683 
+L 154.033607 67.554055 
+L 137.802522 67.554055 
 z
-" clip-path="url(#p6851a1668d)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_17">
-    <!-- 2.27 s -->
-    <g transform="translate(148.67744 69.224683) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 154.033607 357.464 
-L 170.264692 357.464 
-L 170.264692 68.42793 
-L 154.033607 68.42793 
-z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h9792507b23); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_18">
-    <!-- 2.32 s -->
-    <g transform="translate(164.908525 63.42793) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 170.264692 357.464 
-L 186.495777 357.464 
-L 186.495777 75.736806 
-L 170.264692 75.736806 
-z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h09bff8abbe); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 2.26 s -->
-    <g transform="translate(181.13961 70.736806) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 202.726862 357.464 
-L 218.957947 357.464 
-L 218.957947 145.765772 
-L 202.726862 145.765772 
-z
-" clip-path="url(#p6851a1668d)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 267.651202 357.464 
-L 283.882287 357.464 
-L 283.882287 151.358987 
-L 267.651202 151.358987 
-z
-" clip-path="url(#p6851a1668d)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 332.575543 357.464 
-L 348.806628 357.464 
-L 348.806628 247.482421 
-L 332.575543 247.482421 
-z
-" clip-path="url(#p6851a1668d)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 397.499883 357.464 
-L 413.730968 357.464 
-L 413.730968 247.772491 
-L 397.499883 247.772491 
-z
-" clip-path="url(#p6851a1668d)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 462.424223 357.464 
-L 478.655308 357.464 
-L 478.655308 241.174348 
-L 462.424223 241.174348 
-z
-" clip-path="url(#p6851a1668d)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 527.348563 357.464 
-L 543.579648 357.464 
-L 543.579648 241.807378 
-L 527.348563 241.807378 
-z
-" clip-path="url(#p6851a1668d)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 1.70 s -->
-    <g transform="translate(213.60178 140.765772) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 1.65 s -->
-    <g transform="translate(278.52612 146.358987) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 882 ms -->
-    <g transform="translate(343.45046 242.482421) rotate(-90) scale(0.1 -0.1)">
+    <!-- 2.89 s -->
+    <g transform="translate(148.67744 62.554055) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1435,18 +1260,233 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 154.033607 357.464 
+L 170.264692 357.464 
+L 170.264692 94.939954 
+L 154.033607 94.939954 
+z
+" clip-path="url(#p13df8e9828)" style="fill: url(#h46c944a781); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 2.62 s -->
+    <g transform="translate(164.908525 89.939954) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 170.264692 357.464 
+L 186.495777 357.464 
+L 186.495777 90.999173 
+L 170.264692 90.999173 
+z
+" clip-path="url(#p13df8e9828)" style="fill: url(#h3afe99d329); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 2.66 s -->
+    <g transform="translate(181.13961 85.999173) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 202.726862 357.464 
+L 218.957947 357.464 
+L 218.957947 191.260754 
+L 202.726862 191.260754 
+z
+" clip-path="url(#p13df8e9828)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 267.651202 357.464 
+L 283.882287 357.464 
+L 283.882287 194.532421 
+L 267.651202 194.532421 
+z
+" clip-path="url(#p13df8e9828)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 332.575543 357.464 
+L 348.806628 357.464 
+L 348.806628 272.699641 
+L 332.575543 272.699641 
+z
+" clip-path="url(#p13df8e9828)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 397.499883 357.464 
+L 413.730968 357.464 
+L 413.730968 273.113421 
+L 397.499883 273.113421 
+z
+" clip-path="url(#p13df8e9828)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 462.424223 357.464 
+L 478.655308 357.464 
+L 478.655308 269.256876 
+L 462.424223 269.256876 
+z
+" clip-path="url(#p13df8e9828)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 527.348563 357.464 
+L 543.579648 357.464 
+L 543.579648 269.412959 
+L 527.348563 269.412959 
+z
+" clip-path="url(#p13df8e9828)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 1.66 s -->
+    <g transform="translate(213.60178 186.260754) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 1.63 s -->
+    <g transform="translate(278.52612 189.532421) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 846 ms -->
+    <g transform="translate(343.45046 267.699641) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 842 ms -->
+    <g transform="translate(408.3748 268.113421) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_23">
+   <g id="text_25">
+    <!-- 881 ms -->
+    <g transform="translate(473.29914 264.256876) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_26">
     <!-- 879 ms -->
-    <g transform="translate(408.3748 242.772491) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(538.223481 264.412959) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-37" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
@@ -1455,136 +1495,114 @@ z
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- 932 ms -->
-    <g transform="translate(473.29914 236.174348) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 927 ms -->
-    <g transform="translate(538.223481 236.807378) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
    <g id="patch_14">
     <path d="M 218.957947 357.464 
 L 235.189032 357.464 
-L 235.189032 132.370282 
-L 218.957947 132.370282 
+L 235.189032 182.681702 
+L 218.957947 182.681702 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h078da0c997); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h454bc1b669); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 283.882287 357.464 
 L 300.113372 357.464 
-L 300.113372 138.9329 
-L 283.882287 138.9329 
+L 300.113372 184.957858 
+L 283.882287 184.957858 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h078da0c997); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h454bc1b669); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 348.806628 357.464 
 L 365.037713 357.464 
-L 365.037713 246.882663 
-L 348.806628 246.882663 
+L 365.037713 272.056476 
+L 348.806628 272.056476 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h078da0c997); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h454bc1b669); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 413.730968 357.464 
 L 429.962053 357.464 
-L 429.962053 247.455344 
-L 413.730968 247.455344 
+L 429.962053 272.816891 
+L 413.730968 272.816891 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h078da0c997); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h454bc1b669); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 478.655308 357.464 
 L 494.886393 357.464 
-L 494.886393 242.333891 
-L 478.655308 242.333891 
+L 494.886393 269.992953 
+L 478.655308 269.992953 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h078da0c997); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h454bc1b669); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 543.579648 357.464 
 L 559.810733 357.464 
-L 559.810733 242.768953 
-L 543.579648 242.768953 
+L 559.810733 270.417725 
+L 543.579648 270.417725 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h078da0c997); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_26">
-    <!-- 1.80 s -->
-    <g transform="translate(229.832865 127.370282) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h454bc1b669); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_27">
-    <!-- 1.75 s -->
-    <g transform="translate(294.757205 133.9329) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.74 s -->
+    <g transform="translate(229.832865 177.681702) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 886 ms -->
-    <g transform="translate(359.681545 241.882663) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    <!-- 1.72 s -->
+    <g transform="translate(294.757205 179.957858) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 882 ms -->
-    <g transform="translate(424.605885 242.455344) rotate(-90) scale(0.1 -0.1)">
+    <!-- 853 ms -->
+    <g transform="translate(359.681545 267.056476) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 923 ms -->
-    <g transform="translate(489.530225 237.333891) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
+   <g id="text_30">
+    <!-- 845 ms -->
+    <g transform="translate(424.605885 267.816891) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
    <g id="text_31">
-    <!-- 919 ms -->
-    <g transform="translate(554.454566 237.768953) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+    <!-- 873 ms -->
+    <g transform="translate(489.530225 264.992953) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 869 ms -->
+    <g transform="translate(554.454566 265.417725) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1594,118 +1612,118 @@ z
    <g id="patch_20">
     <path d="M 235.189032 357.464 
 L 251.420117 357.464 
-L 251.420117 136.324902 
-L 235.189032 136.324902 
+L 251.420117 186.310087 
+L 235.189032 186.310087 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h5d99b37448); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h65feff32a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 300.113372 357.464 
 L 316.344457 357.464 
-L 316.344457 141.948433 
-L 300.113372 141.948433 
+L 316.344457 188.432839 
+L 300.113372 188.432839 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h5d99b37448); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h65feff32a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 365.037713 357.464 
 L 381.268798 357.464 
-L 381.268798 239.758435 
-L 365.037713 239.758435 
+L 381.268798 266.808243 
+L 365.037713 266.808243 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h5d99b37448); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h65feff32a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 429.962053 357.464 
 L 446.193138 357.464 
-L 446.193138 240.30659 
-L 429.962053 240.30659 
+L 446.193138 267.190387 
+L 429.962053 267.190387 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h5d99b37448); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h65feff32a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 494.886393 357.464 
 L 511.117478 357.464 
-L 511.117478 234.762386 
-L 494.886393 234.762386 
+L 511.117478 264.006898 
+L 494.886393 264.006898 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h5d99b37448); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h65feff32a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 559.810733 357.464 
 L 576.041818 357.464 
-L 576.041818 235.138249 
-L 559.810733 235.138249 
+L 576.041818 264.746427 
+L 559.810733 264.746427 
 z
-" clip-path="url(#p6851a1668d)" style="fill: url(#h5d99b37448); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_32">
-    <!-- 1.77 s -->
-    <g transform="translate(246.06395 131.324902) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
+" clip-path="url(#p13df8e9828)" style="fill: url(#h65feff32a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_33">
-    <!-- 1.73 s -->
-    <g transform="translate(310.98829 136.948433) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.71 s -->
+    <g transform="translate(246.06395 181.310087) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 944 ms -->
-    <g transform="translate(375.91263 234.758435) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    <!-- 1.69 s -->
+    <g transform="translate(310.98829 183.432839) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 939 ms -->
-    <g transform="translate(440.83697 235.30659) rotate(-90) scale(0.1 -0.1)">
+    <!-- 905 ms -->
+    <g transform="translate(375.91263 261.808243) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 984 ms -->
-    <g transform="translate(505.76131 229.762386) rotate(-90) scale(0.1 -0.1)">
+    <!-- 901 ms -->
+    <g transform="translate(440.83697 262.190387) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- 981 ms -->
-    <g transform="translate(570.685651 230.138249) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
+   <g id="text_37">
+    <!-- 933 ms -->
+    <g transform="translate(505.76131 259.006898) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
    <g id="text_38">
+    <!-- 926 ms -->
+    <g transform="translate(570.685651 259.746427) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_39">
     <!-- filled random n=1000  -->
     <g transform="translate(256.754687 20.88) scale(0.12 -0.12)">
      <defs>
@@ -1788,7 +1806,7 @@ L 419.19375 36.478437
 z
 " style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_39">
+    <g id="text_40">
      <!-- mpl2005 no mask -->
      <g transform="translate(447.19375 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1814,9 +1832,9 @@ L 439.19375 58.156563
 L 439.19375 51.156563 
 L 419.19375 51.156563 
 z
-" style="fill: url(#hbe882ef0be); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h53ce05bdcb); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_40">
+    <g id="text_41">
      <!-- mpl2005 corner_mask=False -->
      <g transform="translate(447.19375 58.156563) scale(0.1 -0.1)">
       <defs>
@@ -1876,7 +1894,7 @@ L 419.19375 66.112812
 z
 " style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_41">
+    <g id="text_42">
      <!-- mpl2014 no mask -->
      <g transform="translate(447.19375 73.112812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1902,9 +1920,9 @@ L 439.19375 87.790937
 L 439.19375 80.790937 
 L 419.19375 80.790937 
 z
-" style="fill: url(#h9792507b23); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h46c944a781); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_42">
+    <g id="text_43">
      <!-- mpl2014 corner_mask=False -->
      <g transform="translate(447.19375 87.790937) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1940,9 +1958,9 @@ L 439.19375 102.747187
 L 439.19375 95.747187 
 L 419.19375 95.747187 
 z
-" style="fill: url(#h09bff8abbe); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h3afe99d329); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_43">
+    <g id="text_44">
      <!-- mpl2014 corner_mask=True -->
      <g transform="translate(447.19375 102.747187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1979,7 +1997,7 @@ L 419.19375 110.703437
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_44">
+    <g id="text_45">
      <!-- serial no mask -->
      <g transform="translate(447.19375 117.703437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2004,9 +2022,9 @@ L 439.19375 132.381562
 L 439.19375 125.381562 
 L 419.19375 125.381562 
 z
-" style="fill: url(#h078da0c997); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h454bc1b669); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_45">
+    <g id="text_46">
      <!-- serial corner_mask=False -->
      <g transform="translate(447.19375 132.381562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2041,9 +2059,9 @@ L 439.19375 147.337812
 L 439.19375 140.337812 
 L 419.19375 140.337812 
 z
-" style="fill: url(#h5d99b37448); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h65feff32a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_46">
+    <g id="text_47">
      <!-- serial corner_mask=True -->
      <g transform="translate(447.19375 147.337812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2075,12 +2093,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p6851a1668d">
+  <clipPath id="p13df8e9828">
    <rect x="47.72" y="26.88" width="553.48" height="330.584"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="hbe882ef0be" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h53ce05bdcb" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2120,7 +2138,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h9792507b23" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h46c944a781" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2160,7 +2178,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h09bff8abbe" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h3afe99d329" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2202,7 +2220,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h078da0c997" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h454bc1b669" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2242,7 +2260,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h5d99b37448" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h65feff32a8" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/filled_random_1000_render_dark.svg
+++ b/docs/_static/filled_random_1000_render_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:07.210219</dc:date>
+    <dc:date>2024-05-06T19:15:03.000793</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m627f9f9907" d="M 0 0 
+       <path id="m08062cc051" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m627f9f9907" x="94.356554" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m08062cc051" x="94.356554" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -395,7 +395,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m627f9f9907" x="159.650396" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m08062cc051" x="159.650396" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -464,7 +464,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m627f9f9907" x="224.944238" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m08062cc051" x="224.944238" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -576,7 +576,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m627f9f9907" x="290.238079" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m08062cc051" x="290.238079" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -634,7 +634,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m627f9f9907" x="355.531921" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m08062cc051" x="355.531921" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -760,7 +760,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m627f9f9907" x="420.825762" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m08062cc051" x="420.825762" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -806,7 +806,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m627f9f9907" x="486.119604" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m08062cc051" x="486.119604" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -859,7 +859,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m627f9f9907" x="551.413446" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m08062cc051" x="551.413446" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -917,16 +917,16 @@ z
      <g id="line2d_9">
       <path d="M 44.57 357.464 
 L 601.2 357.464 
-" clip-path="url(#p594637defc)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <defs>
-       <path id="m9df14c841a" d="M 0 0 
+       <path id="mfbf5842a9a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9df14c841a" x="44.57" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mfbf5842a9a" x="44.57" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -938,36 +938,36 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_11">
-      <path d="M 44.57 309.075598 
-L 601.2 309.075598 
-" clip-path="url(#p594637defc)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 317.143648 
+L 601.2 317.143648 
+" clip-path="url(#p0b9c3d7ea9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9df14c841a" x="44.57" y="309.075598" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mfbf5842a9a" x="44.57" y="317.143648" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 5 -->
-      <g style="fill: #ffffff" transform="translate(31.2075 312.874816) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(31.2075 320.942866) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-35"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_13">
-      <path d="M 44.57 260.687195 
-L 601.2 260.687195 
-" clip-path="url(#p594637defc)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 276.823295 
+L 601.2 276.823295 
+" clip-path="url(#p0b9c3d7ea9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m9df14c841a" x="44.57" y="260.687195" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mfbf5842a9a" x="44.57" y="276.823295" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10 -->
-      <g style="fill: #ffffff" transform="translate(24.845 264.486414) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.845 280.622514) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" x="63.623047"/>
       </g>
@@ -975,18 +975,18 @@ L 601.2 260.687195
     </g>
     <g id="ytick_4">
      <g id="line2d_15">
-      <path d="M 44.57 212.298793 
-L 601.2 212.298793 
-" clip-path="url(#p594637defc)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 236.502943 
+L 601.2 236.502943 
+" clip-path="url(#p0b9c3d7ea9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m9df14c841a" x="44.57" y="212.298793" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mfbf5842a9a" x="44.57" y="236.502943" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 15 -->
-      <g style="fill: #ffffff" transform="translate(24.845 216.098011) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.845 240.302162) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-35" x="63.623047"/>
       </g>
@@ -994,18 +994,18 @@ L 601.2 212.298793
     </g>
     <g id="ytick_5">
      <g id="line2d_17">
-      <path d="M 44.57 163.91039 
-L 601.2 163.91039 
-" clip-path="url(#p594637defc)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 196.182591 
+L 601.2 196.182591 
+" clip-path="url(#p0b9c3d7ea9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m9df14c841a" x="44.57" y="163.91039" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mfbf5842a9a" x="44.57" y="196.182591" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 20 -->
-      <g style="fill: #ffffff" transform="translate(24.845 167.709609) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.845 199.981809) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-30" x="63.623047"/>
       </g>
@@ -1013,18 +1013,18 @@ L 601.2 163.91039
     </g>
     <g id="ytick_6">
      <g id="line2d_19">
-      <path d="M 44.57 115.521988 
-L 601.2 115.521988 
-" clip-path="url(#p594637defc)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 155.862238 
+L 601.2 155.862238 
+" clip-path="url(#p0b9c3d7ea9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m9df14c841a" x="44.57" y="115.521988" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mfbf5842a9a" x="44.57" y="155.862238" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 25 -->
-      <g style="fill: #ffffff" transform="translate(24.845 119.321206) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.845 159.661457) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-35" x="63.623047"/>
       </g>
@@ -1032,18 +1032,18 @@ L 601.2 115.521988
     </g>
     <g id="ytick_7">
      <g id="line2d_21">
-      <path d="M 44.57 67.133585 
-L 601.2 67.133585 
-" clip-path="url(#p594637defc)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 115.541886 
+L 601.2 115.541886 
+" clip-path="url(#p0b9c3d7ea9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m9df14c841a" x="44.57" y="67.133585" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mfbf5842a9a" x="44.57" y="115.541886" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 30 -->
-      <g style="fill: #ffffff" transform="translate(24.845 70.932804) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.845 119.341105) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1083,7 +1083,45 @@ z
       </g>
      </g>
     </g>
-    <g id="text_16">
+    <g id="ytick_8">
+     <g id="line2d_23">
+      <path d="M 44.57 75.221534 
+L 601.2 75.221534 
+" clip-path="url(#p0b9c3d7ea9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mfbf5842a9a" x="44.57" y="75.221534" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 35 -->
+      <g style="fill: #ffffff" transform="translate(24.845 79.020753) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_25">
+      <path d="M 44.57 34.901181 
+L 601.2 34.901181 
+" clip-path="url(#p0b9c3d7ea9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mfbf5842a9a" x="44.57" y="34.901181" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 40 -->
+      <g style="fill: #ffffff" transform="translate(24.845 38.7004) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
      <!-- Time (seconds) -->
      <g style="fill: #ffffff" transform="translate(18.765313 230.333719) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1167,14 +1205,14 @@ z
    <g id="patch_3">
     <path d="M 69.871364 357.464 
 L 86.194824 357.464 
-L 86.194824 176.725772 
-L 69.871364 176.725772 
+L 86.194824 209.147443 
+L 69.871364 209.147443 
 z
-" clip-path="url(#p594637defc)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_17">
-    <!-- 18.7 s -->
-    <g style="fill: #ffffff" transform="translate(80.792469 171.725772) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_19">
+    <!-- 18.4 s -->
+    <g style="fill: #ffffff" transform="translate(80.792469 204.147443) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1222,21 +1260,11 @@ L 684 0
 L 684 794 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1244,14 +1272,14 @@ z
    <g id="patch_4">
     <path d="M 86.194824 357.464 
 L 102.518284 357.464 
-L 102.518284 261.329711 
-L 86.194824 261.329711 
+L 102.518284 284.421091 
+L 86.194824 284.421091 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#hc1b541cf6e); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#hf9a8ee1c3e); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_18">
-    <!-- 9.93 s -->
-    <g style="fill: #ffffff" transform="translate(97.115929 256.329711) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_20">
+    <!-- 9.06 s -->
+    <g style="fill: #ffffff" transform="translate(97.115929 279.421091) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1283,46 +1311,6 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 135.165205 357.464 
-L 151.488666 357.464 
-L 151.488666 257.347675 
-L 135.165205 257.347675 
-z
-" clip-path="url(#p594637defc)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 10.3 s -->
-    <g style="fill: #ffffff" transform="translate(146.08631 252.347675) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 151.488666 357.464 
-L 167.812126 357.464 
-L 167.812126 255.108085 
-L 151.488666 255.108085 
-z
-" clip-path="url(#p594637defc)" style="fill: url(#h3bc8b485bf); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 10.6 s -->
-    <g style="fill: #ffffff" transform="translate(162.409771 250.108085) rotate(-90) scale(0.1 -0.1)">
-     <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
 Q 1191 2003 1191 1497 
@@ -1354,10 +1342,60 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
      <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 135.165205 357.464 
+L 151.488666 357.464 
+L 151.488666 279.539224 
+L 135.165205 279.539224 
+z
+" clip-path="url(#p0b9c3d7ea9)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 9.66 s -->
+    <g style="fill: #ffffff" transform="translate(146.08631 274.539224) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 151.488666 357.464 
+L 167.812126 357.464 
+L 167.812126 279.111813 
+L 151.488666 279.111813 
+z
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#h6e3a7e9d72); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 9.72 s -->
+    <g style="fill: #ffffff" transform="translate(162.409771 274.111813) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1365,18 +1403,18 @@ z
    <g id="patch_7">
     <path d="M 167.812126 357.464 
 L 184.135587 357.464 
-L 184.135587 259.820896 
-L 167.812126 259.820896 
+L 184.135587 282.001267 
+L 167.812126 282.001267 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#h31bd45faee); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#h25eba87fa4); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_21">
-    <!-- 10.1 s -->
-    <g style="fill: #ffffff" transform="translate(178.733231 254.820896) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+   <g id="text_23">
+    <!-- 9.36 s -->
+    <g style="fill: #ffffff" transform="translate(178.733231 277.001267) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1384,88 +1422,55 @@ z
    <g id="patch_8">
     <path d="M 200.459047 357.464 
 L 216.782507 357.464 
-L 216.782507 269.402649 
-L 200.459047 269.402649 
+L 216.782507 290.541168 
+L 200.459047 290.541168 
 z
-" clip-path="url(#p594637defc)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 265.752889 357.464 
 L 282.076349 357.464 
-L 282.076349 146.451347 
-L 265.752889 146.451347 
+L 282.076349 143.330732 
+L 265.752889 143.330732 
 z
-" clip-path="url(#p594637defc)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 331.04673 357.464 
 L 347.370191 357.464 
-L 347.370191 325.862796 
-L 331.04673 325.862796 
+L 347.370191 331.737668 
+L 331.04673 331.737668 
 z
-" clip-path="url(#p594637defc)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 396.340572 357.464 
 L 412.664032 357.464 
-L 412.664032 325.51731 
-L 396.340572 325.51731 
+L 412.664032 331.894894 
+L 396.340572 331.894894 
 z
-" clip-path="url(#p594637defc)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 461.634413 357.464 
 L 477.957874 357.464 
-L 477.957874 254.534616 
-L 461.634413 254.534616 
+L 477.957874 278.78245 
+L 461.634413 278.78245 
 z
-" clip-path="url(#p594637defc)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 526.928255 357.464 
 L 543.251716 357.464 
-L 543.251716 100.512685 
-L 526.928255 100.512685 
+L 543.251716 96.754815 
+L 526.928255 96.754815 
 z
-" clip-path="url(#p594637defc)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 9.10 s -->
-    <g style="fill: #ffffff" transform="translate(211.380152 264.402649) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 21.8 s -->
-    <g style="fill: #ffffff" transform="translate(276.673994 141.451347) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_24">
-    <!-- 3.27 s -->
-    <g style="fill: #ffffff" transform="translate(341.967835 320.862796) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 3.30 s -->
-    <g style="fill: #ffffff" transform="translate(407.261677 320.51731) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
+    <!-- 8.30 s -->
+    <g style="fill: #ffffff" transform="translate(211.380152 285.541168) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="95.410156"/>
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
@@ -1473,24 +1478,57 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- 10.6 s -->
-    <g style="fill: #ffffff" transform="translate(472.555519 249.534616) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+   <g id="text_25">
+    <!-- 26.6 s -->
+    <g style="fill: #ffffff" transform="translate(276.673994 138.330732) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
+   <g id="text_26">
+    <!-- 3.19 s -->
+    <g style="fill: #ffffff" transform="translate(341.967835 326.737668) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
    <g id="text_27">
-    <!-- 26.6 s -->
-    <g style="fill: #ffffff" transform="translate(537.84936 95.512685) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+    <!-- 3.17 s -->
+    <g style="fill: #ffffff" transform="translate(407.261677 326.894894) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 9.76 s -->
+    <g style="fill: #ffffff" transform="translate(472.555519 273.78245) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
      <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 32.3 s -->
+    <g style="fill: #ffffff" transform="translate(537.84936 91.754815) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1498,42 +1536,42 @@ z
    <g id="patch_14">
     <path d="M 216.782507 357.464 
 L 233.105968 357.464 
-L 233.105968 263.924485 
-L 216.782507 263.924485 
+L 233.105968 286.226753 
+L 216.782507 286.226753 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#h0431148a7a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#h0256f7fa53); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 282.076349 357.464 
 L 298.399809 357.464 
-L 298.399809 124.066723 
-L 282.076349 124.066723 
+L 298.399809 119.174918 
+L 282.076349 119.174918 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#h0431148a7a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#h0256f7fa53); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 347.370191 357.464 
 L 363.693651 357.464 
-L 363.693651 327.948602 
-L 347.370191 327.948602 
+L 363.693651 333.716924 
+L 347.370191 333.716924 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#h0431148a7a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#h0256f7fa53); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 412.664032 357.464 
 L 428.987493 357.464 
-L 428.987493 327.97582 
-L 412.664032 327.97582 
+L 428.987493 333.654621 
+L 412.664032 333.654621 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#h0431148a7a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#h0256f7fa53); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 477.957874 357.464 
 L 494.281334 357.464 
-L 494.281334 247.023573 
-L 477.957874 247.023573 
+L 494.281334 272.995487 
+L 477.957874 272.995487 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#h0431148a7a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#h0256f7fa53); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 543.251716 357.464 
@@ -1541,70 +1579,70 @@ L 559.575176 357.464
 L 559.575176 71.244087 
 L 543.251716 71.244087 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#h0431148a7a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_28">
-    <!-- 9.67 s -->
-    <g style="fill: #ffffff" transform="translate(227.703613 258.924485) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 24.1 s -->
-    <g style="fill: #ffffff" transform="translate(292.997454 119.066723) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#h0256f7fa53); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_30">
-    <!-- 3.05 s -->
-    <g style="fill: #ffffff" transform="translate(358.291296 322.948602) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
+    <!-- 8.83 s -->
+    <g style="fill: #ffffff" transform="translate(227.703613 281.226753) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-38" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 3.05 s -->
-    <g style="fill: #ffffff" transform="translate(423.585137 322.97582) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+    <!-- 29.5 s -->
+    <g style="fill: #ffffff" transform="translate(292.997454 114.174918) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 11.4 s -->
-    <g style="fill: #ffffff" transform="translate(488.878979 242.023573) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+    <!-- 2.94 s -->
+    <g style="fill: #ffffff" transform="translate(358.291296 328.716924) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="95.410156"/>
      <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 29.6 s -->
-    <g style="fill: #ffffff" transform="translate(554.172821 66.244087) rotate(-90) scale(0.1 -0.1)">
+    <!-- 2.95 s -->
+    <g style="fill: #ffffff" transform="translate(423.585137 328.654621) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 10.5 s -->
+    <g style="fill: #ffffff" transform="translate(488.878979 267.995487) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 35.5 s -->
+    <g style="fill: #ffffff" transform="translate(554.172821 66.244087) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1612,118 +1650,118 @@ z
    <g id="patch_20">
     <path d="M 233.105968 357.464 
 L 249.429428 357.464 
-L 249.429428 268.958084 
-L 233.105968 268.958084 
+L 249.429428 290.14414 
+L 233.105968 290.14414 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#hb632e100ed); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#hca5aa1d21b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 298.399809 357.464 
 L 314.72327 357.464 
-L 314.72327 143.334409 
-L 298.399809 143.334409 
+L 314.72327 144.301085 
+L 298.399809 144.301085 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#hb632e100ed); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#hca5aa1d21b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 363.693651 357.464 
 L 380.017111 357.464 
-L 380.017111 325.944607 
-L 363.693651 325.944607 
+L 380.017111 331.939136 
+L 363.693651 331.939136 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#hb632e100ed); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#hca5aa1d21b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 428.987493 357.464 
 L 445.310953 357.464 
-L 445.310953 325.852525 
-L 428.987493 325.852525 
+L 445.310953 331.877814 
+L 428.987493 331.877814 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#hb632e100ed); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#hca5aa1d21b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 494.281334 357.464 
 L 510.604795 357.464 
-L 510.604795 254.668929 
-L 494.281334 254.668929 
+L 510.604795 278.170784 
+L 494.281334 278.170784 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#hb632e100ed); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#hca5aa1d21b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 559.575176 357.464 
 L 575.898636 357.464 
-L 575.898636 98.144954 
-L 559.575176 98.144954 
+L 575.898636 96.921079 
+L 559.575176 96.921079 
 z
-" clip-path="url(#p594637defc)" style="fill: url(#hb632e100ed); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0b9c3d7ea9)" style="fill: url(#hca5aa1d21b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_34">
-    <!-- 9.15 s -->
-    <g style="fill: #ffffff" transform="translate(244.027073 263.958084) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
+   <g id="text_36">
+    <!-- 8.35 s -->
+    <g style="fill: #ffffff" transform="translate(244.027073 285.14414) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="95.410156"/>
      <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_35">
-    <!-- 22.1 s -->
-    <g style="fill: #ffffff" transform="translate(309.320915 138.334409) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 3.26 s -->
-    <g style="fill: #ffffff" transform="translate(374.614756 320.944607) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
    <g id="text_37">
-    <!-- 3.27 s -->
-    <g style="fill: #ffffff" transform="translate(439.908598 320.852525) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+    <!-- 26.4 s -->
+    <g style="fill: #ffffff" transform="translate(309.320915 139.301085) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 10.6 s -->
-    <g style="fill: #ffffff" transform="translate(505.20244 249.668929) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+    <!-- 3.17 s -->
+    <g style="fill: #ffffff" transform="translate(374.614756 326.939136) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 26.8 s -->
-    <g style="fill: #ffffff" transform="translate(570.496281 93.144954) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+    <!-- 3.17 s -->
+    <g style="fill: #ffffff" transform="translate(439.908598 326.877814) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_40">
+    <!-- 9.83 s -->
+    <g style="fill: #ffffff" transform="translate(505.20244 273.170784) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- 32.3 s -->
+    <g style="fill: #ffffff" transform="translate(570.496281 91.921079) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_42">
     <!-- filled random n=1000 (calculate and render) -->
     <g style="fill: #ffffff" transform="translate(188.47 20.88) scale(0.12 -0.12)">
      <defs>
@@ -1828,7 +1866,7 @@ L 332.4513 41.896413
 z
 " style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_41">
+    <g id="text_43">
      <!-- mpl2005 no mask -->
      <g style="fill: #ffffff" transform="translate(360.4513 48.896413) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1854,9 +1892,9 @@ L 352.4513 63.574538
 L 352.4513 56.574538 
 L 332.4513 56.574538 
 z
-" style="fill: url(#hc1b541cf6e); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hf9a8ee1c3e); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_42">
+    <g id="text_44">
      <!-- mpl2005 corner_mask=False -->
      <g style="fill: #ffffff" transform="translate(360.4513 63.574538) scale(0.1 -0.1)">
       <defs>
@@ -1916,7 +1954,7 @@ L 332.4513 71.530788
 z
 " style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_43">
+    <g id="text_45">
      <!-- mpl2014 no mask -->
      <g style="fill: #ffffff" transform="translate(360.4513 78.530788) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1942,9 +1980,9 @@ L 352.4513 93.208913
 L 352.4513 86.208913 
 L 332.4513 86.208913 
 z
-" style="fill: url(#h3bc8b485bf); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h6e3a7e9d72); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_44">
+    <g id="text_46">
      <!-- mpl2014 corner_mask=False -->
      <g style="fill: #ffffff" transform="translate(360.4513 93.208913) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1980,9 +2018,9 @@ L 352.4513 108.165163
 L 352.4513 101.165163 
 L 332.4513 101.165163 
 z
-" style="fill: url(#h31bd45faee); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h25eba87fa4); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_45">
+    <g id="text_47">
      <!-- mpl2014 corner_mask=True -->
      <g style="fill: #ffffff" transform="translate(360.4513 108.165163) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -2019,7 +2057,7 @@ L 332.4513 116.121413
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_46">
+    <g id="text_48">
      <!-- serial no mask -->
      <g style="fill: #ffffff" transform="translate(360.4513 123.121413) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2044,9 +2082,9 @@ L 352.4513 137.799538
 L 352.4513 130.799538 
 L 332.4513 130.799538 
 z
-" style="fill: url(#h0431148a7a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h0256f7fa53); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_47">
+    <g id="text_49">
      <!-- serial corner_mask=False -->
      <g style="fill: #ffffff" transform="translate(360.4513 137.799538) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2081,9 +2119,9 @@ L 352.4513 152.755788
 L 352.4513 145.755788 
 L 332.4513 145.755788 
 z
-" style="fill: url(#hb632e100ed); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hca5aa1d21b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_48">
+    <g id="text_50">
      <!-- serial corner_mask=True -->
      <g style="fill: #ffffff" transform="translate(360.4513 152.755788) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2115,12 +2153,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p594637defc">
+  <clipPath id="p0b9c3d7ea9">
    <rect x="44.57" y="26.88" width="556.63" height="330.584"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="hc1b541cf6e" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hf9a8ee1c3e" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2160,7 +2198,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h3bc8b485bf" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h6e3a7e9d72" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2200,7 +2238,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h31bd45faee" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h25eba87fa4" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2242,7 +2280,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h0431148a7a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h0256f7fa53" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2282,7 +2320,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hb632e100ed" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hca5aa1d21b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/filled_random_1000_render_light.svg
+++ b/docs/_static/filled_random_1000_render_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:07.019237</dc:date>
+    <dc:date>2024-05-06T19:15:02.808872</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m44779207a1" d="M 0 0 
+       <path id="mb75ad38db6" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m44779207a1" x="94.356554" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb75ad38db6" x="94.356554" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -395,7 +395,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m44779207a1" x="159.650396" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb75ad38db6" x="159.650396" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -464,7 +464,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m44779207a1" x="224.944238" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb75ad38db6" x="224.944238" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -576,7 +576,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m44779207a1" x="290.238079" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb75ad38db6" x="290.238079" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -634,7 +634,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m44779207a1" x="355.531921" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb75ad38db6" x="355.531921" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -760,7 +760,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m44779207a1" x="420.825762" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb75ad38db6" x="420.825762" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -806,7 +806,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m44779207a1" x="486.119604" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb75ad38db6" x="486.119604" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -859,7 +859,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m44779207a1" x="551.413446" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb75ad38db6" x="551.413446" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -917,16 +917,16 @@ z
      <g id="line2d_9">
       <path d="M 44.57 357.464 
 L 601.2 357.464 
-" clip-path="url(#pa1a75ec115)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p92f53444f6)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <defs>
-       <path id="m851a978492" d="M 0 0 
+       <path id="m2e5a9bde13" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m851a978492" x="44.57" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e5a9bde13" x="44.57" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -938,36 +938,36 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_11">
-      <path d="M 44.57 309.075598 
-L 601.2 309.075598 
-" clip-path="url(#pa1a75ec115)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 317.143648 
+L 601.2 317.143648 
+" clip-path="url(#p92f53444f6)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m851a978492" x="44.57" y="309.075598" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e5a9bde13" x="44.57" y="317.143648" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 5 -->
-      <g transform="translate(31.2075 312.874816) scale(0.1 -0.1)">
+      <g transform="translate(31.2075 320.942866) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-35"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_13">
-      <path d="M 44.57 260.687195 
-L 601.2 260.687195 
-" clip-path="url(#pa1a75ec115)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 276.823295 
+L 601.2 276.823295 
+" clip-path="url(#p92f53444f6)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m851a978492" x="44.57" y="260.687195" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e5a9bde13" x="44.57" y="276.823295" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10 -->
-      <g transform="translate(24.845 264.486414) scale(0.1 -0.1)">
+      <g transform="translate(24.845 280.622514) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" x="63.623047"/>
       </g>
@@ -975,18 +975,18 @@ L 601.2 260.687195
     </g>
     <g id="ytick_4">
      <g id="line2d_15">
-      <path d="M 44.57 212.298793 
-L 601.2 212.298793 
-" clip-path="url(#pa1a75ec115)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 236.502943 
+L 601.2 236.502943 
+" clip-path="url(#p92f53444f6)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m851a978492" x="44.57" y="212.298793" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e5a9bde13" x="44.57" y="236.502943" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 15 -->
-      <g transform="translate(24.845 216.098011) scale(0.1 -0.1)">
+      <g transform="translate(24.845 240.302162) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-35" x="63.623047"/>
       </g>
@@ -994,18 +994,18 @@ L 601.2 212.298793
     </g>
     <g id="ytick_5">
      <g id="line2d_17">
-      <path d="M 44.57 163.91039 
-L 601.2 163.91039 
-" clip-path="url(#pa1a75ec115)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 196.182591 
+L 601.2 196.182591 
+" clip-path="url(#p92f53444f6)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m851a978492" x="44.57" y="163.91039" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e5a9bde13" x="44.57" y="196.182591" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 20 -->
-      <g transform="translate(24.845 167.709609) scale(0.1 -0.1)">
+      <g transform="translate(24.845 199.981809) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-30" x="63.623047"/>
       </g>
@@ -1013,18 +1013,18 @@ L 601.2 163.91039
     </g>
     <g id="ytick_6">
      <g id="line2d_19">
-      <path d="M 44.57 115.521988 
-L 601.2 115.521988 
-" clip-path="url(#pa1a75ec115)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 155.862238 
+L 601.2 155.862238 
+" clip-path="url(#p92f53444f6)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m851a978492" x="44.57" y="115.521988" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e5a9bde13" x="44.57" y="155.862238" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 25 -->
-      <g transform="translate(24.845 119.321206) scale(0.1 -0.1)">
+      <g transform="translate(24.845 159.661457) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-35" x="63.623047"/>
       </g>
@@ -1032,18 +1032,18 @@ L 601.2 115.521988
     </g>
     <g id="ytick_7">
      <g id="line2d_21">
-      <path d="M 44.57 67.133585 
-L 601.2 67.133585 
-" clip-path="url(#pa1a75ec115)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 115.541886 
+L 601.2 115.541886 
+" clip-path="url(#p92f53444f6)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m851a978492" x="44.57" y="67.133585" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e5a9bde13" x="44.57" y="115.541886" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 30 -->
-      <g transform="translate(24.845 70.932804) scale(0.1 -0.1)">
+      <g transform="translate(24.845 119.341105) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1083,7 +1083,45 @@ z
       </g>
      </g>
     </g>
-    <g id="text_16">
+    <g id="ytick_8">
+     <g id="line2d_23">
+      <path d="M 44.57 75.221534 
+L 601.2 75.221534 
+" clip-path="url(#p92f53444f6)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m2e5a9bde13" x="44.57" y="75.221534" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 35 -->
+      <g transform="translate(24.845 79.020753) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_25">
+      <path d="M 44.57 34.901181 
+L 601.2 34.901181 
+" clip-path="url(#p92f53444f6)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m2e5a9bde13" x="44.57" y="34.901181" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 40 -->
+      <g transform="translate(24.845 38.7004) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
      <!-- Time (seconds) -->
      <g transform="translate(18.765313 230.333719) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1167,14 +1205,14 @@ z
    <g id="patch_3">
     <path d="M 69.871364 357.464 
 L 86.194824 357.464 
-L 86.194824 176.725772 
-L 69.871364 176.725772 
+L 86.194824 209.147443 
+L 69.871364 209.147443 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_17">
-    <!-- 18.7 s -->
-    <g transform="translate(80.792469 171.725772) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_19">
+    <!-- 18.4 s -->
+    <g transform="translate(80.792469 204.147443) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1222,21 +1260,11 @@ L 684 0
 L 684 794 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1244,14 +1272,14 @@ z
    <g id="patch_4">
     <path d="M 86.194824 357.464 
 L 102.518284 357.464 
-L 102.518284 261.329711 
-L 86.194824 261.329711 
+L 102.518284 284.421091 
+L 86.194824 284.421091 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#h88ffe070dd); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#hca308c86e3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_18">
-    <!-- 9.93 s -->
-    <g transform="translate(97.115929 256.329711) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_20">
+    <!-- 9.06 s -->
+    <g transform="translate(97.115929 279.421091) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1283,46 +1311,6 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 135.165205 357.464 
-L 151.488666 357.464 
-L 151.488666 257.347675 
-L 135.165205 257.347675 
-z
-" clip-path="url(#pa1a75ec115)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 10.3 s -->
-    <g transform="translate(146.08631 252.347675) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 151.488666 357.464 
-L 167.812126 357.464 
-L 167.812126 255.108085 
-L 151.488666 255.108085 
-z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#hfea3a756ec); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 10.6 s -->
-    <g transform="translate(162.409771 250.108085) rotate(-90) scale(0.1 -0.1)">
-     <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
 Q 1191 2003 1191 1497 
@@ -1354,10 +1342,60 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
      <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 135.165205 357.464 
+L 151.488666 357.464 
+L 151.488666 279.539224 
+L 135.165205 279.539224 
+z
+" clip-path="url(#p92f53444f6)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 9.66 s -->
+    <g transform="translate(146.08631 274.539224) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 151.488666 357.464 
+L 167.812126 357.464 
+L 167.812126 279.111813 
+L 151.488666 279.111813 
+z
+" clip-path="url(#p92f53444f6)" style="fill: url(#h50719f2552); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 9.72 s -->
+    <g transform="translate(162.409771 274.111813) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1365,18 +1403,18 @@ z
    <g id="patch_7">
     <path d="M 167.812126 357.464 
 L 184.135587 357.464 
-L 184.135587 259.820896 
-L 167.812126 259.820896 
+L 184.135587 282.001267 
+L 167.812126 282.001267 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#h7b1407cb75); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#ha358ebcac9); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_21">
-    <!-- 10.1 s -->
-    <g transform="translate(178.733231 254.820896) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+   <g id="text_23">
+    <!-- 9.36 s -->
+    <g transform="translate(178.733231 277.001267) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1384,88 +1422,55 @@ z
    <g id="patch_8">
     <path d="M 200.459047 357.464 
 L 216.782507 357.464 
-L 216.782507 269.402649 
-L 200.459047 269.402649 
+L 216.782507 290.541168 
+L 200.459047 290.541168 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 265.752889 357.464 
 L 282.076349 357.464 
-L 282.076349 146.451347 
-L 265.752889 146.451347 
+L 282.076349 143.330732 
+L 265.752889 143.330732 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 331.04673 357.464 
 L 347.370191 357.464 
-L 347.370191 325.862796 
-L 331.04673 325.862796 
+L 347.370191 331.737668 
+L 331.04673 331.737668 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 396.340572 357.464 
 L 412.664032 357.464 
-L 412.664032 325.51731 
-L 396.340572 325.51731 
+L 412.664032 331.894894 
+L 396.340572 331.894894 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 461.634413 357.464 
 L 477.957874 357.464 
-L 477.957874 254.534616 
-L 461.634413 254.534616 
+L 477.957874 278.78245 
+L 461.634413 278.78245 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 526.928255 357.464 
 L 543.251716 357.464 
-L 543.251716 100.512685 
-L 526.928255 100.512685 
+L 543.251716 96.754815 
+L 526.928255 96.754815 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 9.10 s -->
-    <g transform="translate(211.380152 264.402649) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 21.8 s -->
-    <g transform="translate(276.673994 141.451347) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
+" clip-path="url(#p92f53444f6)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_24">
-    <!-- 3.27 s -->
-    <g transform="translate(341.967835 320.862796) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 3.30 s -->
-    <g transform="translate(407.261677 320.51731) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
+    <!-- 8.30 s -->
+    <g transform="translate(211.380152 285.541168) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="95.410156"/>
      <use xlink:href="#DejaVuSans-30" x="159.033203"/>
@@ -1473,24 +1478,57 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- 10.6 s -->
-    <g transform="translate(472.555519 249.534616) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+   <g id="text_25">
+    <!-- 26.6 s -->
+    <g transform="translate(276.673994 138.330732) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
+   <g id="text_26">
+    <!-- 3.19 s -->
+    <g transform="translate(341.967835 326.737668) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
    <g id="text_27">
-    <!-- 26.6 s -->
-    <g transform="translate(537.84936 95.512685) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+    <!-- 3.17 s -->
+    <g transform="translate(407.261677 326.894894) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 9.76 s -->
+    <g transform="translate(472.555519 273.78245) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
      <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 32.3 s -->
+    <g transform="translate(537.84936 91.754815) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1498,42 +1536,42 @@ z
    <g id="patch_14">
     <path d="M 216.782507 357.464 
 L 233.105968 357.464 
-L 233.105968 263.924485 
-L 216.782507 263.924485 
+L 233.105968 286.226753 
+L 216.782507 286.226753 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#h888df09f82); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#h9ecd70dd24); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 282.076349 357.464 
 L 298.399809 357.464 
-L 298.399809 124.066723 
-L 282.076349 124.066723 
+L 298.399809 119.174918 
+L 282.076349 119.174918 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#h888df09f82); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#h9ecd70dd24); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 347.370191 357.464 
 L 363.693651 357.464 
-L 363.693651 327.948602 
-L 347.370191 327.948602 
+L 363.693651 333.716924 
+L 347.370191 333.716924 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#h888df09f82); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#h9ecd70dd24); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 412.664032 357.464 
 L 428.987493 357.464 
-L 428.987493 327.97582 
-L 412.664032 327.97582 
+L 428.987493 333.654621 
+L 412.664032 333.654621 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#h888df09f82); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#h9ecd70dd24); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 477.957874 357.464 
 L 494.281334 357.464 
-L 494.281334 247.023573 
-L 477.957874 247.023573 
+L 494.281334 272.995487 
+L 477.957874 272.995487 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#h888df09f82); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#h9ecd70dd24); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 543.251716 357.464 
@@ -1541,70 +1579,70 @@ L 559.575176 357.464
 L 559.575176 71.244087 
 L 543.251716 71.244087 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#h888df09f82); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_28">
-    <!-- 9.67 s -->
-    <g transform="translate(227.703613 258.924485) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 24.1 s -->
-    <g transform="translate(292.997454 119.066723) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
+" clip-path="url(#p92f53444f6)" style="fill: url(#h9ecd70dd24); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_30">
-    <!-- 3.05 s -->
-    <g transform="translate(358.291296 322.948602) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
+    <!-- 8.83 s -->
+    <g transform="translate(227.703613 281.226753) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-38" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 3.05 s -->
-    <g transform="translate(423.585137 322.97582) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+    <!-- 29.5 s -->
+    <g transform="translate(292.997454 114.174918) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 11.4 s -->
-    <g transform="translate(488.878979 242.023573) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+    <!-- 2.94 s -->
+    <g transform="translate(358.291296 328.716924) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="95.410156"/>
      <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 29.6 s -->
-    <g transform="translate(554.172821 66.244087) rotate(-90) scale(0.1 -0.1)">
+    <!-- 2.95 s -->
+    <g transform="translate(423.585137 328.654621) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 10.5 s -->
+    <g transform="translate(488.878979 267.995487) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 35.5 s -->
+    <g transform="translate(554.172821 66.244087) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1612,118 +1650,118 @@ z
    <g id="patch_20">
     <path d="M 233.105968 357.464 
 L 249.429428 357.464 
-L 249.429428 268.958084 
-L 233.105968 268.958084 
+L 249.429428 290.14414 
+L 233.105968 290.14414 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#hed7ea4fe48); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#hef7ae16f65); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 298.399809 357.464 
 L 314.72327 357.464 
-L 314.72327 143.334409 
-L 298.399809 143.334409 
+L 314.72327 144.301085 
+L 298.399809 144.301085 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#hed7ea4fe48); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#hef7ae16f65); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 363.693651 357.464 
 L 380.017111 357.464 
-L 380.017111 325.944607 
-L 363.693651 325.944607 
+L 380.017111 331.939136 
+L 363.693651 331.939136 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#hed7ea4fe48); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#hef7ae16f65); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 428.987493 357.464 
 L 445.310953 357.464 
-L 445.310953 325.852525 
-L 428.987493 325.852525 
+L 445.310953 331.877814 
+L 428.987493 331.877814 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#hed7ea4fe48); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#hef7ae16f65); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 494.281334 357.464 
 L 510.604795 357.464 
-L 510.604795 254.668929 
-L 494.281334 254.668929 
+L 510.604795 278.170784 
+L 494.281334 278.170784 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#hed7ea4fe48); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#hef7ae16f65); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 559.575176 357.464 
 L 575.898636 357.464 
-L 575.898636 98.144954 
-L 559.575176 98.144954 
+L 575.898636 96.921079 
+L 559.575176 96.921079 
 z
-" clip-path="url(#pa1a75ec115)" style="fill: url(#hed7ea4fe48); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p92f53444f6)" style="fill: url(#hef7ae16f65); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_34">
-    <!-- 9.15 s -->
-    <g transform="translate(244.027073 263.958084) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
+   <g id="text_36">
+    <!-- 8.35 s -->
+    <g transform="translate(244.027073 285.14414) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="95.410156"/>
      <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_35">
-    <!-- 22.1 s -->
-    <g transform="translate(309.320915 138.334409) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 3.26 s -->
-    <g transform="translate(374.614756 320.944607) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
    <g id="text_37">
-    <!-- 3.27 s -->
-    <g transform="translate(439.908598 320.852525) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+    <!-- 26.4 s -->
+    <g transform="translate(309.320915 139.301085) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 10.6 s -->
-    <g transform="translate(505.20244 249.668929) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+    <!-- 3.17 s -->
+    <g transform="translate(374.614756 326.939136) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 26.8 s -->
-    <g transform="translate(570.496281 93.144954) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+    <!-- 3.17 s -->
+    <g transform="translate(439.908598 326.877814) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_40">
+    <!-- 9.83 s -->
+    <g transform="translate(505.20244 273.170784) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- 32.3 s -->
+    <g transform="translate(570.496281 91.921079) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_42">
     <!-- filled random n=1000 (calculate and render) -->
     <g transform="translate(188.47 20.88) scale(0.12 -0.12)">
      <defs>
@@ -1828,7 +1866,7 @@ L 332.4513 41.896413
 z
 " style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_41">
+    <g id="text_43">
      <!-- mpl2005 no mask -->
      <g transform="translate(360.4513 48.896413) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1854,9 +1892,9 @@ L 352.4513 63.574538
 L 352.4513 56.574538 
 L 332.4513 56.574538 
 z
-" style="fill: url(#h88ffe070dd); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hca308c86e3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_42">
+    <g id="text_44">
      <!-- mpl2005 corner_mask=False -->
      <g transform="translate(360.4513 63.574538) scale(0.1 -0.1)">
       <defs>
@@ -1916,7 +1954,7 @@ L 332.4513 71.530788
 z
 " style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_43">
+    <g id="text_45">
      <!-- mpl2014 no mask -->
      <g transform="translate(360.4513 78.530788) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1942,9 +1980,9 @@ L 352.4513 93.208913
 L 352.4513 86.208913 
 L 332.4513 86.208913 
 z
-" style="fill: url(#hfea3a756ec); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h50719f2552); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_44">
+    <g id="text_46">
      <!-- mpl2014 corner_mask=False -->
      <g transform="translate(360.4513 93.208913) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1980,9 +2018,9 @@ L 352.4513 108.165163
 L 352.4513 101.165163 
 L 332.4513 101.165163 
 z
-" style="fill: url(#h7b1407cb75); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#ha358ebcac9); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_45">
+    <g id="text_47">
      <!-- mpl2014 corner_mask=True -->
      <g transform="translate(360.4513 108.165163) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -2019,7 +2057,7 @@ L 332.4513 116.121413
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_46">
+    <g id="text_48">
      <!-- serial no mask -->
      <g transform="translate(360.4513 123.121413) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2044,9 +2082,9 @@ L 352.4513 137.799538
 L 352.4513 130.799538 
 L 332.4513 130.799538 
 z
-" style="fill: url(#h888df09f82); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h9ecd70dd24); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_47">
+    <g id="text_49">
      <!-- serial corner_mask=False -->
      <g transform="translate(360.4513 137.799538) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2081,9 +2119,9 @@ L 352.4513 152.755788
 L 352.4513 145.755788 
 L 332.4513 145.755788 
 z
-" style="fill: url(#hed7ea4fe48); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hef7ae16f65); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_48">
+    <g id="text_50">
      <!-- serial corner_mask=True -->
      <g transform="translate(360.4513 152.755788) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2115,12 +2153,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pa1a75ec115">
+  <clipPath id="p92f53444f6">
    <rect x="44.57" y="26.88" width="556.63" height="330.584"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h88ffe070dd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hca308c86e3" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2160,7 +2198,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hfea3a756ec" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h50719f2552" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2200,7 +2238,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h7b1407cb75" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="ha358ebcac9" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2242,7 +2280,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h888df09f82" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9ecd70dd24" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2282,7 +2320,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hed7ea4fe48" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hef7ae16f65" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/filled_simple_1000_dark.svg
+++ b/docs/_static/filled_simple_1000_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:05.274264</dc:date>
+    <dc:date>2024-05-06T19:15:01.114963</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m1af7c69cee" d="M 0 0 
+       <path id="m28bfef4a0a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1af7c69cee" x="102.96132" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m28bfef4a0a" x="102.96132" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -395,7 +395,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m1af7c69cee" x="167.146657" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m28bfef4a0a" x="167.146657" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -464,7 +464,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m1af7c69cee" x="231.331994" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m28bfef4a0a" x="231.331994" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -576,7 +576,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m1af7c69cee" x="295.517331" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m28bfef4a0a" x="295.517331" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -634,7 +634,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m1af7c69cee" x="359.702669" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m28bfef4a0a" x="359.702669" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -760,7 +760,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m1af7c69cee" x="423.888006" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m28bfef4a0a" x="423.888006" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -806,7 +806,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m1af7c69cee" x="488.073343" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m28bfef4a0a" x="488.073343" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -859,7 +859,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m1af7c69cee" x="552.25868" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m28bfef4a0a" x="552.25868" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -917,16 +917,16 @@ z
      <g id="line2d_9">
       <path d="M 54.02 357.464 
 L 601.2 357.464 
-" clip-path="url(#p9a758c5581)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p1c978982cf)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <defs>
-       <path id="mc346564096" d="M 0 0 
+       <path id="m773dbb6dc5" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc346564096" x="54.02" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m773dbb6dc5" x="54.02" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -950,18 +950,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_11">
-      <path d="M 54.02 302.366667 
-L 601.2 302.366667 
-" clip-path="url(#p9a758c5581)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 296.244741 
+L 601.2 296.244741 
+" clip-path="url(#p1c978982cf)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc346564096" x="54.02" y="302.366667" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m773dbb6dc5" x="54.02" y="296.244741" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.05 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 306.165885) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 300.043959) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -971,18 +971,18 @@ L 601.2 302.366667
     </g>
     <g id="ytick_3">
      <g id="line2d_13">
-      <path d="M 54.02 247.269333 
-L 601.2 247.269333 
-" clip-path="url(#p9a758c5581)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 235.025481 
+L 601.2 235.025481 
+" clip-path="url(#p1c978982cf)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc346564096" x="54.02" y="247.269333" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m773dbb6dc5" x="54.02" y="235.025481" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.10 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 251.068552) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 238.8247) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -992,18 +992,18 @@ L 601.2 247.269333
     </g>
     <g id="ytick_4">
      <g id="line2d_15">
-      <path d="M 54.02 192.172 
-L 601.2 192.172 
-" clip-path="url(#p9a758c5581)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 173.806222 
+L 601.2 173.806222 
+" clip-path="url(#p1c978982cf)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc346564096" x="54.02" y="192.172" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m773dbb6dc5" x="54.02" y="173.806222" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.15 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 195.971219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 177.605441) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1013,18 +1013,18 @@ L 601.2 192.172
     </g>
     <g id="ytick_5">
      <g id="line2d_17">
-      <path d="M 54.02 137.074667 
-L 601.2 137.074667 
-" clip-path="url(#p9a758c5581)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 112.586963 
+L 601.2 112.586963 
+" clip-path="url(#p1c978982cf)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc346564096" x="54.02" y="137.074667" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m773dbb6dc5" x="54.02" y="112.586963" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.20 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 140.873885) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 116.386182) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1034,18 +1034,18 @@ L 601.2 137.074667
     </g>
     <g id="ytick_6">
      <g id="line2d_19">
-      <path d="M 54.02 81.977333 
-L 601.2 81.977333 
-" clip-path="url(#p9a758c5581)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 51.367704 
+L 601.2 51.367704 
+" clip-path="url(#p1c978982cf)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc346564096" x="54.02" y="81.977333" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m773dbb6dc5" x="54.02" y="51.367704" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.25 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 85.776552) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 55.166922) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1053,62 +1053,7 @@ L 601.2 81.977333
       </g>
      </g>
     </g>
-    <g id="ytick_7">
-     <g id="line2d_21">
-      <path d="M 54.02 26.88 
-L 601.2 26.88 
-" clip-path="url(#p9a758c5581)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_22">
-      <g>
-       <use xlink:href="#mc346564096" x="54.02" y="26.88" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 0.30 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 30.679219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_16">
+    <g id="text_15">
      <!-- Time (seconds) -->
      <g style="fill: #ffffff" transform="translate(18.674688 230.333719) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1192,17 +1137,17 @@ z
    <g id="patch_3">
     <path d="M 78.891818 357.464 
 L 94.938152 357.464 
-L 94.938152 192.412389 
-L 78.891818 192.412389 
+L 94.938152 217.240237 
+L 78.891818 217.240237 
 z
-" clip-path="url(#p9a758c5581)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c978982cf)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_17">
-    <!-- 150 ms -->
-    <g style="fill: #ffffff" transform="translate(89.67436 187.412389) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_16">
+    <!-- 115 ms -->
+    <g style="fill: #ffffff" transform="translate(89.67436 212.240237) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1211,310 +1156,14 @@ z
    <g id="patch_4">
     <path d="M 94.938152 357.464 
 L 110.984487 357.464 
-L 110.984487 184.89684 
-L 94.938152 184.89684 
+L 110.984487 212.819918 
+L 94.938152 212.819918 
 z
-" clip-path="url(#p9a758c5581)" style="fill: url(#hb935814d91); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c978982cf)" style="fill: url(#h50a6f1eb34); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_18">
-    <!-- 157 ms -->
-    <g style="fill: #ffffff" transform="translate(105.720695 179.89684) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 143.077155 357.464 
-L 159.12349 357.464 
-L 159.12349 87.299009 
-L 143.077155 87.299009 
-z
-" clip-path="url(#p9a758c5581)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 245 ms -->
-    <g style="fill: #ffffff" transform="translate(153.859698 82.299009) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 159.12349 357.464 
-L 175.169824 357.464 
-L 175.169824 123.284135 
-L 159.12349 123.284135 
-z
-" clip-path="url(#p9a758c5581)" style="fill: url(#hbd172e44b9); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 213 ms -->
-    <g style="fill: #ffffff" transform="translate(169.906032 118.284135) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 175.169824 357.464 
-L 191.216158 357.464 
-L 191.216158 116.160077 
-L 175.169824 116.160077 
-z
-" clip-path="url(#p9a758c5581)" style="fill: url(#hc84d416e00); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 219 ms -->
-    <g style="fill: #ffffff" transform="translate(185.952366 111.160077) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 207.262493 357.464 
-L 223.308827 357.464 
-L 223.308827 208.369783 
-L 207.262493 208.369783 
-z
-" clip-path="url(#p9a758c5581)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 271.44783 357.464 
-L 287.494164 357.464 
-L 287.494164 208.454404 
-L 271.44783 208.454404 
-z
-" clip-path="url(#p9a758c5581)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 335.633167 357.464 
-L 351.679501 357.464 
-L 351.679501 208.428719 
-L 335.633167 208.428719 
-z
-" clip-path="url(#p9a758c5581)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 399.818504 357.464 
-L 415.864839 357.464 
-L 415.864839 208.170679 
-L 399.818504 208.170679 
-z
-" clip-path="url(#p9a758c5581)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 464.003842 357.464 
-L 480.050176 357.464 
-L 480.050176 208.163875 
-L 464.003842 208.163875 
-z
-" clip-path="url(#p9a758c5581)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 528.189179 357.464 
-L 544.235513 357.464 
-L 544.235513 208.402958 
-L 528.189179 208.402958 
-z
-" clip-path="url(#p9a758c5581)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(218.045035 203.369783) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(282.230372 203.454404) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(346.415709 203.428719) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(410.601047 203.170679) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(474.786384 203.163875) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(538.971721 203.402958) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_14">
-    <path d="M 223.308827 357.464 
-L 239.355161 357.464 
-L 239.355161 215.473028 
-L 223.308827 215.473028 
-z
-" clip-path="url(#p9a758c5581)" style="fill: url(#h2545af1118); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 287.494164 357.464 
-L 303.540499 357.464 
-L 303.540499 215.663367 
-L 287.494164 215.663367 
-z
-" clip-path="url(#p9a758c5581)" style="fill: url(#h2545af1118); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 351.679501 357.464 
-L 367.725836 357.464 
-L 367.725836 215.908618 
-L 351.679501 215.908618 
-z
-" clip-path="url(#p9a758c5581)" style="fill: url(#h2545af1118); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 415.864839 357.464 
-L 431.911173 357.464 
-L 431.911173 215.792327 
-L 415.864839 215.792327 
-z
-" clip-path="url(#p9a758c5581)" style="fill: url(#h2545af1118); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 480.050176 357.464 
-L 496.09651 357.464 
-L 496.09651 215.645767 
-L 480.050176 215.645767 
-z
-" clip-path="url(#p9a758c5581)" style="fill: url(#h2545af1118); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 544.235513 357.464 
-L 560.281848 357.464 
-L 560.281848 215.977658 
-L 544.235513 215.977658 
-z
-" clip-path="url(#p9a758c5581)" style="fill: url(#h2545af1118); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_28">
-    <!-- 129 ms -->
-    <g style="fill: #ffffff" transform="translate(234.091369 210.473028) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 129 ms -->
-    <g style="fill: #ffffff" transform="translate(298.276706 210.663367) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 128 ms -->
-    <g style="fill: #ffffff" transform="translate(362.462044 210.908618) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_17">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(105.720695 207.819918) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1557,7 +1206,368 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 143.077155 357.464 
+L 159.12349 357.464 
+L 159.12349 72.849842 
+L 143.077155 72.849842 
+z
+" clip-path="url(#p1c978982cf)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_18">
+    <!-- 232 ms -->
+    <g style="fill: #ffffff" transform="translate(153.859698 67.849842) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 159.12349 357.464 
+L 175.169824 357.464 
+L 175.169824 93.938019 
+L 159.12349 93.938019 
+z
+" clip-path="url(#p1c978982cf)" style="fill: url(#h882247c18a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 215 ms -->
+    <g style="fill: #ffffff" transform="translate(169.906032 88.938019) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 175.169824 357.464 
+L 191.216158 357.464 
+L 191.216158 97.506096 
+L 175.169824 97.506096 
+z
+" clip-path="url(#p1c978982cf)" style="fill: url(#h3c009a9e7f); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 212 ms -->
+    <g style="fill: #ffffff" transform="translate(185.952366 92.506096) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 207.262493 357.464 
+L 223.308827 357.464 
+L 223.308827 215.819728 
+L 207.262493 215.819728 
+z
+" clip-path="url(#p1c978982cf)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 271.44783 357.464 
+L 287.494164 357.464 
+L 287.494164 215.479475 
+L 271.44783 215.479475 
+z
+" clip-path="url(#p1c978982cf)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 335.633167 357.464 
+L 351.679501 357.464 
+L 351.679501 213.338449 
+L 335.633167 213.338449 
+z
+" clip-path="url(#p1c978982cf)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 399.818504 357.464 
+L 415.864839 357.464 
+L 415.864839 213.556875 
+L 399.818504 213.556875 
+z
+" clip-path="url(#p1c978982cf)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 464.003842 357.464 
+L 480.050176 357.464 
+L 480.050176 213.093433 
+L 464.003842 213.093433 
+z
+" clip-path="url(#p1c978982cf)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 528.189179 357.464 
+L 544.235513 357.464 
+L 544.235513 213.041472 
+L 528.189179 213.041472 
+z
+" clip-path="url(#p1c978982cf)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 116 ms -->
+    <g style="fill: #ffffff" transform="translate(218.045035 210.819728) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 116 ms -->
+    <g style="fill: #ffffff" transform="translate(282.230372 210.479475) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(346.415709 208.338449) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(410.601047 208.556875) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(474.786384 208.093433) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(538.971721 208.041472) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_14">
+    <path d="M 223.308827 357.464 
+L 239.355161 357.464 
+L 239.355161 223.133498 
+L 223.308827 223.133498 
+z
+" clip-path="url(#p1c978982cf)" style="fill: url(#hbd0432aa3c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 287.494164 357.464 
+L 303.540499 357.464 
+L 303.540499 223.990047 
+L 287.494164 223.990047 
+z
+" clip-path="url(#p1c978982cf)" style="fill: url(#hbd0432aa3c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 351.679501 357.464 
+L 367.725836 357.464 
+L 367.725836 225.100934 
+L 351.679501 225.100934 
+z
+" clip-path="url(#p1c978982cf)" style="fill: url(#hbd0432aa3c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 415.864839 357.464 
+L 431.911173 357.464 
+L 431.911173 225.175862 
+L 415.864839 225.175862 
+z
+" clip-path="url(#p1c978982cf)" style="fill: url(#hbd0432aa3c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 480.050176 357.464 
+L 496.09651 357.464 
+L 496.09651 224.682557 
+L 480.050176 224.682557 
+z
+" clip-path="url(#p1c978982cf)" style="fill: url(#hbd0432aa3c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 544.235513 357.464 
+L 560.281848 357.464 
+L 560.281848 224.380123 
+L 544.235513 224.380123 
+z
+" clip-path="url(#p1c978982cf)" style="fill: url(#hbd0432aa3c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_27">
+    <!-- 110 ms -->
+    <g style="fill: #ffffff" transform="translate(234.091369 218.133498) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 109 ms -->
+    <g style="fill: #ffffff" transform="translate(298.276706 218.990047) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 108 ms -->
+    <g style="fill: #ffffff" transform="translate(362.462044 220.100934) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 108 ms -->
+    <g style="fill: #ffffff" transform="translate(426.647381 220.175862) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1565,33 +1575,22 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 129 ms -->
-    <g style="fill: #ffffff" transform="translate(426.647381 210.792327) rotate(-90) scale(0.1 -0.1)">
+    <!-- 108 ms -->
+    <g style="fill: #ffffff" transform="translate(490.832718 219.682557) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 129 ms -->
-    <g style="fill: #ffffff" transform="translate(490.832718 210.645767) rotate(-90) scale(0.1 -0.1)">
+    <!-- 109 ms -->
+    <g style="fill: #ffffff" transform="translate(555.018055 219.380123) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- 128 ms -->
-    <g style="fill: #ffffff" transform="translate(555.018055 210.977658) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1600,118 +1599,118 @@ z
    <g id="patch_20">
     <path d="M 239.355161 357.464 
 L 255.401496 357.464 
-L 255.401496 213.596102 
-L 239.355161 213.596102 
+L 255.401496 221.245294 
+L 239.355161 221.245294 
 z
-" clip-path="url(#p9a758c5581)" style="fill: url(#h59aae8eb10); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c978982cf)" style="fill: url(#hcc94cd978b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 303.540499 357.464 
 L 319.586833 357.464 
-L 319.586833 213.462995 
-L 303.540499 213.462995 
+L 319.586833 223.31227 
+L 303.540499 223.31227 
 z
-" clip-path="url(#p9a758c5581)" style="fill: url(#h59aae8eb10); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c978982cf)" style="fill: url(#hcc94cd978b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 367.725836 357.464 
 L 383.77217 357.464 
-L 383.77217 213.903083 
-L 367.725836 213.903083 
+L 383.77217 223.721026 
+L 367.725836 223.721026 
 z
-" clip-path="url(#p9a758c5581)" style="fill: url(#h59aae8eb10); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c978982cf)" style="fill: url(#hcc94cd978b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 431.911173 357.464 
 L 447.957507 357.464 
-L 447.957507 213.587995 
-L 431.911173 213.587995 
+L 447.957507 223.720004 
+L 431.911173 223.720004 
 z
-" clip-path="url(#p9a758c5581)" style="fill: url(#h59aae8eb10); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c978982cf)" style="fill: url(#hcc94cd978b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 496.09651 357.464 
 L 512.142845 357.464 
-L 512.142845 214.006237 
-L 496.09651 214.006237 
+L 512.142845 223.181776 
+L 496.09651 223.181776 
 z
-" clip-path="url(#p9a758c5581)" style="fill: url(#h59aae8eb10); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c978982cf)" style="fill: url(#hcc94cd978b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 560.281848 357.464 
 L 576.328182 357.464 
-L 576.328182 213.6646 
-L 560.281848 213.6646 
+L 576.328182 223.618136 
+L 560.281848 223.618136 
 z
-" clip-path="url(#p9a758c5581)" style="fill: url(#h59aae8eb10); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c978982cf)" style="fill: url(#hcc94cd978b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_33">
+    <!-- 111 ms -->
+    <g style="fill: #ffffff" transform="translate(250.137703 216.245294) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
    </g>
    <g id="text_34">
-    <!-- 131 ms -->
-    <g style="fill: #ffffff" transform="translate(250.137703 208.596102) rotate(-90) scale(0.1 -0.1)">
+    <!-- 110 ms -->
+    <g style="fill: #ffffff" transform="translate(314.323041 218.31227) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 131 ms -->
-    <g style="fill: #ffffff" transform="translate(314.323041 208.462995) rotate(-90) scale(0.1 -0.1)">
+    <!-- 109 ms -->
+    <g style="fill: #ffffff" transform="translate(378.508378 218.721026) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 130 ms -->
-    <g style="fill: #ffffff" transform="translate(378.508378 208.903083) rotate(-90) scale(0.1 -0.1)">
+    <!-- 109 ms -->
+    <g style="fill: #ffffff" transform="translate(442.693715 218.720004) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 131 ms -->
-    <g style="fill: #ffffff" transform="translate(442.693715 208.587995) rotate(-90) scale(0.1 -0.1)">
+    <!-- 110 ms -->
+    <g style="fill: #ffffff" transform="translate(506.879052 218.181776) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 130 ms -->
-    <g style="fill: #ffffff" transform="translate(506.879052 209.006237) rotate(-90) scale(0.1 -0.1)">
+    <!-- 109 ms -->
+    <g style="fill: #ffffff" transform="translate(571.06439 218.618136) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 130 ms -->
-    <g style="fill: #ffffff" transform="translate(571.06439 208.6646) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_40">
     <!-- filled simple n=1000  -->
     <g style="fill: #ffffff" transform="translate(263.370625 20.88) scale(0.12 -0.12)">
      <defs>
@@ -1794,7 +1793,7 @@ L 419.19375 36.478437
 z
 " style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_41">
+    <g id="text_40">
      <!-- mpl2005 no mask -->
      <g style="fill: #ffffff" transform="translate(447.19375 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1820,9 +1819,9 @@ L 439.19375 58.156563
 L 439.19375 51.156563 
 L 419.19375 51.156563 
 z
-" style="fill: url(#hb935814d91); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h50a6f1eb34); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_42">
+    <g id="text_41">
      <!-- mpl2005 corner_mask=False -->
      <g style="fill: #ffffff" transform="translate(447.19375 58.156563) scale(0.1 -0.1)">
       <defs>
@@ -1882,7 +1881,7 @@ L 419.19375 66.112812
 z
 " style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_43">
+    <g id="text_42">
      <!-- mpl2014 no mask -->
      <g style="fill: #ffffff" transform="translate(447.19375 73.112812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1908,9 +1907,9 @@ L 439.19375 87.790937
 L 439.19375 80.790937 
 L 419.19375 80.790937 
 z
-" style="fill: url(#hbd172e44b9); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h882247c18a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_44">
+    <g id="text_43">
      <!-- mpl2014 corner_mask=False -->
      <g style="fill: #ffffff" transform="translate(447.19375 87.790937) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1946,9 +1945,9 @@ L 439.19375 102.747187
 L 439.19375 95.747187 
 L 419.19375 95.747187 
 z
-" style="fill: url(#hc84d416e00); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h3c009a9e7f); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_45">
+    <g id="text_44">
      <!-- mpl2014 corner_mask=True -->
      <g style="fill: #ffffff" transform="translate(447.19375 102.747187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1985,7 +1984,7 @@ L 419.19375 110.703437
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_46">
+    <g id="text_45">
      <!-- serial no mask -->
      <g style="fill: #ffffff" transform="translate(447.19375 117.703437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2010,9 +2009,9 @@ L 439.19375 132.381562
 L 439.19375 125.381562 
 L 419.19375 125.381562 
 z
-" style="fill: url(#h2545af1118); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hbd0432aa3c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_47">
+    <g id="text_46">
      <!-- serial corner_mask=False -->
      <g style="fill: #ffffff" transform="translate(447.19375 132.381562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2047,9 +2046,9 @@ L 439.19375 147.337812
 L 439.19375 140.337812 
 L 419.19375 140.337812 
 z
-" style="fill: url(#h59aae8eb10); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hcc94cd978b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_48">
+    <g id="text_47">
      <!-- serial corner_mask=True -->
      <g style="fill: #ffffff" transform="translate(447.19375 147.337812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2081,12 +2080,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p9a758c5581">
+  <clipPath id="p1c978982cf">
    <rect x="54.02" y="26.88" width="547.18" height="330.584"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="hb935814d91" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h50a6f1eb34" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2126,7 +2125,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hbd172e44b9" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h882247c18a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2166,7 +2165,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hc84d416e00" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h3c009a9e7f" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2208,7 +2207,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h2545af1118" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hbd0432aa3c" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2248,7 +2247,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h59aae8eb10" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hcc94cd978b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/filled_simple_1000_light.svg
+++ b/docs/_static/filled_simple_1000_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:05.083364</dc:date>
+    <dc:date>2024-05-06T19:15:00.930251</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m092380b7ad" d="M 0 0 
+       <path id="m1826ec381c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m092380b7ad" x="102.96132" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1826ec381c" x="102.96132" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -395,7 +395,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m092380b7ad" x="167.146657" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1826ec381c" x="167.146657" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -464,7 +464,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m092380b7ad" x="231.331994" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1826ec381c" x="231.331994" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -576,7 +576,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m092380b7ad" x="295.517331" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1826ec381c" x="295.517331" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -634,7 +634,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m092380b7ad" x="359.702669" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1826ec381c" x="359.702669" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -760,7 +760,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m092380b7ad" x="423.888006" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1826ec381c" x="423.888006" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -806,7 +806,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m092380b7ad" x="488.073343" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1826ec381c" x="488.073343" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -859,7 +859,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m092380b7ad" x="552.25868" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1826ec381c" x="552.25868" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -917,16 +917,16 @@ z
      <g id="line2d_9">
       <path d="M 54.02 357.464 
 L 601.2 357.464 
-" clip-path="url(#p37ef70d189)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p94cde1cb1c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <defs>
-       <path id="m41ec72522d" d="M 0 0 
+       <path id="m5b3ec5658c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m41ec72522d" x="54.02" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b3ec5658c" x="54.02" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -950,18 +950,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_11">
-      <path d="M 54.02 302.366667 
-L 601.2 302.366667 
-" clip-path="url(#p37ef70d189)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 296.244741 
+L 601.2 296.244741 
+" clip-path="url(#p94cde1cb1c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m41ec72522d" x="54.02" y="302.366667" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b3ec5658c" x="54.02" y="296.244741" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.05 -->
-      <g transform="translate(24.754375 306.165885) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 300.043959) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -971,18 +971,18 @@ L 601.2 302.366667
     </g>
     <g id="ytick_3">
      <g id="line2d_13">
-      <path d="M 54.02 247.269333 
-L 601.2 247.269333 
-" clip-path="url(#p37ef70d189)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 235.025481 
+L 601.2 235.025481 
+" clip-path="url(#p94cde1cb1c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m41ec72522d" x="54.02" y="247.269333" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b3ec5658c" x="54.02" y="235.025481" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.10 -->
-      <g transform="translate(24.754375 251.068552) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 238.8247) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -992,18 +992,18 @@ L 601.2 247.269333
     </g>
     <g id="ytick_4">
      <g id="line2d_15">
-      <path d="M 54.02 192.172 
-L 601.2 192.172 
-" clip-path="url(#p37ef70d189)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 173.806222 
+L 601.2 173.806222 
+" clip-path="url(#p94cde1cb1c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m41ec72522d" x="54.02" y="192.172" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b3ec5658c" x="54.02" y="173.806222" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.15 -->
-      <g transform="translate(24.754375 195.971219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 177.605441) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1013,18 +1013,18 @@ L 601.2 192.172
     </g>
     <g id="ytick_5">
      <g id="line2d_17">
-      <path d="M 54.02 137.074667 
-L 601.2 137.074667 
-" clip-path="url(#p37ef70d189)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 112.586963 
+L 601.2 112.586963 
+" clip-path="url(#p94cde1cb1c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m41ec72522d" x="54.02" y="137.074667" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b3ec5658c" x="54.02" y="112.586963" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.20 -->
-      <g transform="translate(24.754375 140.873885) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 116.386182) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1034,18 +1034,18 @@ L 601.2 137.074667
     </g>
     <g id="ytick_6">
      <g id="line2d_19">
-      <path d="M 54.02 81.977333 
-L 601.2 81.977333 
-" clip-path="url(#p37ef70d189)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 51.367704 
+L 601.2 51.367704 
+" clip-path="url(#p94cde1cb1c)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m41ec72522d" x="54.02" y="81.977333" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b3ec5658c" x="54.02" y="51.367704" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 85.776552) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 55.166922) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1053,62 +1053,7 @@ L 601.2 81.977333
       </g>
      </g>
     </g>
-    <g id="ytick_7">
-     <g id="line2d_21">
-      <path d="M 54.02 26.88 
-L 601.2 26.88 
-" clip-path="url(#p37ef70d189)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_22">
-      <g>
-       <use xlink:href="#m41ec72522d" x="54.02" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 0.30 -->
-      <g transform="translate(24.754375 30.679219) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_16">
+    <g id="text_15">
      <!-- Time (seconds) -->
      <g transform="translate(18.674688 230.333719) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1192,17 +1137,17 @@ z
    <g id="patch_3">
     <path d="M 78.891818 357.464 
 L 94.938152 357.464 
-L 94.938152 192.412389 
-L 78.891818 192.412389 
+L 94.938152 217.240237 
+L 78.891818 217.240237 
 z
-" clip-path="url(#p37ef70d189)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p94cde1cb1c)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_17">
-    <!-- 150 ms -->
-    <g transform="translate(89.67436 187.412389) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_16">
+    <!-- 115 ms -->
+    <g transform="translate(89.67436 212.240237) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1211,310 +1156,14 @@ z
    <g id="patch_4">
     <path d="M 94.938152 357.464 
 L 110.984487 357.464 
-L 110.984487 184.89684 
-L 94.938152 184.89684 
+L 110.984487 212.819918 
+L 94.938152 212.819918 
 z
-" clip-path="url(#p37ef70d189)" style="fill: url(#h49a0087681); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#ha3633ca07c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_18">
-    <!-- 157 ms -->
-    <g transform="translate(105.720695 179.89684) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 143.077155 357.464 
-L 159.12349 357.464 
-L 159.12349 87.299009 
-L 143.077155 87.299009 
-z
-" clip-path="url(#p37ef70d189)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 245 ms -->
-    <g transform="translate(153.859698 82.299009) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 159.12349 357.464 
-L 175.169824 357.464 
-L 175.169824 123.284135 
-L 159.12349 123.284135 
-z
-" clip-path="url(#p37ef70d189)" style="fill: url(#h0d196596c1); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 213 ms -->
-    <g transform="translate(169.906032 118.284135) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 175.169824 357.464 
-L 191.216158 357.464 
-L 191.216158 116.160077 
-L 175.169824 116.160077 
-z
-" clip-path="url(#p37ef70d189)" style="fill: url(#h9e61b70246); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 219 ms -->
-    <g transform="translate(185.952366 111.160077) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 207.262493 357.464 
-L 223.308827 357.464 
-L 223.308827 208.369783 
-L 207.262493 208.369783 
-z
-" clip-path="url(#p37ef70d189)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 271.44783 357.464 
-L 287.494164 357.464 
-L 287.494164 208.454404 
-L 271.44783 208.454404 
-z
-" clip-path="url(#p37ef70d189)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 335.633167 357.464 
-L 351.679501 357.464 
-L 351.679501 208.428719 
-L 335.633167 208.428719 
-z
-" clip-path="url(#p37ef70d189)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 399.818504 357.464 
-L 415.864839 357.464 
-L 415.864839 208.170679 
-L 399.818504 208.170679 
-z
-" clip-path="url(#p37ef70d189)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 464.003842 357.464 
-L 480.050176 357.464 
-L 480.050176 208.163875 
-L 464.003842 208.163875 
-z
-" clip-path="url(#p37ef70d189)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 528.189179 357.464 
-L 544.235513 357.464 
-L 544.235513 208.402958 
-L 528.189179 208.402958 
-z
-" clip-path="url(#p37ef70d189)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 135 ms -->
-    <g transform="translate(218.045035 203.369783) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 135 ms -->
-    <g transform="translate(282.230372 203.454404) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 135 ms -->
-    <g transform="translate(346.415709 203.428719) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 135 ms -->
-    <g transform="translate(410.601047 203.170679) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 135 ms -->
-    <g transform="translate(474.786384 203.163875) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 135 ms -->
-    <g transform="translate(538.971721 203.402958) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_14">
-    <path d="M 223.308827 357.464 
-L 239.355161 357.464 
-L 239.355161 215.473028 
-L 223.308827 215.473028 
-z
-" clip-path="url(#p37ef70d189)" style="fill: url(#h1212527356); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 287.494164 357.464 
-L 303.540499 357.464 
-L 303.540499 215.663367 
-L 287.494164 215.663367 
-z
-" clip-path="url(#p37ef70d189)" style="fill: url(#h1212527356); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 351.679501 357.464 
-L 367.725836 357.464 
-L 367.725836 215.908618 
-L 351.679501 215.908618 
-z
-" clip-path="url(#p37ef70d189)" style="fill: url(#h1212527356); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 415.864839 357.464 
-L 431.911173 357.464 
-L 431.911173 215.792327 
-L 415.864839 215.792327 
-z
-" clip-path="url(#p37ef70d189)" style="fill: url(#h1212527356); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 480.050176 357.464 
-L 496.09651 357.464 
-L 496.09651 215.645767 
-L 480.050176 215.645767 
-z
-" clip-path="url(#p37ef70d189)" style="fill: url(#h1212527356); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 544.235513 357.464 
-L 560.281848 357.464 
-L 560.281848 215.977658 
-L 544.235513 215.977658 
-z
-" clip-path="url(#p37ef70d189)" style="fill: url(#h1212527356); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_28">
-    <!-- 129 ms -->
-    <g transform="translate(234.091369 210.473028) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 129 ms -->
-    <g transform="translate(298.276706 210.663367) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 128 ms -->
-    <g transform="translate(362.462044 210.908618) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_17">
+    <!-- 118 ms -->
+    <g transform="translate(105.720695 207.819918) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1557,7 +1206,368 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 143.077155 357.464 
+L 159.12349 357.464 
+L 159.12349 72.849842 
+L 143.077155 72.849842 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_18">
+    <!-- 232 ms -->
+    <g transform="translate(153.859698 67.849842) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 159.12349 357.464 
+L 175.169824 357.464 
+L 175.169824 93.938019 
+L 159.12349 93.938019 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h85616edfd2); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 215 ms -->
+    <g transform="translate(169.906032 88.938019) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 175.169824 357.464 
+L 191.216158 357.464 
+L 191.216158 97.506096 
+L 175.169824 97.506096 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h013859768b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 212 ms -->
+    <g transform="translate(185.952366 92.506096) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 207.262493 357.464 
+L 223.308827 357.464 
+L 223.308827 215.819728 
+L 207.262493 215.819728 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 271.44783 357.464 
+L 287.494164 357.464 
+L 287.494164 215.479475 
+L 271.44783 215.479475 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 335.633167 357.464 
+L 351.679501 357.464 
+L 351.679501 213.338449 
+L 335.633167 213.338449 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 399.818504 357.464 
+L 415.864839 357.464 
+L 415.864839 213.556875 
+L 399.818504 213.556875 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 464.003842 357.464 
+L 480.050176 357.464 
+L 480.050176 213.093433 
+L 464.003842 213.093433 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 528.189179 357.464 
+L 544.235513 357.464 
+L 544.235513 213.041472 
+L 528.189179 213.041472 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 116 ms -->
+    <g transform="translate(218.045035 210.819728) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 116 ms -->
+    <g transform="translate(282.230372 210.479475) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 118 ms -->
+    <g transform="translate(346.415709 208.338449) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 118 ms -->
+    <g transform="translate(410.601047 208.556875) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 118 ms -->
+    <g transform="translate(474.786384 208.093433) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 118 ms -->
+    <g transform="translate(538.971721 208.041472) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_14">
+    <path d="M 223.308827 357.464 
+L 239.355161 357.464 
+L 239.355161 223.133498 
+L 223.308827 223.133498 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h94d08b79b2); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 287.494164 357.464 
+L 303.540499 357.464 
+L 303.540499 223.990047 
+L 287.494164 223.990047 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h94d08b79b2); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 351.679501 357.464 
+L 367.725836 357.464 
+L 367.725836 225.100934 
+L 351.679501 225.100934 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h94d08b79b2); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 415.864839 357.464 
+L 431.911173 357.464 
+L 431.911173 225.175862 
+L 415.864839 225.175862 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h94d08b79b2); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 480.050176 357.464 
+L 496.09651 357.464 
+L 496.09651 224.682557 
+L 480.050176 224.682557 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h94d08b79b2); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 544.235513 357.464 
+L 560.281848 357.464 
+L 560.281848 224.380123 
+L 544.235513 224.380123 
+z
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h94d08b79b2); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_27">
+    <!-- 110 ms -->
+    <g transform="translate(234.091369 218.133498) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 109 ms -->
+    <g transform="translate(298.276706 218.990047) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 108 ms -->
+    <g transform="translate(362.462044 220.100934) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 108 ms -->
+    <g transform="translate(426.647381 220.175862) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1565,33 +1575,22 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 129 ms -->
-    <g transform="translate(426.647381 210.792327) rotate(-90) scale(0.1 -0.1)">
+    <!-- 108 ms -->
+    <g transform="translate(490.832718 219.682557) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 129 ms -->
-    <g transform="translate(490.832718 210.645767) rotate(-90) scale(0.1 -0.1)">
+    <!-- 109 ms -->
+    <g transform="translate(555.018055 219.380123) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- 128 ms -->
-    <g transform="translate(555.018055 210.977658) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1600,118 +1599,118 @@ z
    <g id="patch_20">
     <path d="M 239.355161 357.464 
 L 255.401496 357.464 
-L 255.401496 213.596102 
-L 239.355161 213.596102 
+L 255.401496 221.245294 
+L 239.355161 221.245294 
 z
-" clip-path="url(#p37ef70d189)" style="fill: url(#he28685320c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h7cfcf81f6b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 303.540499 357.464 
 L 319.586833 357.464 
-L 319.586833 213.462995 
-L 303.540499 213.462995 
+L 319.586833 223.31227 
+L 303.540499 223.31227 
 z
-" clip-path="url(#p37ef70d189)" style="fill: url(#he28685320c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h7cfcf81f6b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 367.725836 357.464 
 L 383.77217 357.464 
-L 383.77217 213.903083 
-L 367.725836 213.903083 
+L 383.77217 223.721026 
+L 367.725836 223.721026 
 z
-" clip-path="url(#p37ef70d189)" style="fill: url(#he28685320c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h7cfcf81f6b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 431.911173 357.464 
 L 447.957507 357.464 
-L 447.957507 213.587995 
-L 431.911173 213.587995 
+L 447.957507 223.720004 
+L 431.911173 223.720004 
 z
-" clip-path="url(#p37ef70d189)" style="fill: url(#he28685320c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h7cfcf81f6b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 496.09651 357.464 
 L 512.142845 357.464 
-L 512.142845 214.006237 
-L 496.09651 214.006237 
+L 512.142845 223.181776 
+L 496.09651 223.181776 
 z
-" clip-path="url(#p37ef70d189)" style="fill: url(#he28685320c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h7cfcf81f6b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 560.281848 357.464 
 L 576.328182 357.464 
-L 576.328182 213.6646 
-L 560.281848 213.6646 
+L 576.328182 223.618136 
+L 560.281848 223.618136 
 z
-" clip-path="url(#p37ef70d189)" style="fill: url(#he28685320c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p94cde1cb1c)" style="fill: url(#h7cfcf81f6b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_33">
+    <!-- 111 ms -->
+    <g transform="translate(250.137703 216.245294) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
    </g>
    <g id="text_34">
-    <!-- 131 ms -->
-    <g transform="translate(250.137703 208.596102) rotate(-90) scale(0.1 -0.1)">
+    <!-- 110 ms -->
+    <g transform="translate(314.323041 218.31227) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 131 ms -->
-    <g transform="translate(314.323041 208.462995) rotate(-90) scale(0.1 -0.1)">
+    <!-- 109 ms -->
+    <g transform="translate(378.508378 218.721026) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 130 ms -->
-    <g transform="translate(378.508378 208.903083) rotate(-90) scale(0.1 -0.1)">
+    <!-- 109 ms -->
+    <g transform="translate(442.693715 218.720004) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 131 ms -->
-    <g transform="translate(442.693715 208.587995) rotate(-90) scale(0.1 -0.1)">
+    <!-- 110 ms -->
+    <g transform="translate(506.879052 218.181776) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 130 ms -->
-    <g transform="translate(506.879052 209.006237) rotate(-90) scale(0.1 -0.1)">
+    <!-- 109 ms -->
+    <g transform="translate(571.06439 218.618136) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 130 ms -->
-    <g transform="translate(571.06439 208.6646) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_40">
     <!-- filled simple n=1000  -->
     <g transform="translate(263.370625 20.88) scale(0.12 -0.12)">
      <defs>
@@ -1794,7 +1793,7 @@ L 419.19375 36.478437
 z
 " style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_41">
+    <g id="text_40">
      <!-- mpl2005 no mask -->
      <g transform="translate(447.19375 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1820,9 +1819,9 @@ L 439.19375 58.156563
 L 439.19375 51.156563 
 L 419.19375 51.156563 
 z
-" style="fill: url(#h49a0087681); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#ha3633ca07c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_42">
+    <g id="text_41">
      <!-- mpl2005 corner_mask=False -->
      <g transform="translate(447.19375 58.156563) scale(0.1 -0.1)">
       <defs>
@@ -1882,7 +1881,7 @@ L 419.19375 66.112812
 z
 " style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_43">
+    <g id="text_42">
      <!-- mpl2014 no mask -->
      <g transform="translate(447.19375 73.112812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1908,9 +1907,9 @@ L 439.19375 87.790937
 L 439.19375 80.790937 
 L 419.19375 80.790937 
 z
-" style="fill: url(#h0d196596c1); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h85616edfd2); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_44">
+    <g id="text_43">
      <!-- mpl2014 corner_mask=False -->
      <g transform="translate(447.19375 87.790937) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1946,9 +1945,9 @@ L 439.19375 102.747187
 L 439.19375 95.747187 
 L 419.19375 95.747187 
 z
-" style="fill: url(#h9e61b70246); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h013859768b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_45">
+    <g id="text_44">
      <!-- mpl2014 corner_mask=True -->
      <g transform="translate(447.19375 102.747187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1985,7 +1984,7 @@ L 419.19375 110.703437
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_46">
+    <g id="text_45">
      <!-- serial no mask -->
      <g transform="translate(447.19375 117.703437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2010,9 +2009,9 @@ L 439.19375 132.381562
 L 439.19375 125.381562 
 L 419.19375 125.381562 
 z
-" style="fill: url(#h1212527356); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h94d08b79b2); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_47">
+    <g id="text_46">
      <!-- serial corner_mask=False -->
      <g transform="translate(447.19375 132.381562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2047,9 +2046,9 @@ L 439.19375 147.337812
 L 439.19375 140.337812 
 L 419.19375 140.337812 
 z
-" style="fill: url(#he28685320c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h7cfcf81f6b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_48">
+    <g id="text_47">
      <!-- serial corner_mask=True -->
      <g transform="translate(447.19375 147.337812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2081,12 +2080,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p37ef70d189">
+  <clipPath id="p94cde1cb1c">
    <rect x="54.02" y="26.88" width="547.18" height="330.584"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h49a0087681" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="ha3633ca07c" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2126,7 +2125,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h0d196596c1" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h85616edfd2" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2166,7 +2165,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h9e61b70246" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h013859768b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2208,7 +2207,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h1212527356" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h94d08b79b2" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2248,7 +2247,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="he28685320c" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h7cfcf81f6b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/filled_simple_1000_render_dark.svg
+++ b/docs/_static/filled_simple_1000_render_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:06.789717</dc:date>
+    <dc:date>2024-05-06T19:15:02.617475</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mb08109be58" d="M 0 0 
+       <path id="m11fc782f03" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb08109be58" x="102.96132" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m11fc782f03" x="102.96132" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -395,7 +395,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mb08109be58" x="167.146657" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m11fc782f03" x="167.146657" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -464,7 +464,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mb08109be58" x="231.331994" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m11fc782f03" x="231.331994" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -576,7 +576,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb08109be58" x="295.517331" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m11fc782f03" x="295.517331" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -634,7 +634,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mb08109be58" x="359.702669" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m11fc782f03" x="359.702669" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -760,7 +760,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb08109be58" x="423.888006" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m11fc782f03" x="423.888006" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -806,7 +806,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mb08109be58" x="488.073343" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m11fc782f03" x="488.073343" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -859,7 +859,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb08109be58" x="552.25868" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m11fc782f03" x="552.25868" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -917,16 +917,16 @@ z
      <g id="line2d_9">
       <path d="M 54.02 357.464 
 L 601.2 357.464 
-" clip-path="url(#p68e8b6cd27)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#peff24c7f31)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <defs>
-       <path id="mc25a3dbaa9" d="M 0 0 
+       <path id="mf2bf2b76b1" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc25a3dbaa9" x="54.02" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf2bf2b76b1" x="54.02" y="357.464" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -950,18 +950,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_11">
-      <path d="M 54.02 318.571765 
-L 601.2 318.571765 
-" clip-path="url(#p68e8b6cd27)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 317.148878 
+L 601.2 317.148878 
+" clip-path="url(#peff24c7f31)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc25a3dbaa9" x="54.02" y="318.571765" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf2bf2b76b1" x="54.02" y="317.148878" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.05 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 322.370983) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 320.948097) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -971,18 +971,18 @@ L 601.2 318.571765
     </g>
     <g id="ytick_3">
      <g id="line2d_13">
-      <path d="M 54.02 279.679529 
-L 601.2 279.679529 
-" clip-path="url(#p68e8b6cd27)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 276.833756 
+L 601.2 276.833756 
+" clip-path="url(#peff24c7f31)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc25a3dbaa9" x="54.02" y="279.679529" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf2bf2b76b1" x="54.02" y="276.833756" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.10 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 283.478748) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 280.632975) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -992,18 +992,18 @@ L 601.2 279.679529
     </g>
     <g id="ytick_4">
      <g id="line2d_15">
-      <path d="M 54.02 240.787294 
-L 601.2 240.787294 
-" clip-path="url(#p68e8b6cd27)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 236.518634 
+L 601.2 236.518634 
+" clip-path="url(#peff24c7f31)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc25a3dbaa9" x="54.02" y="240.787294" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf2bf2b76b1" x="54.02" y="236.518634" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.15 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 244.586513) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 240.317853) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1013,18 +1013,18 @@ L 601.2 240.787294
     </g>
     <g id="ytick_5">
      <g id="line2d_17">
-      <path d="M 54.02 201.895059 
-L 601.2 201.895059 
-" clip-path="url(#p68e8b6cd27)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 196.203512 
+L 601.2 196.203512 
+" clip-path="url(#peff24c7f31)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc25a3dbaa9" x="54.02" y="201.895059" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf2bf2b76b1" x="54.02" y="196.203512" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.20 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 205.694278) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 200.002731) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1034,18 +1034,18 @@ L 601.2 201.895059
     </g>
     <g id="ytick_6">
      <g id="line2d_19">
-      <path d="M 54.02 163.002824 
-L 601.2 163.002824 
-" clip-path="url(#p68e8b6cd27)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 155.88839 
+L 601.2 155.88839 
+" clip-path="url(#peff24c7f31)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc25a3dbaa9" x="54.02" y="163.002824" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf2bf2b76b1" x="54.02" y="155.88839" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.25 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 166.802042) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 159.687609) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1055,18 +1055,18 @@ L 601.2 163.002824
     </g>
     <g id="ytick_7">
      <g id="line2d_21">
-      <path d="M 54.02 124.110588 
-L 601.2 124.110588 
-" clip-path="url(#p68e8b6cd27)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 115.573268 
+L 601.2 115.573268 
+" clip-path="url(#peff24c7f31)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc25a3dbaa9" x="54.02" y="124.110588" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf2bf2b76b1" x="54.02" y="115.573268" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 0.30 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 127.909807) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 119.372487) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1110,18 +1110,18 @@ z
     </g>
     <g id="ytick_8">
      <g id="line2d_23">
-      <path d="M 54.02 85.218353 
-L 601.2 85.218353 
-" clip-path="url(#p68e8b6cd27)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 75.258146 
+L 601.2 75.258146 
+" clip-path="url(#peff24c7f31)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc25a3dbaa9" x="54.02" y="85.218353" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf2bf2b76b1" x="54.02" y="75.258146" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 0.35 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 89.017572) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 79.057365) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-33" x="95.410156"/>
@@ -1131,18 +1131,18 @@ L 601.2 85.218353
     </g>
     <g id="ytick_9">
      <g id="line2d_25">
-      <path d="M 54.02 46.326118 
-L 601.2 46.326118 
-" clip-path="url(#p68e8b6cd27)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 34.943024 
+L 601.2 34.943024 
+" clip-path="url(#peff24c7f31)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc25a3dbaa9" x="54.02" y="46.326118" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mf2bf2b76b1" x="54.02" y="34.943024" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- 0.40 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 50.125336) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 38.742243) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -1234,45 +1234,53 @@ z
    <g id="patch_3">
     <path d="M 78.891818 357.464 
 L 94.938152 357.464 
-L 94.938152 149.018356 
-L 78.891818 149.018356 
+L 94.938152 176.129449 
+L 78.891818 176.129449 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_19">
-    <!-- 268 ms -->
-    <g style="fill: #ffffff" transform="translate(89.67436 144.018356) rotate(-90) scale(0.1 -0.1)">
+    <!-- 225 ms -->
+    <g style="fill: #ffffff" transform="translate(89.67436 171.129449) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 94.938152 357.464 
+L 110.984487 357.464 
+L 110.984487 175.725235 
+L 94.938152 175.725235 
+z
+" clip-path="url(#peff24c7f31)" style="fill: url(#h12ef09b099); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 225 ms -->
+    <g style="fill: #ffffff" transform="translate(105.720695 170.725235) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 143.077155 357.464 
+L 159.12349 357.464 
+L 159.12349 77.057104 
+L 143.077155 77.057104 
+z
+" clip-path="url(#peff24c7f31)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 348 ms -->
+    <g style="fill: #ffffff" transform="translate(153.859698 72.057104) rotate(-90) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1313,47 +1321,9 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_4">
-    <path d="M 94.938152 357.464 
-L 110.984487 357.464 
-L 110.984487 148.749016 
-L 94.938152 148.749016 
-z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#h2b58f64b1b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 268 ms -->
-    <g style="fill: #ffffff" transform="translate(105.720695 143.749016) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 143.077155 357.464 
-L 159.12349 357.464 
-L 159.12349 75.285733 
-L 143.077155 75.285733 
-z
-" clip-path="url(#p68e8b6cd27)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 363 ms -->
-    <g style="fill: #ffffff" transform="translate(153.859698 70.285733) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1362,17 +1332,17 @@ z
    <g id="patch_6">
     <path d="M 159.12349 357.464 
 L 175.169824 357.464 
-L 175.169824 104.245348 
-L 159.12349 104.245348 
+L 175.169824 98.162534 
+L 159.12349 98.162534 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#h4305e895b7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: url(#haba1a62166); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_22">
-    <!-- 326 ms -->
-    <g style="fill: #ffffff" transform="translate(169.906032 99.245348) rotate(-90) scale(0.1 -0.1)">
+    <!-- 322 ms -->
+    <g style="fill: #ffffff" transform="translate(169.906032 93.162534) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1381,17 +1351,17 @@ z
    <g id="patch_7">
     <path d="M 175.169824 357.464 
 L 191.216158 357.464 
-L 191.216158 97.675929 
-L 175.169824 97.675929 
+L 191.216158 99.699102 
+L 175.169824 99.699102 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#he50de654a6); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: url(#h238a4e8c6b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_23">
-    <!-- 334 ms -->
-    <g style="fill: #ffffff" transform="translate(185.952366 92.675929) rotate(-90) scale(0.1 -0.1)">
+    <!-- 320 ms -->
+    <g style="fill: #ffffff" transform="translate(185.952366 94.699102) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1400,190 +1370,76 @@ z
    <g id="patch_8">
     <path d="M 207.262493 357.464 
 L 223.308827 357.464 
-L 223.308827 162.075422 
-L 207.262493 162.075422 
+L 223.308827 173.431183 
+L 207.262493 173.431183 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 271.44783 357.464 
 L 287.494164 357.464 
-L 287.494164 160.365984 
-L 271.44783 160.365984 
+L 287.494164 172.277024 
+L 271.44783 172.277024 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 335.633167 357.464 
 L 351.679501 357.464 
-L 351.679501 162.494093 
-L 335.633167 162.494093 
+L 351.679501 172.960549 
+L 335.633167 172.960549 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 399.818504 357.464 
 L 415.864839 357.464 
-L 415.864839 162.367431 
-L 399.818504 162.367431 
+L 415.864839 172.551902 
+L 399.818504 172.551902 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 464.003842 357.464 
 L 480.050176 357.464 
-L 480.050176 161.940334 
-L 464.003842 161.940334 
+L 480.050176 172.869597 
+L 464.003842 172.869597 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 528.189179 357.464 
 L 544.235513 357.464 
-L 544.235513 160.531596 
-L 528.189179 160.531596 
+L 544.235513 171.647752 
+L 528.189179 171.647752 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_24">
-    <!-- 251 ms -->
-    <g style="fill: #ffffff" transform="translate(218.045035 157.075422) rotate(-90) scale(0.1 -0.1)">
+    <!-- 228 ms -->
+    <g style="fill: #ffffff" transform="translate(218.045035 168.431183) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 253 ms -->
-    <g style="fill: #ffffff" transform="translate(282.230372 155.365984) rotate(-90) scale(0.1 -0.1)">
+    <!-- 230 ms -->
+    <g style="fill: #ffffff" transform="translate(282.230372 167.277024) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 251 ms -->
-    <g style="fill: #ffffff" transform="translate(346.415709 157.494093) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 251 ms -->
-    <g style="fill: #ffffff" transform="translate(410.601047 157.367431) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 251 ms -->
-    <g style="fill: #ffffff" transform="translate(474.786384 156.940334) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 253 ms -->
-    <g style="fill: #ffffff" transform="translate(538.971721 155.531596) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_14">
-    <path d="M 223.308827 357.464 
-L 239.355161 357.464 
-L 239.355161 170.446288 
-L 223.308827 170.446288 
-z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#ha9701ea266); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 287.494164 357.464 
-L 303.540499 357.464 
-L 303.540499 169.544176 
-L 287.494164 169.544176 
-z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#ha9701ea266); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 351.679501 357.464 
-L 367.725836 357.464 
-L 367.725836 171.227833 
-L 351.679501 171.227833 
-z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#ha9701ea266); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 415.864839 357.464 
-L 431.911173 357.464 
-L 431.911173 171.068256 
-L 415.864839 171.068256 
-z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#ha9701ea266); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 480.050176 357.464 
-L 496.09651 357.464 
-L 496.09651 169.908742 
-L 480.050176 169.908742 
-z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#ha9701ea266); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 544.235513 357.464 
-L 560.281848 357.464 
-L 560.281848 168.794256 
-L 544.235513 168.794256 
-z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#ha9701ea266); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_30">
-    <!-- 240 ms -->
-    <g style="fill: #ffffff" transform="translate(234.091369 165.446288) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- 242 ms -->
-    <g style="fill: #ffffff" transform="translate(298.276706 164.544176) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 239 ms -->
-    <g style="fill: #ffffff" transform="translate(362.462044 166.227833) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_26">
+    <!-- 229 ms -->
+    <g style="fill: #ffffff" transform="translate(346.415709 167.960549) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1617,41 +1473,199 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_33">
-    <!-- 240 ms -->
-    <g style="fill: #ffffff" transform="translate(426.647381 166.068256) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_27">
+    <!-- 229 ms -->
+    <g style="fill: #ffffff" transform="translate(410.601047 167.551902) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 229 ms -->
+    <g style="fill: #ffffff" transform="translate(474.786384 167.869597) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 230 ms -->
+    <g style="fill: #ffffff" transform="translate(538.971721 166.647752) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_34">
-    <!-- 241 ms -->
-    <g style="fill: #ffffff" transform="translate(490.832718 164.908742) rotate(-90) scale(0.1 -0.1)">
+   <g id="patch_14">
+    <path d="M 223.308827 357.464 
+L 239.355161 357.464 
+L 239.355161 183.208943 
+L 223.308827 183.208943 
+z
+" clip-path="url(#peff24c7f31)" style="fill: url(#h11c8efa63d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 287.494164 357.464 
+L 303.540499 357.464 
+L 303.540499 182.028114 
+L 287.494164 182.028114 
+z
+" clip-path="url(#peff24c7f31)" style="fill: url(#h11c8efa63d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 351.679501 357.464 
+L 367.725836 357.464 
+L 367.725836 184.53074 
+L 351.679501 184.53074 
+z
+" clip-path="url(#peff24c7f31)" style="fill: url(#h11c8efa63d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 415.864839 357.464 
+L 431.911173 357.464 
+L 431.911173 183.477426 
+L 415.864839 183.477426 
+z
+" clip-path="url(#peff24c7f31)" style="fill: url(#h11c8efa63d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 480.050176 357.464 
+L 496.09651 357.464 
+L 496.09651 182.70611 
+L 480.050176 182.70611 
+z
+" clip-path="url(#peff24c7f31)" style="fill: url(#h11c8efa63d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 544.235513 357.464 
+L 560.281848 357.464 
+L 560.281848 181.537977 
+L 544.235513 181.537977 
+z
+" clip-path="url(#peff24c7f31)" style="fill: url(#h11c8efa63d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_30">
+    <!-- 216 ms -->
+    <g style="fill: #ffffff" transform="translate(234.091369 178.208943) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 218 ms -->
+    <g style="fill: #ffffff" transform="translate(298.276706 177.028114) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 214 ms -->
+    <g style="fill: #ffffff" transform="translate(362.462044 179.53074) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- 216 ms -->
+    <g style="fill: #ffffff" transform="translate(426.647381 178.477426) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 217 ms -->
+    <g style="fill: #ffffff" transform="translate(490.832718 177.70611) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 243 ms -->
-    <g style="fill: #ffffff" transform="translate(555.018055 163.794256) rotate(-90) scale(0.1 -0.1)">
+    <!-- 218 ms -->
+    <g style="fill: #ffffff" transform="translate(555.018055 176.537977) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1660,112 +1674,112 @@ z
    <g id="patch_20">
     <path d="M 239.355161 357.464 
 L 255.401496 357.464 
-L 255.401496 168.568474 
-L 239.355161 168.568474 
+L 255.401496 183.163778 
+L 239.355161 183.163778 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#h398d92aaaa); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: url(#h1123af2235); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 303.540499 357.464 
 L 319.586833 357.464 
-L 319.586833 168.194035 
-L 303.540499 168.194035 
+L 319.586833 181.816562 
+L 303.540499 181.816562 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#h398d92aaaa); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: url(#h1123af2235); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 367.725836 357.464 
 L 383.77217 357.464 
-L 383.77217 169.934367 
-L 367.725836 169.934367 
+L 383.77217 183.660302 
+L 367.725836 183.660302 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#h398d92aaaa); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: url(#h1123af2235); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 431.911173 357.464 
 L 447.957507 357.464 
-L 447.957507 169.227469 
-L 431.911173 169.227469 
+L 447.957507 182.814049 
+L 431.911173 182.814049 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#h398d92aaaa); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: url(#h1123af2235); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 496.09651 357.464 
 L 512.142845 357.464 
-L 512.142845 168.71718 
-L 496.09651 168.71718 
+L 512.142845 181.681022 
+L 496.09651 181.681022 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#h398d92aaaa); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: url(#h1123af2235); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 560.281848 357.464 
 L 576.328182 357.464 
-L 576.328182 167.645691 
-L 560.281848 167.645691 
+L 576.328182 181.075825 
+L 560.281848 181.075825 
 z
-" clip-path="url(#p68e8b6cd27)" style="fill: url(#h398d92aaaa); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#peff24c7f31)" style="fill: url(#h1123af2235); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_36">
-    <!-- 243 ms -->
-    <g style="fill: #ffffff" transform="translate(250.137703 163.568474) rotate(-90) scale(0.1 -0.1)">
+    <!-- 216 ms -->
+    <g style="fill: #ffffff" transform="translate(250.137703 178.163778) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 243 ms -->
-    <g style="fill: #ffffff" transform="translate(314.323041 163.194035) rotate(-90) scale(0.1 -0.1)">
+    <!-- 218 ms -->
+    <g style="fill: #ffffff" transform="translate(314.323041 176.816562) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 241 ms -->
-    <g style="fill: #ffffff" transform="translate(378.508378 164.934367) rotate(-90) scale(0.1 -0.1)">
+    <!-- 216 ms -->
+    <g style="fill: #ffffff" transform="translate(378.508378 178.660302) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 242 ms -->
-    <g style="fill: #ffffff" transform="translate(442.693715 164.227469) rotate(-90) scale(0.1 -0.1)">
+    <!-- 217 ms -->
+    <g style="fill: #ffffff" transform="translate(442.693715 177.814049) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_40">
-    <!-- 243 ms -->
-    <g style="fill: #ffffff" transform="translate(506.879052 163.71718) rotate(-90) scale(0.1 -0.1)">
+    <!-- 218 ms -->
+    <g style="fill: #ffffff" transform="translate(506.879052 176.681022) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- 244 ms -->
-    <g style="fill: #ffffff" transform="translate(571.06439 162.645691) rotate(-90) scale(0.1 -0.1)">
+    <!-- 219 ms -->
+    <g style="fill: #ffffff" transform="translate(571.06439 176.075825) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1902,7 +1916,7 @@ L 439.19375 256.924938
 L 439.19375 249.924938 
 L 419.19375 249.924938 
 z
-" style="fill: url(#h2b58f64b1b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h12ef09b099); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_44">
      <!-- mpl2005 corner_mask=False -->
@@ -1990,7 +2004,7 @@ L 439.19375 286.559313
 L 439.19375 279.559313 
 L 419.19375 279.559313 
 z
-" style="fill: url(#h4305e895b7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#haba1a62166); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_46">
      <!-- mpl2014 corner_mask=False -->
@@ -2028,7 +2042,7 @@ L 439.19375 301.515563
 L 439.19375 294.515563 
 L 419.19375 294.515563 
 z
-" style="fill: url(#he50de654a6); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h238a4e8c6b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_47">
      <!-- mpl2014 corner_mask=True -->
@@ -2092,7 +2106,7 @@ L 439.19375 331.149938
 L 439.19375 324.149938 
 L 419.19375 324.149938 
 z
-" style="fill: url(#ha9701ea266); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h11c8efa63d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_49">
      <!-- serial corner_mask=False -->
@@ -2129,7 +2143,7 @@ L 439.19375 346.106188
 L 439.19375 339.106188 
 L 419.19375 339.106188 
 z
-" style="fill: url(#h398d92aaaa); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h1123af2235); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_50">
      <!-- serial corner_mask=True -->
@@ -2163,12 +2177,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p68e8b6cd27">
+  <clipPath id="peff24c7f31">
    <rect x="54.02" y="26.88" width="547.18" height="330.584"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h2b58f64b1b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h12ef09b099" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2208,7 +2222,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h4305e895b7" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="haba1a62166" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2248,7 +2262,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="he50de654a6" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h238a4e8c6b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2290,7 +2304,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="ha9701ea266" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h11c8efa63d" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2330,7 +2344,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h398d92aaaa" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h1123af2235" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/filled_simple_1000_render_light.svg
+++ b/docs/_static/filled_simple_1000_render_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:06.591955</dc:date>
+    <dc:date>2024-05-06T19:15:02.427434</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="ma6a1fbda44" d="M 0 0 
+       <path id="m1917a97730" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma6a1fbda44" x="102.96132" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1917a97730" x="102.96132" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -395,7 +395,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#ma6a1fbda44" x="167.146657" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1917a97730" x="167.146657" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -464,7 +464,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#ma6a1fbda44" x="231.331994" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1917a97730" x="231.331994" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -576,7 +576,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma6a1fbda44" x="295.517331" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1917a97730" x="295.517331" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -634,7 +634,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#ma6a1fbda44" x="359.702669" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1917a97730" x="359.702669" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -760,7 +760,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma6a1fbda44" x="423.888006" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1917a97730" x="423.888006" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -806,7 +806,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#ma6a1fbda44" x="488.073343" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1917a97730" x="488.073343" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -859,7 +859,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma6a1fbda44" x="552.25868" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1917a97730" x="552.25868" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -917,16 +917,16 @@ z
      <g id="line2d_9">
       <path d="M 54.02 357.464 
 L 601.2 357.464 
-" clip-path="url(#p94fd9ed09a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pd34644c418)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <defs>
-       <path id="m367250312e" d="M 0 0 
+       <path id="m00aa00ccc6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m367250312e" x="54.02" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00aa00ccc6" x="54.02" y="357.464" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -950,18 +950,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_11">
-      <path d="M 54.02 318.571765 
-L 601.2 318.571765 
-" clip-path="url(#p94fd9ed09a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 317.148878 
+L 601.2 317.148878 
+" clip-path="url(#pd34644c418)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m367250312e" x="54.02" y="318.571765" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00aa00ccc6" x="54.02" y="317.148878" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.05 -->
-      <g transform="translate(24.754375 322.370983) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 320.948097) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -971,18 +971,18 @@ L 601.2 318.571765
     </g>
     <g id="ytick_3">
      <g id="line2d_13">
-      <path d="M 54.02 279.679529 
-L 601.2 279.679529 
-" clip-path="url(#p94fd9ed09a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 276.833756 
+L 601.2 276.833756 
+" clip-path="url(#pd34644c418)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m367250312e" x="54.02" y="279.679529" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00aa00ccc6" x="54.02" y="276.833756" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.10 -->
-      <g transform="translate(24.754375 283.478748) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 280.632975) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -992,18 +992,18 @@ L 601.2 279.679529
     </g>
     <g id="ytick_4">
      <g id="line2d_15">
-      <path d="M 54.02 240.787294 
-L 601.2 240.787294 
-" clip-path="url(#p94fd9ed09a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 236.518634 
+L 601.2 236.518634 
+" clip-path="url(#pd34644c418)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m367250312e" x="54.02" y="240.787294" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00aa00ccc6" x="54.02" y="236.518634" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.15 -->
-      <g transform="translate(24.754375 244.586513) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 240.317853) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1013,18 +1013,18 @@ L 601.2 240.787294
     </g>
     <g id="ytick_5">
      <g id="line2d_17">
-      <path d="M 54.02 201.895059 
-L 601.2 201.895059 
-" clip-path="url(#p94fd9ed09a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 196.203512 
+L 601.2 196.203512 
+" clip-path="url(#pd34644c418)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m367250312e" x="54.02" y="201.895059" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00aa00ccc6" x="54.02" y="196.203512" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.20 -->
-      <g transform="translate(24.754375 205.694278) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 200.002731) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1034,18 +1034,18 @@ L 601.2 201.895059
     </g>
     <g id="ytick_6">
      <g id="line2d_19">
-      <path d="M 54.02 163.002824 
-L 601.2 163.002824 
-" clip-path="url(#p94fd9ed09a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 155.88839 
+L 601.2 155.88839 
+" clip-path="url(#pd34644c418)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m367250312e" x="54.02" y="163.002824" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00aa00ccc6" x="54.02" y="155.88839" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 166.802042) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 159.687609) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1055,18 +1055,18 @@ L 601.2 163.002824
     </g>
     <g id="ytick_7">
      <g id="line2d_21">
-      <path d="M 54.02 124.110588 
-L 601.2 124.110588 
-" clip-path="url(#p94fd9ed09a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 115.573268 
+L 601.2 115.573268 
+" clip-path="url(#pd34644c418)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m367250312e" x="54.02" y="124.110588" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00aa00ccc6" x="54.02" y="115.573268" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 0.30 -->
-      <g transform="translate(24.754375 127.909807) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 119.372487) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1110,18 +1110,18 @@ z
     </g>
     <g id="ytick_8">
      <g id="line2d_23">
-      <path d="M 54.02 85.218353 
-L 601.2 85.218353 
-" clip-path="url(#p94fd9ed09a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 75.258146 
+L 601.2 75.258146 
+" clip-path="url(#pd34644c418)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m367250312e" x="54.02" y="85.218353" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00aa00ccc6" x="54.02" y="75.258146" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 0.35 -->
-      <g transform="translate(24.754375 89.017572) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 79.057365) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-33" x="95.410156"/>
@@ -1131,18 +1131,18 @@ L 601.2 85.218353
     </g>
     <g id="ytick_9">
      <g id="line2d_25">
-      <path d="M 54.02 46.326118 
-L 601.2 46.326118 
-" clip-path="url(#p94fd9ed09a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 34.943024 
+L 601.2 34.943024 
+" clip-path="url(#pd34644c418)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m367250312e" x="54.02" y="46.326118" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00aa00ccc6" x="54.02" y="34.943024" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- 0.40 -->
-      <g transform="translate(24.754375 50.125336) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 38.742243) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -1234,45 +1234,53 @@ z
    <g id="patch_3">
     <path d="M 78.891818 357.464 
 L 94.938152 357.464 
-L 94.938152 149.018356 
-L 78.891818 149.018356 
+L 94.938152 176.129449 
+L 78.891818 176.129449 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_19">
-    <!-- 268 ms -->
-    <g transform="translate(89.67436 144.018356) rotate(-90) scale(0.1 -0.1)">
+    <!-- 225 ms -->
+    <g transform="translate(89.67436 171.129449) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 94.938152 357.464 
+L 110.984487 357.464 
+L 110.984487 175.725235 
+L 94.938152 175.725235 
+z
+" clip-path="url(#pd34644c418)" style="fill: url(#ha3c8aa31da); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 225 ms -->
+    <g transform="translate(105.720695 170.725235) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 143.077155 357.464 
+L 159.12349 357.464 
+L 159.12349 77.057104 
+L 143.077155 77.057104 
+z
+" clip-path="url(#pd34644c418)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 348 ms -->
+    <g transform="translate(153.859698 72.057104) rotate(-90) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1313,47 +1321,9 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_4">
-    <path d="M 94.938152 357.464 
-L 110.984487 357.464 
-L 110.984487 148.749016 
-L 94.938152 148.749016 
-z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#hc041f4c5ce); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 268 ms -->
-    <g transform="translate(105.720695 143.749016) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 143.077155 357.464 
-L 159.12349 357.464 
-L 159.12349 75.285733 
-L 143.077155 75.285733 
-z
-" clip-path="url(#p94fd9ed09a)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 363 ms -->
-    <g transform="translate(153.859698 70.285733) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1362,17 +1332,17 @@ z
    <g id="patch_6">
     <path d="M 159.12349 357.464 
 L 175.169824 357.464 
-L 175.169824 104.245348 
-L 159.12349 104.245348 
+L 175.169824 98.162534 
+L 159.12349 98.162534 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#hdc9ab49cfb); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: url(#hfd8ed4e135); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_22">
-    <!-- 326 ms -->
-    <g transform="translate(169.906032 99.245348) rotate(-90) scale(0.1 -0.1)">
+    <!-- 322 ms -->
+    <g transform="translate(169.906032 93.162534) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1381,17 +1351,17 @@ z
    <g id="patch_7">
     <path d="M 175.169824 357.464 
 L 191.216158 357.464 
-L 191.216158 97.675929 
-L 175.169824 97.675929 
+L 191.216158 99.699102 
+L 175.169824 99.699102 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#hd3067ca219); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: url(#h091d6ba42b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_23">
-    <!-- 334 ms -->
-    <g transform="translate(185.952366 92.675929) rotate(-90) scale(0.1 -0.1)">
+    <!-- 320 ms -->
+    <g transform="translate(185.952366 94.699102) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1400,190 +1370,76 @@ z
    <g id="patch_8">
     <path d="M 207.262493 357.464 
 L 223.308827 357.464 
-L 223.308827 162.075422 
-L 207.262493 162.075422 
+L 223.308827 173.431183 
+L 207.262493 173.431183 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 271.44783 357.464 
 L 287.494164 357.464 
-L 287.494164 160.365984 
-L 271.44783 160.365984 
+L 287.494164 172.277024 
+L 271.44783 172.277024 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 335.633167 357.464 
 L 351.679501 357.464 
-L 351.679501 162.494093 
-L 335.633167 162.494093 
+L 351.679501 172.960549 
+L 335.633167 172.960549 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 399.818504 357.464 
 L 415.864839 357.464 
-L 415.864839 162.367431 
-L 399.818504 162.367431 
+L 415.864839 172.551902 
+L 399.818504 172.551902 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 464.003842 357.464 
 L 480.050176 357.464 
-L 480.050176 161.940334 
-L 464.003842 161.940334 
+L 480.050176 172.869597 
+L 464.003842 172.869597 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 528.189179 357.464 
 L 544.235513 357.464 
-L 544.235513 160.531596 
-L 528.189179 160.531596 
+L 544.235513 171.647752 
+L 528.189179 171.647752 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_24">
-    <!-- 251 ms -->
-    <g transform="translate(218.045035 157.075422) rotate(-90) scale(0.1 -0.1)">
+    <!-- 228 ms -->
+    <g transform="translate(218.045035 168.431183) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 253 ms -->
-    <g transform="translate(282.230372 155.365984) rotate(-90) scale(0.1 -0.1)">
+    <!-- 230 ms -->
+    <g transform="translate(282.230372 167.277024) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 251 ms -->
-    <g transform="translate(346.415709 157.494093) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 251 ms -->
-    <g transform="translate(410.601047 157.367431) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 251 ms -->
-    <g transform="translate(474.786384 156.940334) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 253 ms -->
-    <g transform="translate(538.971721 155.531596) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_14">
-    <path d="M 223.308827 357.464 
-L 239.355161 357.464 
-L 239.355161 170.446288 
-L 223.308827 170.446288 
-z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#h58922c0ff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 287.494164 357.464 
-L 303.540499 357.464 
-L 303.540499 169.544176 
-L 287.494164 169.544176 
-z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#h58922c0ff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 351.679501 357.464 
-L 367.725836 357.464 
-L 367.725836 171.227833 
-L 351.679501 171.227833 
-z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#h58922c0ff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 415.864839 357.464 
-L 431.911173 357.464 
-L 431.911173 171.068256 
-L 415.864839 171.068256 
-z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#h58922c0ff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 480.050176 357.464 
-L 496.09651 357.464 
-L 496.09651 169.908742 
-L 480.050176 169.908742 
-z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#h58922c0ff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 544.235513 357.464 
-L 560.281848 357.464 
-L 560.281848 168.794256 
-L 544.235513 168.794256 
-z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#h58922c0ff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_30">
-    <!-- 240 ms -->
-    <g transform="translate(234.091369 165.446288) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- 242 ms -->
-    <g transform="translate(298.276706 164.544176) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 239 ms -->
-    <g transform="translate(362.462044 166.227833) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_26">
+    <!-- 229 ms -->
+    <g transform="translate(346.415709 167.960549) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1617,41 +1473,199 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_33">
-    <!-- 240 ms -->
-    <g transform="translate(426.647381 166.068256) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_27">
+    <!-- 229 ms -->
+    <g transform="translate(410.601047 167.551902) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 229 ms -->
+    <g transform="translate(474.786384 167.869597) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 230 ms -->
+    <g transform="translate(538.971721 166.647752) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_34">
-    <!-- 241 ms -->
-    <g transform="translate(490.832718 164.908742) rotate(-90) scale(0.1 -0.1)">
+   <g id="patch_14">
+    <path d="M 223.308827 357.464 
+L 239.355161 357.464 
+L 239.355161 183.208943 
+L 223.308827 183.208943 
+z
+" clip-path="url(#pd34644c418)" style="fill: url(#hfabe50a32d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 287.494164 357.464 
+L 303.540499 357.464 
+L 303.540499 182.028114 
+L 287.494164 182.028114 
+z
+" clip-path="url(#pd34644c418)" style="fill: url(#hfabe50a32d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 351.679501 357.464 
+L 367.725836 357.464 
+L 367.725836 184.53074 
+L 351.679501 184.53074 
+z
+" clip-path="url(#pd34644c418)" style="fill: url(#hfabe50a32d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 415.864839 357.464 
+L 431.911173 357.464 
+L 431.911173 183.477426 
+L 415.864839 183.477426 
+z
+" clip-path="url(#pd34644c418)" style="fill: url(#hfabe50a32d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 480.050176 357.464 
+L 496.09651 357.464 
+L 496.09651 182.70611 
+L 480.050176 182.70611 
+z
+" clip-path="url(#pd34644c418)" style="fill: url(#hfabe50a32d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 544.235513 357.464 
+L 560.281848 357.464 
+L 560.281848 181.537977 
+L 544.235513 181.537977 
+z
+" clip-path="url(#pd34644c418)" style="fill: url(#hfabe50a32d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_30">
+    <!-- 216 ms -->
+    <g transform="translate(234.091369 178.208943) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 218 ms -->
+    <g transform="translate(298.276706 177.028114) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 214 ms -->
+    <g transform="translate(362.462044 179.53074) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- 216 ms -->
+    <g transform="translate(426.647381 178.477426) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 217 ms -->
+    <g transform="translate(490.832718 177.70611) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 243 ms -->
-    <g transform="translate(555.018055 163.794256) rotate(-90) scale(0.1 -0.1)">
+    <!-- 218 ms -->
+    <g transform="translate(555.018055 176.537977) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1660,112 +1674,112 @@ z
    <g id="patch_20">
     <path d="M 239.355161 357.464 
 L 255.401496 357.464 
-L 255.401496 168.568474 
-L 239.355161 168.568474 
+L 255.401496 183.163778 
+L 239.355161 183.163778 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#h789652f254); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: url(#hab54dec4a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 303.540499 357.464 
 L 319.586833 357.464 
-L 319.586833 168.194035 
-L 303.540499 168.194035 
+L 319.586833 181.816562 
+L 303.540499 181.816562 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#h789652f254); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: url(#hab54dec4a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 367.725836 357.464 
 L 383.77217 357.464 
-L 383.77217 169.934367 
-L 367.725836 169.934367 
+L 383.77217 183.660302 
+L 367.725836 183.660302 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#h789652f254); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: url(#hab54dec4a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 431.911173 357.464 
 L 447.957507 357.464 
-L 447.957507 169.227469 
-L 431.911173 169.227469 
+L 447.957507 182.814049 
+L 431.911173 182.814049 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#h789652f254); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: url(#hab54dec4a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 496.09651 357.464 
 L 512.142845 357.464 
-L 512.142845 168.71718 
-L 496.09651 168.71718 
+L 512.142845 181.681022 
+L 496.09651 181.681022 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#h789652f254); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: url(#hab54dec4a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 560.281848 357.464 
 L 576.328182 357.464 
-L 576.328182 167.645691 
-L 560.281848 167.645691 
+L 576.328182 181.075825 
+L 560.281848 181.075825 
 z
-" clip-path="url(#p94fd9ed09a)" style="fill: url(#h789652f254); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pd34644c418)" style="fill: url(#hab54dec4a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_36">
-    <!-- 243 ms -->
-    <g transform="translate(250.137703 163.568474) rotate(-90) scale(0.1 -0.1)">
+    <!-- 216 ms -->
+    <g transform="translate(250.137703 178.163778) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 243 ms -->
-    <g transform="translate(314.323041 163.194035) rotate(-90) scale(0.1 -0.1)">
+    <!-- 218 ms -->
+    <g transform="translate(314.323041 176.816562) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 241 ms -->
-    <g transform="translate(378.508378 164.934367) rotate(-90) scale(0.1 -0.1)">
+    <!-- 216 ms -->
+    <g transform="translate(378.508378 178.660302) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 242 ms -->
-    <g transform="translate(442.693715 164.227469) rotate(-90) scale(0.1 -0.1)">
+    <!-- 217 ms -->
+    <g transform="translate(442.693715 177.814049) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_40">
-    <!-- 243 ms -->
-    <g transform="translate(506.879052 163.71718) rotate(-90) scale(0.1 -0.1)">
+    <!-- 218 ms -->
+    <g transform="translate(506.879052 176.681022) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- 244 ms -->
-    <g transform="translate(571.06439 162.645691) rotate(-90) scale(0.1 -0.1)">
+    <!-- 219 ms -->
+    <g transform="translate(571.06439 176.075825) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1902,7 +1916,7 @@ L 439.19375 256.924938
 L 439.19375 249.924938 
 L 419.19375 249.924938 
 z
-" style="fill: url(#hc041f4c5ce); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#ha3c8aa31da); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_44">
      <!-- mpl2005 corner_mask=False -->
@@ -1990,7 +2004,7 @@ L 439.19375 286.559313
 L 439.19375 279.559313 
 L 419.19375 279.559313 
 z
-" style="fill: url(#hdc9ab49cfb); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hfd8ed4e135); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_46">
      <!-- mpl2014 corner_mask=False -->
@@ -2028,7 +2042,7 @@ L 439.19375 301.515563
 L 439.19375 294.515563 
 L 419.19375 294.515563 
 z
-" style="fill: url(#hd3067ca219); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h091d6ba42b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_47">
      <!-- mpl2014 corner_mask=True -->
@@ -2092,7 +2106,7 @@ L 439.19375 331.149938
 L 439.19375 324.149938 
 L 419.19375 324.149938 
 z
-" style="fill: url(#h58922c0ff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hfabe50a32d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_49">
      <!-- serial corner_mask=False -->
@@ -2129,7 +2143,7 @@ L 439.19375 346.106188
 L 439.19375 339.106188 
 L 419.19375 339.106188 
 z
-" style="fill: url(#h789652f254); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hab54dec4a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_50">
      <!-- serial corner_mask=True -->
@@ -2163,12 +2177,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p94fd9ed09a">
+  <clipPath id="pd34644c418">
    <rect x="54.02" y="26.88" width="547.18" height="330.584"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="hc041f4c5ce" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="ha3c8aa31da" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2208,7 +2222,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hdc9ab49cfb" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hfd8ed4e135" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2248,7 +2262,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hd3067ca219" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h091d6ba42b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2290,7 +2304,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h58922c0ff5" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hfabe50a32d" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2330,7 +2344,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h789652f254" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hab54dec4a8" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/lines_random_1000_dark.svg
+++ b/docs/_static/lines_random_1000_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:04.876040</dc:date>
+    <dc:date>2024-05-06T19:15:00.743268</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m5749b5a904" d="M 0 0 
+       <path id="m0ea741496b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5749b5a904" x="106.527172" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0ea741496b" x="106.527172" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -419,7 +419,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m5749b5a904" x="180.221448" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0ea741496b" x="180.221448" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -491,7 +491,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m5749b5a904" x="253.915724" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0ea741496b" x="253.915724" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -566,7 +566,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5749b5a904" x="327.61" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0ea741496b" x="327.61" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -602,7 +602,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m5749b5a904" x="401.304276" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0ea741496b" x="401.304276" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -750,7 +750,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5749b5a904" x="474.998552" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0ea741496b" x="474.998552" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -840,7 +840,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m5749b5a904" x="548.692828" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0ea741496b" x="548.692828" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -901,16 +901,16 @@ z
      <g id="line2d_8">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#p0cc75e0c83)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <defs>
-       <path id="m011193ee86" d="M 0 0 
+       <path id="mb80d0beae0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m011193ee86" x="54.02" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mb80d0beae0" x="54.02" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -934,18 +934,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_10">
-      <path d="M 54.02 323.124138 
-L 601.2 323.124138 
-" clip-path="url(#p0cc75e0c83)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 321.633822 
+L 601.2 321.633822 
+" clip-path="url(#p9ddcec22ca)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m011193ee86" x="54.02" y="323.124138" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mb80d0beae0" x="54.02" y="321.633822" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.25 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 326.923357) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 325.433041) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -955,18 +955,18 @@ L 601.2 323.124138
     </g>
     <g id="ytick_3">
      <g id="line2d_12">
-      <path d="M 54.02 277.120276 
-L 601.2 277.120276 
-" clip-path="url(#p0cc75e0c83)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 274.139645 
+L 601.2 274.139645 
+" clip-path="url(#p9ddcec22ca)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m011193ee86" x="54.02" y="277.120276" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mb80d0beae0" x="54.02" y="274.139645" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.50 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 280.919495) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 277.938863) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -976,18 +976,18 @@ L 601.2 277.120276
     </g>
     <g id="ytick_4">
      <g id="line2d_14">
-      <path d="M 54.02 231.116414 
-L 601.2 231.116414 
-" clip-path="url(#p0cc75e0c83)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 226.645467 
+L 601.2 226.645467 
+" clip-path="url(#p9ddcec22ca)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m011193ee86" x="54.02" y="231.116414" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mb80d0beae0" x="54.02" y="226.645467" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.75 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 234.915633) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 230.444686) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1009,18 +1009,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_16">
-      <path d="M 54.02 185.112552 
-L 601.2 185.112552 
-" clip-path="url(#p0cc75e0c83)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 179.151289 
+L 601.2 179.151289 
+" clip-path="url(#p9ddcec22ca)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m011193ee86" x="54.02" y="185.112552" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mb80d0beae0" x="54.02" y="179.151289" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.00 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 188.911771) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 182.950508) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1030,18 +1030,18 @@ L 601.2 185.112552
     </g>
     <g id="ytick_6">
      <g id="line2d_18">
-      <path d="M 54.02 139.10869 
-L 601.2 139.10869 
-" clip-path="url(#p0cc75e0c83)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 131.657111 
+L 601.2 131.657111 
+" clip-path="url(#p9ddcec22ca)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m011193ee86" x="54.02" y="139.10869" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mb80d0beae0" x="54.02" y="131.657111" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.25 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 142.907909) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 135.45633) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1051,18 +1051,18 @@ L 601.2 139.10869
     </g>
     <g id="ytick_7">
      <g id="line2d_20">
-      <path d="M 54.02 93.104828 
-L 601.2 93.104828 
-" clip-path="url(#p0cc75e0c83)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 84.162934 
+L 601.2 84.162934 
+" clip-path="url(#p9ddcec22ca)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m011193ee86" x="54.02" y="93.104828" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mb80d0beae0" x="54.02" y="84.162934" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 1.50 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 96.904047) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 87.962152) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -1072,18 +1072,18 @@ L 601.2 93.104828
     </g>
     <g id="ytick_8">
      <g id="line2d_22">
-      <path d="M 54.02 47.100966 
-L 601.2 47.100966 
-" clip-path="url(#p0cc75e0c83)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 36.668756 
+L 601.2 36.668756 
+" clip-path="url(#p9ddcec22ca)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m011193ee86" x="54.02" y="47.100966" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mb80d0beae0" x="54.02" y="36.668756" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 1.75 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 50.900185) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 40.467975) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-37" x="95.410156"/>
@@ -1175,14 +1175,14 @@ z
    <g id="patch_3">
     <path d="M 78.891818 369.128 
 L 97.315387 369.128 
-L 97.315387 121.877492 
-L 78.891818 121.877492 
+L 97.315387 111.994543 
+L 78.891818 111.994543 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_17">
-    <!-- 1.34 s -->
-    <g style="fill: #ffffff" transform="translate(90.862978 116.877492) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.35 s -->
+    <g style="fill: #ffffff" transform="translate(90.862978 106.994543) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1220,7 +1220,7 @@ z
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1231,10 +1231,10 @@ L 115.738956 369.128
 L 115.738956 72.809385 
 L 97.315387 72.809385 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#h49a7f1166b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#h1f4510d8dd); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_18">
-    <!-- 1.61 s -->
+    <!-- 1.56 s -->
     <g style="fill: #ffffff" transform="translate(109.286547 67.809385) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
@@ -1270,8 +1270,8 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1279,18 +1279,18 @@ z
    <g id="patch_5">
     <path d="M 152.586094 369.128 
 L 171.009663 369.128 
-L 171.009663 171.648801 
-L 152.586094 171.648801 
+L 171.009663 160.258304 
+L 152.586094 160.258304 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_19">
-    <!-- 1.07 s -->
-    <g style="fill: #ffffff" transform="translate(164.557254 166.648801) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.10 s -->
+    <g style="fill: #ffffff" transform="translate(164.557254 155.258304) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1298,18 +1298,18 @@ z
    <g id="patch_6">
     <path d="M 171.009663 369.128 
 L 189.433232 369.128 
-L 189.433232 126.225421 
-L 171.009663 126.225421 
+L 189.433232 114.412782 
+L 171.009663 114.412782 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#h65074fb330); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#haad70f2c09); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_20">
-    <!-- 1.32 s -->
-    <g style="fill: #ffffff" transform="translate(182.980823 121.225421) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.34 s -->
+    <g style="fill: #ffffff" transform="translate(182.980823 109.412782) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1317,65 +1317,14 @@ z
    <g id="patch_7">
     <path d="M 189.433232 369.128 
 L 207.856801 369.128 
-L 207.856801 137.228195 
-L 189.433232 137.228195 
+L 207.856801 125.715299 
+L 189.433232 125.715299 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#h7d17faa5f1); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#hf4b765b03e); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_21">
-    <!-- 1.26 s -->
-    <g style="fill: #ffffff" transform="translate(201.404392 132.228195) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 226.28037 369.128 
-L 244.703939 369.128 
-L 244.703939 213.514381 
-L 226.28037 213.514381 
-z
-" clip-path="url(#p0cc75e0c83)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 299.974646 369.128 
-L 318.398215 369.128 
-L 318.398215 147.045055 
-L 299.974646 147.045055 
-z
-" clip-path="url(#p0cc75e0c83)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 373.668923 369.128 
-L 392.092492 369.128 
-L 392.092492 276.546051 
-L 373.668923 276.546051 
-z
-" clip-path="url(#p0cc75e0c83)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 447.363199 369.128 
-L 465.786768 369.128 
-L 465.786768 277.943074 
-L 447.363199 277.943074 
-z
-" clip-path="url(#p0cc75e0c83)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 521.057475 369.128 
-L 539.481044 369.128 
-L 539.481044 277.662126 
-L 521.057475 277.662126 
-z
-" clip-path="url(#p0cc75e0c83)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 846 ms -->
-    <g style="fill: #ffffff" transform="translate(238.25153 208.514381) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.28 s -->
+    <g style="fill: #ffffff" transform="translate(201.404392 120.715299) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1417,39 +1366,68 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 1.21 s -->
-    <g style="fill: #ffffff" transform="translate(311.945806 142.045055) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- 503 ms -->
-    <g style="fill: #ffffff" transform="translate(385.640082 271.546051) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+   <g id="patch_8">
+    <path d="M 226.28037 369.128 
+L 244.703939 369.128 
+L 244.703939 212.808774 
+L 226.28037 212.808774 
+z
+" clip-path="url(#p9ddcec22ca)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 299.974646 369.128 
+L 318.398215 369.128 
+L 318.398215 143.150491 
+L 299.974646 143.150491 
+z
+" clip-path="url(#p9ddcec22ca)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 373.668923 369.128 
+L 392.092492 369.128 
+L 392.092492 277.110688 
+L 373.668923 277.110688 
+z
+" clip-path="url(#p9ddcec22ca)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 447.363199 369.128 
+L 465.786768 369.128 
+L 465.786768 277.766859 
+L 447.363199 277.766859 
+z
+" clip-path="url(#p9ddcec22ca)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 521.057475 369.128 
+L 539.481044 369.128 
+L 539.481044 277.176139 
+L 521.057475 277.176139 
+z
+" clip-path="url(#p9ddcec22ca)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 823 ms -->
+    <g style="fill: #ffffff" transform="translate(238.25153 207.808774) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_25">
-    <!-- 496 ms -->
-    <g style="fill: #ffffff" transform="translate(459.334358 272.943074) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_23">
+    <!-- 1.19 s -->
+    <g style="fill: #ffffff" transform="translate(311.945806 138.150491) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1482,20 +1460,42 @@ Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 484 ms -->
+    <g style="fill: #ffffff" transform="translate(385.640082 272.110688) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 481 ms -->
+    <g style="fill: #ffffff" transform="translate(459.334358 272.766859) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 497 ms -->
-    <g style="fill: #ffffff" transform="translate(533.028634 272.662126) rotate(-90) scale(0.1 -0.1)">
+    <!-- 484 ms -->
+    <g style="fill: #ffffff" transform="translate(533.028634 272.176139) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1504,48 +1504,48 @@ z
    <g id="patch_13">
     <path d="M 244.703939 369.128 
 L 263.127508 369.128 
-L 263.127508 200.406423 
-L 244.703939 200.406423 
+L 263.127508 200.531987 
+L 244.703939 200.531987 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#hba0347c9c7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#h0a390a9cdc); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 318.398215 369.128 
 L 336.821785 369.128 
-L 336.821785 124.256731 
-L 318.398215 124.256731 
+L 336.821785 118.111268 
+L 318.398215 118.111268 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#hba0347c9c7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#h0a390a9cdc); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 392.092492 369.128 
 L 410.516061 369.128 
-L 410.516061 273.68474 
-L 392.092492 273.68474 
+L 410.516061 275.691342 
+L 392.092492 275.691342 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#hba0347c9c7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#h0a390a9cdc); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 465.786768 369.128 
 L 484.210337 369.128 
-L 484.210337 275.950432 
-L 465.786768 275.950432 
+L 484.210337 277.775025 
+L 465.786768 277.775025 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#hba0347c9c7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#h0a390a9cdc); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 539.481044 369.128 
 L 557.904613 369.128 
-L 557.904613 275.511352 
-L 539.481044 275.511352 
+L 557.904613 276.824783 
+L 539.481044 276.824783 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#hba0347c9c7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#h0a390a9cdc); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_27">
-    <!-- 917 ms -->
-    <g style="fill: #ffffff" transform="translate(256.675099 195.406423) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+    <!-- 887 ms -->
+    <g style="fill: #ffffff" transform="translate(256.675099 195.531987) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1553,44 +1553,44 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 1.33 s -->
-    <g style="fill: #ffffff" transform="translate(330.369375 119.256731) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.32 s -->
+    <g style="fill: #ffffff" transform="translate(330.369375 113.111268) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 519 ms -->
-    <g style="fill: #ffffff" transform="translate(404.063651 268.68474) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+    <!-- 492 ms -->
+    <g style="fill: #ffffff" transform="translate(404.063651 270.691342) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 506 ms -->
-    <g style="fill: #ffffff" transform="translate(477.757927 270.950432) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+    <!-- 481 ms -->
+    <g style="fill: #ffffff" transform="translate(477.757927 272.775025) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 509 ms -->
-    <g style="fill: #ffffff" transform="translate(551.452203 270.511352) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+    <!-- 486 ms -->
+    <g style="fill: #ffffff" transform="translate(551.452203 271.824783) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1599,93 +1599,93 @@ z
    <g id="patch_18">
     <path d="M 263.127508 369.128 
 L 281.551077 369.128 
-L 281.551077 202.103212 
-L 263.127508 202.103212 
+L 281.551077 202.009838 
+L 263.127508 202.009838 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#h4c9f11c857); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#hb679b9a739); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 336.821785 369.128 
 L 355.245354 369.128 
-L 355.245354 133.942679 
-L 336.821785 133.942679 
+L 355.245354 129.812898 
+L 336.821785 129.812898 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#h4c9f11c857); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#hb679b9a739); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 410.516061 369.128 
 L 428.93963 369.128 
-L 428.93963 267.844864 
-L 410.516061 267.844864 
+L 428.93963 269.938878 
+L 410.516061 269.938878 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#h4c9f11c857); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#hb679b9a739); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 484.210337 369.128 
 L 502.633906 369.128 
-L 502.633906 269.777895 
-L 484.210337 269.777895 
+L 502.633906 271.758875 
+L 484.210337 271.758875 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#h4c9f11c857); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#hb679b9a739); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 557.904613 369.128 
 L 576.328182 369.128 
-L 576.328182 269.475944 
-L 557.904613 269.475944 
+L 576.328182 270.821859 
+L 557.904613 270.821859 
 z
-" clip-path="url(#p0cc75e0c83)" style="fill: url(#h4c9f11c857); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p9ddcec22ca)" style="fill: url(#hb679b9a739); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_32">
-    <!-- 908 ms -->
-    <g style="fill: #ffffff" transform="translate(275.098668 197.103212) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+    <!-- 880 ms -->
+    <g style="fill: #ffffff" transform="translate(275.098668 197.009838) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 1.28 s -->
-    <g style="fill: #ffffff" transform="translate(348.792944 128.942679) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.26 s -->
+    <g style="fill: #ffffff" transform="translate(348.792944 124.812898) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 550 ms -->
-    <g style="fill: #ffffff" transform="translate(422.48722 262.844864) rotate(-90) scale(0.1 -0.1)">
+    <!-- 522 ms -->
+    <g style="fill: #ffffff" transform="translate(422.48722 264.938878) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 540 ms -->
-    <g style="fill: #ffffff" transform="translate(496.181496 264.777895) rotate(-90) scale(0.1 -0.1)">
+    <!-- 513 ms -->
+    <g style="fill: #ffffff" transform="translate(496.181496 266.758875) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 542 ms -->
-    <g style="fill: #ffffff" transform="translate(569.875772 264.475944) rotate(-90) scale(0.1 -0.1)">
+    <!-- 517 ms -->
+    <g style="fill: #ffffff" transform="translate(569.875772 265.821859) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1799,7 +1799,7 @@ L 439.19375 58.156563
 L 439.19375 51.156563 
 L 419.19375 51.156563 
 z
-" style="fill: url(#h49a7f1166b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h1f4510d8dd); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_39">
      <!-- mpl2005 corner_mask=False -->
@@ -1887,7 +1887,7 @@ L 439.19375 87.790937
 L 439.19375 80.790937 
 L 419.19375 80.790937 
 z
-" style="fill: url(#h65074fb330); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#haad70f2c09); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_41">
      <!-- mpl2014 corner_mask=False -->
@@ -1925,7 +1925,7 @@ L 439.19375 102.747187
 L 439.19375 95.747187 
 L 419.19375 95.747187 
 z
-" style="fill: url(#h7d17faa5f1); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hf4b765b03e); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_42">
      <!-- mpl2014 corner_mask=True -->
@@ -1989,7 +1989,7 @@ L 439.19375 132.381562
 L 439.19375 125.381562 
 L 419.19375 125.381562 
 z
-" style="fill: url(#hba0347c9c7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h0a390a9cdc); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_44">
      <!-- serial corner_mask=False -->
@@ -2026,7 +2026,7 @@ L 439.19375 147.337812
 L 439.19375 140.337812 
 L 419.19375 140.337812 
 z
-" style="fill: url(#h4c9f11c857); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hb679b9a739); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_45">
      <!-- serial corner_mask=True -->
@@ -2060,12 +2060,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p0cc75e0c83">
+  <clipPath id="p9ddcec22ca">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h49a7f1166b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h1f4510d8dd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2105,7 +2105,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h65074fb330" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="haad70f2c09" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2145,7 +2145,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h7d17faa5f1" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hf4b765b03e" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2187,7 +2187,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hba0347c9c7" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h0a390a9cdc" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2227,7 +2227,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h4c9f11c857" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hb679b9a739" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/lines_random_1000_light.svg
+++ b/docs/_static/lines_random_1000_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:04.684181</dc:date>
+    <dc:date>2024-05-06T19:15:00.559443</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m2e65f0fc23" d="M 0 0 
+       <path id="m421cbab269" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2e65f0fc23" x="106.527172" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m421cbab269" x="106.527172" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -419,7 +419,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m2e65f0fc23" x="180.221448" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m421cbab269" x="180.221448" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -491,7 +491,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m2e65f0fc23" x="253.915724" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m421cbab269" x="253.915724" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -566,7 +566,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2e65f0fc23" x="327.61" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m421cbab269" x="327.61" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -602,7 +602,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m2e65f0fc23" x="401.304276" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m421cbab269" x="401.304276" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -750,7 +750,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2e65f0fc23" x="474.998552" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m421cbab269" x="474.998552" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -840,7 +840,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m2e65f0fc23" x="548.692828" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m421cbab269" x="548.692828" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -901,16 +901,16 @@ z
      <g id="line2d_8">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#p3a575460fc)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p0542bda40a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <defs>
-       <path id="m3a1f736e15" d="M 0 0 
+       <path id="m43088ad8d6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3a1f736e15" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m43088ad8d6" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -934,18 +934,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_10">
-      <path d="M 54.02 323.124138 
-L 601.2 323.124138 
-" clip-path="url(#p3a575460fc)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 321.633822 
+L 601.2 321.633822 
+" clip-path="url(#p0542bda40a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m3a1f736e15" x="54.02" y="323.124138" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m43088ad8d6" x="54.02" y="321.633822" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 326.923357) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 325.433041) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -955,18 +955,18 @@ L 601.2 323.124138
     </g>
     <g id="ytick_3">
      <g id="line2d_12">
-      <path d="M 54.02 277.120276 
-L 601.2 277.120276 
-" clip-path="url(#p3a575460fc)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 274.139645 
+L 601.2 274.139645 
+" clip-path="url(#p0542bda40a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m3a1f736e15" x="54.02" y="277.120276" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m43088ad8d6" x="54.02" y="274.139645" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.50 -->
-      <g transform="translate(24.754375 280.919495) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 277.938863) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -976,18 +976,18 @@ L 601.2 277.120276
     </g>
     <g id="ytick_4">
      <g id="line2d_14">
-      <path d="M 54.02 231.116414 
-L 601.2 231.116414 
-" clip-path="url(#p3a575460fc)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 226.645467 
+L 601.2 226.645467 
+" clip-path="url(#p0542bda40a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m3a1f736e15" x="54.02" y="231.116414" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m43088ad8d6" x="54.02" y="226.645467" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.75 -->
-      <g transform="translate(24.754375 234.915633) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 230.444686) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1009,18 +1009,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_16">
-      <path d="M 54.02 185.112552 
-L 601.2 185.112552 
-" clip-path="url(#p3a575460fc)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 179.151289 
+L 601.2 179.151289 
+" clip-path="url(#p0542bda40a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m3a1f736e15" x="54.02" y="185.112552" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m43088ad8d6" x="54.02" y="179.151289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.00 -->
-      <g transform="translate(24.754375 188.911771) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 182.950508) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -1030,18 +1030,18 @@ L 601.2 185.112552
     </g>
     <g id="ytick_6">
      <g id="line2d_18">
-      <path d="M 54.02 139.10869 
-L 601.2 139.10869 
-" clip-path="url(#p3a575460fc)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 131.657111 
+L 601.2 131.657111 
+" clip-path="url(#p0542bda40a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m3a1f736e15" x="54.02" y="139.10869" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m43088ad8d6" x="54.02" y="131.657111" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.25 -->
-      <g transform="translate(24.754375 142.907909) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 135.45633) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1051,18 +1051,18 @@ L 601.2 139.10869
     </g>
     <g id="ytick_7">
      <g id="line2d_20">
-      <path d="M 54.02 93.104828 
-L 601.2 93.104828 
-" clip-path="url(#p3a575460fc)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 84.162934 
+L 601.2 84.162934 
+" clip-path="url(#p0542bda40a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m3a1f736e15" x="54.02" y="93.104828" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m43088ad8d6" x="54.02" y="84.162934" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 1.50 -->
-      <g transform="translate(24.754375 96.904047) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 87.962152) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -1072,18 +1072,18 @@ L 601.2 93.104828
     </g>
     <g id="ytick_8">
      <g id="line2d_22">
-      <path d="M 54.02 47.100966 
-L 601.2 47.100966 
-" clip-path="url(#p3a575460fc)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 36.668756 
+L 601.2 36.668756 
+" clip-path="url(#p0542bda40a)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3a1f736e15" x="54.02" y="47.100966" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m43088ad8d6" x="54.02" y="36.668756" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 1.75 -->
-      <g transform="translate(24.754375 50.900185) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 40.467975) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-37" x="95.410156"/>
@@ -1175,14 +1175,14 @@ z
    <g id="patch_3">
     <path d="M 78.891818 369.128 
 L 97.315387 369.128 
-L 97.315387 121.877492 
-L 78.891818 121.877492 
+L 97.315387 111.994543 
+L 78.891818 111.994543 
 z
-" clip-path="url(#p3a575460fc)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_17">
-    <!-- 1.34 s -->
-    <g transform="translate(90.862978 116.877492) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.35 s -->
+    <g transform="translate(90.862978 106.994543) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1220,7 +1220,7 @@ z
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1231,10 +1231,10 @@ L 115.738956 369.128
 L 115.738956 72.809385 
 L 97.315387 72.809385 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#h117cd3a00c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#hb080ff9618); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_18">
-    <!-- 1.61 s -->
+    <!-- 1.56 s -->
     <g transform="translate(109.286547 67.809385) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
@@ -1270,8 +1270,8 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1279,18 +1279,18 @@ z
    <g id="patch_5">
     <path d="M 152.586094 369.128 
 L 171.009663 369.128 
-L 171.009663 171.648801 
-L 152.586094 171.648801 
+L 171.009663 160.258304 
+L 152.586094 160.258304 
 z
-" clip-path="url(#p3a575460fc)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_19">
-    <!-- 1.07 s -->
-    <g transform="translate(164.557254 166.648801) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.10 s -->
+    <g transform="translate(164.557254 155.258304) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1298,18 +1298,18 @@ z
    <g id="patch_6">
     <path d="M 171.009663 369.128 
 L 189.433232 369.128 
-L 189.433232 126.225421 
-L 171.009663 126.225421 
+L 189.433232 114.412782 
+L 171.009663 114.412782 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#hea8a1871df); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#ha0df22674d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_20">
-    <!-- 1.32 s -->
-    <g transform="translate(182.980823 121.225421) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.34 s -->
+    <g transform="translate(182.980823 109.412782) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1317,65 +1317,14 @@ z
    <g id="patch_7">
     <path d="M 189.433232 369.128 
 L 207.856801 369.128 
-L 207.856801 137.228195 
-L 189.433232 137.228195 
+L 207.856801 125.715299 
+L 189.433232 125.715299 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#h940892ab66); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#h4fb55ae5c9); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_21">
-    <!-- 1.26 s -->
-    <g transform="translate(201.404392 132.228195) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 226.28037 369.128 
-L 244.703939 369.128 
-L 244.703939 213.514381 
-L 226.28037 213.514381 
-z
-" clip-path="url(#p3a575460fc)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 299.974646 369.128 
-L 318.398215 369.128 
-L 318.398215 147.045055 
-L 299.974646 147.045055 
-z
-" clip-path="url(#p3a575460fc)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 373.668923 369.128 
-L 392.092492 369.128 
-L 392.092492 276.546051 
-L 373.668923 276.546051 
-z
-" clip-path="url(#p3a575460fc)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 447.363199 369.128 
-L 465.786768 369.128 
-L 465.786768 277.943074 
-L 447.363199 277.943074 
-z
-" clip-path="url(#p3a575460fc)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 521.057475 369.128 
-L 539.481044 369.128 
-L 539.481044 277.662126 
-L 521.057475 277.662126 
-z
-" clip-path="url(#p3a575460fc)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 846 ms -->
-    <g transform="translate(238.25153 208.514381) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.28 s -->
+    <g transform="translate(201.404392 120.715299) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1417,39 +1366,68 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 1.21 s -->
-    <g transform="translate(311.945806 142.045055) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- 503 ms -->
-    <g transform="translate(385.640082 271.546051) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+   <g id="patch_8">
+    <path d="M 226.28037 369.128 
+L 244.703939 369.128 
+L 244.703939 212.808774 
+L 226.28037 212.808774 
+z
+" clip-path="url(#p0542bda40a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 299.974646 369.128 
+L 318.398215 369.128 
+L 318.398215 143.150491 
+L 299.974646 143.150491 
+z
+" clip-path="url(#p0542bda40a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 373.668923 369.128 
+L 392.092492 369.128 
+L 392.092492 277.110688 
+L 373.668923 277.110688 
+z
+" clip-path="url(#p0542bda40a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 447.363199 369.128 
+L 465.786768 369.128 
+L 465.786768 277.766859 
+L 447.363199 277.766859 
+z
+" clip-path="url(#p0542bda40a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 521.057475 369.128 
+L 539.481044 369.128 
+L 539.481044 277.176139 
+L 521.057475 277.176139 
+z
+" clip-path="url(#p0542bda40a)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 823 ms -->
+    <g transform="translate(238.25153 207.808774) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_25">
-    <!-- 496 ms -->
-    <g transform="translate(459.334358 272.943074) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_23">
+    <!-- 1.19 s -->
+    <g transform="translate(311.945806 138.150491) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1482,20 +1460,42 @@ Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 484 ms -->
+    <g transform="translate(385.640082 272.110688) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 481 ms -->
+    <g transform="translate(459.334358 272.766859) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 497 ms -->
-    <g transform="translate(533.028634 272.662126) rotate(-90) scale(0.1 -0.1)">
+    <!-- 484 ms -->
+    <g transform="translate(533.028634 272.176139) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1504,48 +1504,48 @@ z
    <g id="patch_13">
     <path d="M 244.703939 369.128 
 L 263.127508 369.128 
-L 263.127508 200.406423 
-L 244.703939 200.406423 
+L 263.127508 200.531987 
+L 244.703939 200.531987 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#h40c222ae38); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#hba94e6c315); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 318.398215 369.128 
 L 336.821785 369.128 
-L 336.821785 124.256731 
-L 318.398215 124.256731 
+L 336.821785 118.111268 
+L 318.398215 118.111268 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#h40c222ae38); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#hba94e6c315); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 392.092492 369.128 
 L 410.516061 369.128 
-L 410.516061 273.68474 
-L 392.092492 273.68474 
+L 410.516061 275.691342 
+L 392.092492 275.691342 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#h40c222ae38); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#hba94e6c315); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 465.786768 369.128 
 L 484.210337 369.128 
-L 484.210337 275.950432 
-L 465.786768 275.950432 
+L 484.210337 277.775025 
+L 465.786768 277.775025 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#h40c222ae38); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#hba94e6c315); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 539.481044 369.128 
 L 557.904613 369.128 
-L 557.904613 275.511352 
-L 539.481044 275.511352 
+L 557.904613 276.824783 
+L 539.481044 276.824783 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#h40c222ae38); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#hba94e6c315); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_27">
-    <!-- 917 ms -->
-    <g transform="translate(256.675099 195.406423) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+    <!-- 887 ms -->
+    <g transform="translate(256.675099 195.531987) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1553,44 +1553,44 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 1.33 s -->
-    <g transform="translate(330.369375 119.256731) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.32 s -->
+    <g transform="translate(330.369375 113.111268) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-33" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 519 ms -->
-    <g transform="translate(404.063651 268.68474) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+    <!-- 492 ms -->
+    <g transform="translate(404.063651 270.691342) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 506 ms -->
-    <g transform="translate(477.757927 270.950432) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+    <!-- 481 ms -->
+    <g transform="translate(477.757927 272.775025) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 509 ms -->
-    <g transform="translate(551.452203 270.511352) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+    <!-- 486 ms -->
+    <g transform="translate(551.452203 271.824783) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1599,93 +1599,93 @@ z
    <g id="patch_18">
     <path d="M 263.127508 369.128 
 L 281.551077 369.128 
-L 281.551077 202.103212 
-L 263.127508 202.103212 
+L 281.551077 202.009838 
+L 263.127508 202.009838 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#h8a8b27fcbf); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#he139e46710); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 336.821785 369.128 
 L 355.245354 369.128 
-L 355.245354 133.942679 
-L 336.821785 133.942679 
+L 355.245354 129.812898 
+L 336.821785 129.812898 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#h8a8b27fcbf); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#he139e46710); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 410.516061 369.128 
 L 428.93963 369.128 
-L 428.93963 267.844864 
-L 410.516061 267.844864 
+L 428.93963 269.938878 
+L 410.516061 269.938878 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#h8a8b27fcbf); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#he139e46710); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 484.210337 369.128 
 L 502.633906 369.128 
-L 502.633906 269.777895 
-L 484.210337 269.777895 
+L 502.633906 271.758875 
+L 484.210337 271.758875 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#h8a8b27fcbf); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#he139e46710); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 557.904613 369.128 
 L 576.328182 369.128 
-L 576.328182 269.475944 
-L 557.904613 269.475944 
+L 576.328182 270.821859 
+L 557.904613 270.821859 
 z
-" clip-path="url(#p3a575460fc)" style="fill: url(#h8a8b27fcbf); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p0542bda40a)" style="fill: url(#he139e46710); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_32">
-    <!-- 908 ms -->
-    <g transform="translate(275.098668 197.103212) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+    <!-- 880 ms -->
+    <g transform="translate(275.098668 197.009838) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 1.28 s -->
-    <g transform="translate(348.792944 128.942679) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.26 s -->
+    <g transform="translate(348.792944 124.812898) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 550 ms -->
-    <g transform="translate(422.48722 262.844864) rotate(-90) scale(0.1 -0.1)">
+    <!-- 522 ms -->
+    <g transform="translate(422.48722 264.938878) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 540 ms -->
-    <g transform="translate(496.181496 264.777895) rotate(-90) scale(0.1 -0.1)">
+    <!-- 513 ms -->
+    <g transform="translate(496.181496 266.758875) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 542 ms -->
-    <g transform="translate(569.875772 264.475944) rotate(-90) scale(0.1 -0.1)">
+    <!-- 517 ms -->
+    <g transform="translate(569.875772 265.821859) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1799,7 +1799,7 @@ L 439.19375 58.156563
 L 439.19375 51.156563 
 L 419.19375 51.156563 
 z
-" style="fill: url(#h117cd3a00c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hb080ff9618); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_39">
      <!-- mpl2005 corner_mask=False -->
@@ -1887,7 +1887,7 @@ L 439.19375 87.790937
 L 439.19375 80.790937 
 L 419.19375 80.790937 
 z
-" style="fill: url(#hea8a1871df); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#ha0df22674d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_41">
      <!-- mpl2014 corner_mask=False -->
@@ -1925,7 +1925,7 @@ L 439.19375 102.747187
 L 439.19375 95.747187 
 L 419.19375 95.747187 
 z
-" style="fill: url(#h940892ab66); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h4fb55ae5c9); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_42">
      <!-- mpl2014 corner_mask=True -->
@@ -1989,7 +1989,7 @@ L 439.19375 132.381562
 L 439.19375 125.381562 
 L 419.19375 125.381562 
 z
-" style="fill: url(#h40c222ae38); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hba94e6c315); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_44">
      <!-- serial corner_mask=False -->
@@ -2026,7 +2026,7 @@ L 439.19375 147.337812
 L 439.19375 140.337812 
 L 419.19375 140.337812 
 z
-" style="fill: url(#h8a8b27fcbf); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#he139e46710); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_45">
      <!-- serial corner_mask=True -->
@@ -2060,12 +2060,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p3a575460fc">
+  <clipPath id="p0542bda40a">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h117cd3a00c" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hb080ff9618" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2105,7 +2105,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hea8a1871df" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="ha0df22674d" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2145,7 +2145,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h940892ab66" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h4fb55ae5c9" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2187,7 +2187,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h40c222ae38" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hba94e6c315" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2227,7 +2227,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h8a8b27fcbf" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="he139e46710" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/lines_random_1000_render_dark.svg
+++ b/docs/_static/lines_random_1000_render_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:06.397906</dc:date>
+    <dc:date>2024-05-06T19:15:02.239714</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mcf9e87fcdf" d="M 0 0 
+       <path id="m05d9fdf3f0" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcf9e87fcdf" x="97.98399" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m05d9fdf3f0" x="97.98399" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -419,7 +419,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mcf9e87fcdf" x="172.950993" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m05d9fdf3f0" x="172.950993" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -491,7 +491,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mcf9e87fcdf" x="247.917997" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m05d9fdf3f0" x="247.917997" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -566,7 +566,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mcf9e87fcdf" x="322.885" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m05d9fdf3f0" x="322.885" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -602,7 +602,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mcf9e87fcdf" x="397.852003" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m05d9fdf3f0" x="397.852003" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -750,7 +750,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mcf9e87fcdf" x="472.819007" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m05d9fdf3f0" x="472.819007" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -840,7 +840,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mcf9e87fcdf" x="547.78601" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m05d9fdf3f0" x="547.78601" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -901,16 +901,16 @@ z
      <g id="line2d_8">
       <path d="M 44.57 369.128 
 L 601.2 369.128 
-" clip-path="url(#pb7af75c1b7)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <defs>
-       <path id="m0b703bab7c" d="M 0 0 
+       <path id="m0029be217a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0b703bab7c" x="44.57" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0029be217a" x="44.57" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -922,54 +922,54 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_10">
-      <path d="M 44.57 325.511096 
-L 601.2 325.511096 
-" clip-path="url(#pb7af75c1b7)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 324.872584 
+L 601.2 324.872584 
+" clip-path="url(#p62ff8fe23f)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m0b703bab7c" x="44.57" y="325.511096" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0029be217a" x="44.57" y="324.872584" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 2 -->
-      <g style="fill: #ffffff" transform="translate(31.2075 329.310315) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(31.2075 328.671803) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_12">
-      <path d="M 44.57 281.894193 
-L 601.2 281.894193 
-" clip-path="url(#pb7af75c1b7)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 280.617168 
+L 601.2 280.617168 
+" clip-path="url(#p62ff8fe23f)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m0b703bab7c" x="44.57" y="281.894193" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0029be217a" x="44.57" y="280.617168" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 4 -->
-      <g style="fill: #ffffff" transform="translate(31.2075 285.693412) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(31.2075 284.416387) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-34"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_14">
-      <path d="M 44.57 238.277289 
-L 601.2 238.277289 
-" clip-path="url(#pb7af75c1b7)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 236.361752 
+L 601.2 236.361752 
+" clip-path="url(#p62ff8fe23f)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m0b703bab7c" x="44.57" y="238.277289" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0029be217a" x="44.57" y="236.361752" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 6 -->
-      <g style="fill: #ffffff" transform="translate(31.2075 242.076508) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(31.2075 240.160971) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1008,18 +1008,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_16">
-      <path d="M 44.57 194.660386 
-L 601.2 194.660386 
-" clip-path="url(#pb7af75c1b7)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 192.106336 
+L 601.2 192.106336 
+" clip-path="url(#p62ff8fe23f)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m0b703bab7c" x="44.57" y="194.660386" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0029be217a" x="44.57" y="192.106336" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 8 -->
-      <g style="fill: #ffffff" transform="translate(31.2075 198.459605) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(31.2075 195.905555) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1067,18 +1067,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_18">
-      <path d="M 44.57 151.043482 
-L 601.2 151.043482 
-" clip-path="url(#pb7af75c1b7)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 147.85092 
+L 601.2 147.85092 
+" clip-path="url(#p62ff8fe23f)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m0b703bab7c" x="44.57" y="151.043482" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0029be217a" x="44.57" y="147.85092" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 10 -->
-      <g style="fill: #ffffff" transform="translate(24.845 154.842701) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.845 151.650139) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" x="63.623047"/>
       </g>
@@ -1086,18 +1086,18 @@ L 601.2 151.043482
     </g>
     <g id="ytick_7">
      <g id="line2d_20">
-      <path d="M 44.57 107.426579 
-L 601.2 107.426579 
-" clip-path="url(#pb7af75c1b7)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 103.595504 
+L 601.2 103.595504 
+" clip-path="url(#p62ff8fe23f)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m0b703bab7c" x="44.57" y="107.426579" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0029be217a" x="44.57" y="103.595504" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 12 -->
-      <g style="fill: #ffffff" transform="translate(24.845 111.225798) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.845 107.394723) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-32" x="63.623047"/>
       </g>
@@ -1105,18 +1105,18 @@ L 601.2 107.426579
     </g>
     <g id="ytick_8">
      <g id="line2d_22">
-      <path d="M 44.57 63.809675 
-L 601.2 63.809675 
-" clip-path="url(#pb7af75c1b7)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 59.340088 
+L 601.2 59.340088 
+" clip-path="url(#p62ff8fe23f)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m0b703bab7c" x="44.57" y="63.809675" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0029be217a" x="44.57" y="59.340088" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 14 -->
-      <g style="fill: #ffffff" transform="translate(24.845 67.608894) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.845 63.139307) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-34" x="63.623047"/>
       </g>
@@ -1206,14 +1206,14 @@ z
    <g id="patch_3">
     <path d="M 69.871364 369.128 
 L 88.613114 369.128 
-L 88.613114 110.403132 
-L 69.871364 110.403132 
+L 88.613114 125.139403 
+L 69.871364 125.139403 
 z
-" clip-path="url(#pb7af75c1b7)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_17">
-    <!-- 11.9 s -->
-    <g style="fill: #ffffff" transform="translate(82.001614 105.403132) rotate(-90) scale(0.1 -0.1)">
+    <!-- 11.0 s -->
+    <g style="fill: #ffffff" transform="translate(82.001614 120.139403) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -1222,6 +1222,84 @@ L 684 0
 L 684 794 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 88.613114 369.128 
+L 107.354865 369.128 
+L 107.354865 120.229628 
+L 88.613114 120.229628 
+z
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#ha2839cc4fa); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_18">
+    <!-- 11.2 s -->
+    <g style="fill: #ffffff" transform="translate(100.743365 115.229628) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 144.838367 369.128 
+L 163.580118 369.128 
+L 163.580118 129.176285 
+L 144.838367 129.176285 
+z
+" clip-path="url(#p62ff8fe23f)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 10.8 s -->
+    <g style="fill: #ffffff" transform="translate(156.968617 124.176285) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 163.580118 369.128 
+L 182.321869 369.128 
+L 182.321869 126.548305 
+L 163.580118 126.548305 
+z
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#h96c94a83dd); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 11.0 s -->
+    <g style="fill: #ffffff" transform="translate(175.710368 121.548305) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 182.321869 369.128 
+L 201.06362 369.128 
+L 201.06362 128.165058 
+L 182.321869 128.165058 
+z
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#h9c203d797a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 10.9 s -->
+    <g style="fill: #ffffff" transform="translate(194.452119 123.165058) rotate(-90) scale(0.1 -0.1)">
+     <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
 Q 941 559 1184 500 
@@ -1254,24 +1332,101 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-39" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="patch_4">
-    <path d="M 88.613114 369.128 
-L 107.354865 369.128 
-L 107.354865 101.869271 
-L 88.613114 101.869271 
+   <g id="patch_8">
+    <path d="M 219.80537 369.128 
+L 238.547121 369.128 
+L 238.547121 87.870596 
+L 219.80537 87.870596 
 z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h6f8f56a566); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_18">
-    <!-- 12.3 s -->
-    <g style="fill: #ffffff" transform="translate(100.743365 96.869271) rotate(-90) scale(0.1 -0.1)">
+   <g id="patch_9">
+    <path d="M 294.772374 369.128 
+L 313.514125 369.128 
+L 313.514125 126.428353 
+L 294.772374 126.428353 
+z
+" clip-path="url(#p62ff8fe23f)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 369.739377 369.128 
+L 388.481128 369.128 
+L 388.481128 241.257483 
+L 369.739377 241.257483 
+z
+" clip-path="url(#p62ff8fe23f)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 444.70638 369.128 
+L 463.448131 369.128 
+L 463.448131 76.526206 
+L 444.70638 76.526206 
+z
+" clip-path="url(#p62ff8fe23f)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 519.673384 369.128 
+L 538.415135 369.128 
+L 538.415135 72.809385 
+L 519.673384 72.809385 
+z
+" clip-path="url(#p62ff8fe23f)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 12.7 s -->
+    <g style="fill: #ffffff" transform="translate(231.935621 82.870596) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 11.0 s -->
+    <g style="fill: #ffffff" transform="translate(306.902624 121.428353) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 5.78 s -->
+    <g style="fill: #ffffff" transform="translate(381.869628 236.257483) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 13.2 s -->
+    <g style="fill: #ffffff" transform="translate(456.836631 71.526206) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1307,173 +1462,20 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 144.838367 369.128 
-L 163.580118 369.128 
-L 163.580118 115.937522 
-L 144.838367 115.937522 
-z
-" clip-path="url(#pb7af75c1b7)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 11.6 s -->
-    <g style="fill: #ffffff" transform="translate(156.968617 110.937522) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 163.580118 369.128 
-L 182.321869 369.128 
-L 182.321869 108.033524 
-L 163.580118 108.033524 
-z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h21000cf7a6); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 12.0 s -->
-    <g style="fill: #ffffff" transform="translate(175.710368 103.033524) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 182.321869 369.128 
-L 201.06362 369.128 
-L 201.06362 114.419149 
-L 182.321869 114.419149 
-z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h237ee9e39f); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 11.7 s -->
-    <g style="fill: #ffffff" transform="translate(194.452119 109.419149) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 219.80537 369.128 
-L 238.547121 369.128 
-L 238.547121 84.121087 
-L 219.80537 84.121087 
-z
-" clip-path="url(#pb7af75c1b7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 294.772374 369.128 
-L 313.514125 369.128 
-L 313.514125 112.254247 
-L 294.772374 112.254247 
-z
-" clip-path="url(#pb7af75c1b7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 369.739377 369.128 
-L 388.481128 369.128 
-L 388.481128 242.714198 
-L 369.739377 242.714198 
-z
-" clip-path="url(#pb7af75c1b7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 444.70638 369.128 
-L 463.448131 369.128 
-L 463.448131 74.360302 
-L 444.70638 74.360302 
-z
-" clip-path="url(#pb7af75c1b7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 519.673384 369.128 
-L 538.415135 369.128 
-L 538.415135 72.809385 
-L 519.673384 72.809385 
-z
-" clip-path="url(#pb7af75c1b7)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 13.1 s -->
-    <g style="fill: #ffffff" transform="translate(231.935621 79.121087) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 11.8 s -->
-    <g style="fill: #ffffff" transform="translate(306.902624 107.254247) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 5.80 s -->
-    <g style="fill: #ffffff" transform="translate(381.869628 237.714198) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 13.5 s -->
-    <g style="fill: #ffffff" transform="translate(456.836631 69.360302) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 13.6 s -->
+    <!-- 13.4 s -->
     <g style="fill: #ffffff" transform="translate(531.803634 67.809385) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1481,46 +1483,79 @@ z
    <g id="patch_13">
     <path d="M 238.547121 369.128 
 L 257.288872 369.128 
-L 257.288872 96.303943 
-L 238.547121 96.303943 
+L 257.288872 103.821818 
+L 238.547121 103.821818 
 z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h4e44631d4b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#h60f1491f1a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 313.514125 369.128 
 L 332.255875 369.128 
-L 332.255875 108.128944 
-L 313.514125 108.128944 
+L 332.255875 124.081053 
+L 313.514125 124.081053 
 z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h4e44631d4b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#h60f1491f1a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 388.481128 369.128 
 L 407.222879 369.128 
-L 407.222879 259.916085 
-L 388.481128 259.916085 
+L 407.222879 258.546218 
+L 388.481128 258.546218 
 z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h4e44631d4b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#h60f1491f1a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 463.448131 369.128 
 L 482.189882 369.128 
-L 482.189882 84.571948 
-L 463.448131 84.571948 
+L 482.189882 92.085108 
+L 463.448131 92.085108 
 z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h4e44631d4b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#h60f1491f1a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 538.415135 369.128 
 L 557.156886 369.128 
-L 557.156886 84.241125 
-L 538.415135 84.241125 
+L 557.156886 89.500233 
+L 538.415135 89.500233 
 z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h4e44631d4b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#h60f1491f1a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_27">
+    <!-- 12.0 s -->
+    <g style="fill: #ffffff" transform="translate(250.677372 98.821818) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 11.1 s -->
+    <g style="fill: #ffffff" transform="translate(325.644375 119.081053) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 5.00 s -->
+    <g style="fill: #ffffff" transform="translate(400.611378 253.546218) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_30">
     <!-- 12.5 s -->
-    <g style="fill: #ffffff" transform="translate(250.677372 91.303943) rotate(-90) scale(0.1 -0.1)">
+    <g style="fill: #ffffff" transform="translate(475.578382 87.085108) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
@@ -1529,46 +1564,13 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- 12.0 s -->
-    <g style="fill: #ffffff" transform="translate(325.644375 103.128944) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_31">
+    <!-- 12.6 s -->
+    <g style="fill: #ffffff" transform="translate(550.545385 84.500233) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 5.01 s -->
-    <g style="fill: #ffffff" transform="translate(400.611378 254.916085) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 13.0 s -->
-    <g style="fill: #ffffff" transform="translate(475.578382 79.571948) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 13.1 s -->
-    <g style="fill: #ffffff" transform="translate(550.545385 79.241125) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1576,59 +1578,59 @@ z
    <g id="patch_18">
     <path d="M 257.288872 369.128 
 L 276.030623 369.128 
-L 276.030623 92.992201 
-L 257.288872 92.992201 
+L 276.030623 98.280747 
+L 257.288872 98.280747 
 z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h83db4daff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#h9251e52336); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 332.255875 369.128 
 L 350.997626 369.128 
-L 350.997626 110.381911 
-L 332.255875 110.381911 
+L 350.997626 128.435046 
+L 332.255875 128.435046 
 z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h83db4daff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#h9251e52336); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 407.222879 369.128 
 L 425.96463 369.128 
-L 425.96463 246.702841 
-L 407.222879 246.702841 
+L 425.96463 245.948673 
+L 407.222879 245.948673 
 z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h83db4daff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#h9251e52336); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 482.189882 369.128 
 L 500.931633 369.128 
-L 500.931633 86.551046 
-L 482.189882 86.551046 
+L 500.931633 89.536601 
+L 482.189882 89.536601 
 z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h83db4daff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#h9251e52336); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 557.156886 369.128 
 L 575.898636 369.128 
-L 575.898636 83.56056 
-L 557.156886 83.56056 
+L 575.898636 88.210582 
+L 557.156886 88.210582 
 z
-" clip-path="url(#pb7af75c1b7)" style="fill: url(#h83db4daff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p62ff8fe23f)" style="fill: url(#h9251e52336); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_32">
-    <!-- 12.7 s -->
-    <g style="fill: #ffffff" transform="translate(269.419122 87.992201) rotate(-90) scale(0.1 -0.1)">
+    <!-- 12.2 s -->
+    <g style="fill: #ffffff" transform="translate(269.419122 93.280747) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 11.9 s -->
-    <g style="fill: #ffffff" transform="translate(344.386126 105.381911) rotate(-90) scale(0.1 -0.1)">
+    <!-- 10.9 s -->
+    <g style="fill: #ffffff" transform="translate(344.386126 123.435046) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-39" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1636,34 +1638,34 @@ z
     </g>
    </g>
    <g id="text_34">
-    <!-- 5.61 s -->
-    <g style="fill: #ffffff" transform="translate(419.353129 241.702841) rotate(-90) scale(0.1 -0.1)">
+    <!-- 5.57 s -->
+    <g style="fill: #ffffff" transform="translate(419.353129 240.948673) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 13.0 s -->
-    <g style="fill: #ffffff" transform="translate(494.320133 81.551046) rotate(-90) scale(0.1 -0.1)">
+    <!-- 12.6 s -->
+    <g style="fill: #ffffff" transform="translate(494.320133 84.536601) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 13.1 s -->
-    <g style="fill: #ffffff" transform="translate(569.287136 78.56056) rotate(-90) scale(0.1 -0.1)">
+    <!-- 12.7 s -->
+    <g style="fill: #ffffff" transform="translate(569.287136 83.210582) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1798,7 +1800,7 @@ L 73.57 268.588938
 L 73.57 261.588938 
 L 53.57 261.588938 
 z
-" style="fill: url(#h6f8f56a566); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#ha2839cc4fa); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_39">
      <!-- mpl2005 corner_mask=False -->
@@ -1886,7 +1888,7 @@ L 73.57 298.223313
 L 73.57 291.223313 
 L 53.57 291.223313 
 z
-" style="fill: url(#h21000cf7a6); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h96c94a83dd); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_41">
      <!-- mpl2014 corner_mask=False -->
@@ -1924,7 +1926,7 @@ L 73.57 313.179563
 L 73.57 306.179563 
 L 53.57 306.179563 
 z
-" style="fill: url(#h237ee9e39f); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h9c203d797a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_42">
      <!-- mpl2014 corner_mask=True -->
@@ -1988,7 +1990,7 @@ L 73.57 342.813938
 L 73.57 335.813938 
 L 53.57 335.813938 
 z
-" style="fill: url(#h4e44631d4b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h60f1491f1a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_44">
      <!-- serial corner_mask=False -->
@@ -2025,7 +2027,7 @@ L 73.57 357.770188
 L 73.57 350.770188 
 L 53.57 350.770188 
 z
-" style="fill: url(#h83db4daff5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h9251e52336); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_45">
      <!-- serial corner_mask=True -->
@@ -2059,12 +2061,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pb7af75c1b7">
+  <clipPath id="p62ff8fe23f">
    <rect x="44.57" y="26.88" width="556.63" height="342.248"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h6f8f56a566" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="ha2839cc4fa" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2104,7 +2106,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h21000cf7a6" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h96c94a83dd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2144,7 +2146,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h237ee9e39f" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9c203d797a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2186,7 +2188,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h4e44631d4b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h60f1491f1a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2226,7 +2228,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h83db4daff5" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h9251e52336" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/lines_random_1000_render_light.svg
+++ b/docs/_static/lines_random_1000_render_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:06.215150</dc:date>
+    <dc:date>2024-05-06T19:15:02.060179</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7994b8ffac" d="M 0 0 
+       <path id="mef756904e9" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7994b8ffac" x="97.98399" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef756904e9" x="97.98399" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -419,7 +419,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7994b8ffac" x="172.950993" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef756904e9" x="172.950993" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -491,7 +491,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7994b8ffac" x="247.917997" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef756904e9" x="247.917997" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -566,7 +566,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7994b8ffac" x="322.885" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef756904e9" x="322.885" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -602,7 +602,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7994b8ffac" x="397.852003" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef756904e9" x="397.852003" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -750,7 +750,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7994b8ffac" x="472.819007" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef756904e9" x="472.819007" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -840,7 +840,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7994b8ffac" x="547.78601" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef756904e9" x="547.78601" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -901,16 +901,16 @@ z
      <g id="line2d_8">
       <path d="M 44.57 369.128 
 L 601.2 369.128 
-" clip-path="url(#pacddcd2959)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <defs>
-       <path id="m425ad975e5" d="M 0 0 
+       <path id="m35063eb290" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m425ad975e5" x="44.57" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35063eb290" x="44.57" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -922,54 +922,54 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_10">
-      <path d="M 44.57 325.511096 
-L 601.2 325.511096 
-" clip-path="url(#pacddcd2959)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 324.872584 
+L 601.2 324.872584 
+" clip-path="url(#pc6a2b314e1)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m425ad975e5" x="44.57" y="325.511096" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35063eb290" x="44.57" y="324.872584" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 2 -->
-      <g transform="translate(31.2075 329.310315) scale(0.1 -0.1)">
+      <g transform="translate(31.2075 328.671803) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_12">
-      <path d="M 44.57 281.894193 
-L 601.2 281.894193 
-" clip-path="url(#pacddcd2959)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 280.617168 
+L 601.2 280.617168 
+" clip-path="url(#pc6a2b314e1)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m425ad975e5" x="44.57" y="281.894193" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35063eb290" x="44.57" y="280.617168" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 4 -->
-      <g transform="translate(31.2075 285.693412) scale(0.1 -0.1)">
+      <g transform="translate(31.2075 284.416387) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-34"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_14">
-      <path d="M 44.57 238.277289 
-L 601.2 238.277289 
-" clip-path="url(#pacddcd2959)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 236.361752 
+L 601.2 236.361752 
+" clip-path="url(#pc6a2b314e1)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m425ad975e5" x="44.57" y="238.277289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35063eb290" x="44.57" y="236.361752" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 6 -->
-      <g transform="translate(31.2075 242.076508) scale(0.1 -0.1)">
+      <g transform="translate(31.2075 240.160971) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1008,18 +1008,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_16">
-      <path d="M 44.57 194.660386 
-L 601.2 194.660386 
-" clip-path="url(#pacddcd2959)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 192.106336 
+L 601.2 192.106336 
+" clip-path="url(#pc6a2b314e1)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m425ad975e5" x="44.57" y="194.660386" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35063eb290" x="44.57" y="192.106336" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 8 -->
-      <g transform="translate(31.2075 198.459605) scale(0.1 -0.1)">
+      <g transform="translate(31.2075 195.905555) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1067,18 +1067,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_18">
-      <path d="M 44.57 151.043482 
-L 601.2 151.043482 
-" clip-path="url(#pacddcd2959)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 147.85092 
+L 601.2 147.85092 
+" clip-path="url(#pc6a2b314e1)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m425ad975e5" x="44.57" y="151.043482" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35063eb290" x="44.57" y="147.85092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 10 -->
-      <g transform="translate(24.845 154.842701) scale(0.1 -0.1)">
+      <g transform="translate(24.845 151.650139) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" x="63.623047"/>
       </g>
@@ -1086,18 +1086,18 @@ L 601.2 151.043482
     </g>
     <g id="ytick_7">
      <g id="line2d_20">
-      <path d="M 44.57 107.426579 
-L 601.2 107.426579 
-" clip-path="url(#pacddcd2959)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 103.595504 
+L 601.2 103.595504 
+" clip-path="url(#pc6a2b314e1)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m425ad975e5" x="44.57" y="107.426579" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35063eb290" x="44.57" y="103.595504" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 12 -->
-      <g transform="translate(24.845 111.225798) scale(0.1 -0.1)">
+      <g transform="translate(24.845 107.394723) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-32" x="63.623047"/>
       </g>
@@ -1105,18 +1105,18 @@ L 601.2 107.426579
     </g>
     <g id="ytick_8">
      <g id="line2d_22">
-      <path d="M 44.57 63.809675 
-L 601.2 63.809675 
-" clip-path="url(#pacddcd2959)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 44.57 59.340088 
+L 601.2 59.340088 
+" clip-path="url(#pc6a2b314e1)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m425ad975e5" x="44.57" y="63.809675" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35063eb290" x="44.57" y="59.340088" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 14 -->
-      <g transform="translate(24.845 67.608894) scale(0.1 -0.1)">
+      <g transform="translate(24.845 63.139307) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-34" x="63.623047"/>
       </g>
@@ -1206,14 +1206,14 @@ z
    <g id="patch_3">
     <path d="M 69.871364 369.128 
 L 88.613114 369.128 
-L 88.613114 110.403132 
-L 69.871364 110.403132 
+L 88.613114 125.139403 
+L 69.871364 125.139403 
 z
-" clip-path="url(#pacddcd2959)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_17">
-    <!-- 11.9 s -->
-    <g transform="translate(82.001614 105.403132) rotate(-90) scale(0.1 -0.1)">
+    <!-- 11.0 s -->
+    <g transform="translate(82.001614 120.139403) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-2e" d="M 684 794 
 L 1344 794 
@@ -1222,6 +1222,84 @@ L 684 0
 L 684 794 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 88.613114 369.128 
+L 107.354865 369.128 
+L 107.354865 120.229628 
+L 88.613114 120.229628 
+z
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h696baae134); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_18">
+    <!-- 11.2 s -->
+    <g transform="translate(100.743365 115.229628) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 144.838367 369.128 
+L 163.580118 369.128 
+L 163.580118 129.176285 
+L 144.838367 129.176285 
+z
+" clip-path="url(#pc6a2b314e1)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 10.8 s -->
+    <g transform="translate(156.968617 124.176285) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 163.580118 369.128 
+L 182.321869 369.128 
+L 182.321869 126.548305 
+L 163.580118 126.548305 
+z
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h15f15791b3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 11.0 s -->
+    <g transform="translate(175.710368 121.548305) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 182.321869 369.128 
+L 201.06362 369.128 
+L 201.06362 128.165058 
+L 182.321869 128.165058 
+z
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h777748339c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 10.9 s -->
+    <g transform="translate(194.452119 123.165058) rotate(-90) scale(0.1 -0.1)">
+     <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
 Q 941 559 1184 500 
@@ -1254,24 +1332,101 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-39" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="patch_4">
-    <path d="M 88.613114 369.128 
-L 107.354865 369.128 
-L 107.354865 101.869271 
-L 88.613114 101.869271 
+   <g id="patch_8">
+    <path d="M 219.80537 369.128 
+L 238.547121 369.128 
+L 238.547121 87.870596 
+L 219.80537 87.870596 
 z
-" clip-path="url(#pacddcd2959)" style="fill: url(#h328bd54f9f); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_18">
-    <!-- 12.3 s -->
-    <g transform="translate(100.743365 96.869271) rotate(-90) scale(0.1 -0.1)">
+   <g id="patch_9">
+    <path d="M 294.772374 369.128 
+L 313.514125 369.128 
+L 313.514125 126.428353 
+L 294.772374 126.428353 
+z
+" clip-path="url(#pc6a2b314e1)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 369.739377 369.128 
+L 388.481128 369.128 
+L 388.481128 241.257483 
+L 369.739377 241.257483 
+z
+" clip-path="url(#pc6a2b314e1)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 444.70638 369.128 
+L 463.448131 369.128 
+L 463.448131 76.526206 
+L 444.70638 76.526206 
+z
+" clip-path="url(#pc6a2b314e1)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 519.673384 369.128 
+L 538.415135 369.128 
+L 538.415135 72.809385 
+L 519.673384 72.809385 
+z
+" clip-path="url(#pc6a2b314e1)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 12.7 s -->
+    <g transform="translate(231.935621 82.870596) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 11.0 s -->
+    <g transform="translate(306.902624 121.428353) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 5.78 s -->
+    <g transform="translate(381.869628 236.257483) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 13.2 s -->
+    <g transform="translate(456.836631 71.526206) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1307,173 +1462,20 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 144.838367 369.128 
-L 163.580118 369.128 
-L 163.580118 115.937522 
-L 144.838367 115.937522 
-z
-" clip-path="url(#pacddcd2959)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 11.6 s -->
-    <g transform="translate(156.968617 110.937522) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 163.580118 369.128 
-L 182.321869 369.128 
-L 182.321869 108.033524 
-L 163.580118 108.033524 
-z
-" clip-path="url(#pacddcd2959)" style="fill: url(#h773ca735af); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 12.0 s -->
-    <g transform="translate(175.710368 103.033524) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 182.321869 369.128 
-L 201.06362 369.128 
-L 201.06362 114.419149 
-L 182.321869 114.419149 
-z
-" clip-path="url(#pacddcd2959)" style="fill: url(#h4897a4e6e3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 11.7 s -->
-    <g transform="translate(194.452119 109.419149) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 219.80537 369.128 
-L 238.547121 369.128 
-L 238.547121 84.121087 
-L 219.80537 84.121087 
-z
-" clip-path="url(#pacddcd2959)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 294.772374 369.128 
-L 313.514125 369.128 
-L 313.514125 112.254247 
-L 294.772374 112.254247 
-z
-" clip-path="url(#pacddcd2959)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 369.739377 369.128 
-L 388.481128 369.128 
-L 388.481128 242.714198 
-L 369.739377 242.714198 
-z
-" clip-path="url(#pacddcd2959)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 444.70638 369.128 
-L 463.448131 369.128 
-L 463.448131 74.360302 
-L 444.70638 74.360302 
-z
-" clip-path="url(#pacddcd2959)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 519.673384 369.128 
-L 538.415135 369.128 
-L 538.415135 72.809385 
-L 519.673384 72.809385 
-z
-" clip-path="url(#pacddcd2959)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 13.1 s -->
-    <g transform="translate(231.935621 79.121087) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 11.8 s -->
-    <g transform="translate(306.902624 107.254247) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 5.80 s -->
-    <g transform="translate(381.869628 237.714198) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 13.5 s -->
-    <g transform="translate(456.836631 69.360302) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 13.6 s -->
+    <!-- 13.4 s -->
     <g transform="translate(531.803634 67.809385) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1481,46 +1483,79 @@ z
    <g id="patch_13">
     <path d="M 238.547121 369.128 
 L 257.288872 369.128 
-L 257.288872 96.303943 
-L 238.547121 96.303943 
+L 257.288872 103.821818 
+L 238.547121 103.821818 
 z
-" clip-path="url(#pacddcd2959)" style="fill: url(#hbf644ffdc4); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h8e7767736b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 313.514125 369.128 
 L 332.255875 369.128 
-L 332.255875 108.128944 
-L 313.514125 108.128944 
+L 332.255875 124.081053 
+L 313.514125 124.081053 
 z
-" clip-path="url(#pacddcd2959)" style="fill: url(#hbf644ffdc4); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h8e7767736b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 388.481128 369.128 
 L 407.222879 369.128 
-L 407.222879 259.916085 
-L 388.481128 259.916085 
+L 407.222879 258.546218 
+L 388.481128 258.546218 
 z
-" clip-path="url(#pacddcd2959)" style="fill: url(#hbf644ffdc4); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h8e7767736b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 463.448131 369.128 
 L 482.189882 369.128 
-L 482.189882 84.571948 
-L 463.448131 84.571948 
+L 482.189882 92.085108 
+L 463.448131 92.085108 
 z
-" clip-path="url(#pacddcd2959)" style="fill: url(#hbf644ffdc4); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h8e7767736b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 538.415135 369.128 
 L 557.156886 369.128 
-L 557.156886 84.241125 
-L 538.415135 84.241125 
+L 557.156886 89.500233 
+L 538.415135 89.500233 
 z
-" clip-path="url(#pacddcd2959)" style="fill: url(#hbf644ffdc4); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h8e7767736b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_27">
+    <!-- 12.0 s -->
+    <g transform="translate(250.677372 98.821818) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 11.1 s -->
+    <g transform="translate(325.644375 119.081053) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 5.00 s -->
+    <g transform="translate(400.611378 253.546218) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_30">
     <!-- 12.5 s -->
-    <g transform="translate(250.677372 91.303943) rotate(-90) scale(0.1 -0.1)">
+    <g transform="translate(475.578382 87.085108) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
@@ -1529,46 +1564,13 @@ z
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- 12.0 s -->
-    <g transform="translate(325.644375 103.128944) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_31">
+    <!-- 12.6 s -->
+    <g transform="translate(550.545385 84.500233) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 5.01 s -->
-    <g transform="translate(400.611378 254.916085) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 13.0 s -->
-    <g transform="translate(475.578382 79.571948) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 13.1 s -->
-    <g transform="translate(550.545385 79.241125) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1576,59 +1578,59 @@ z
    <g id="patch_18">
     <path d="M 257.288872 369.128 
 L 276.030623 369.128 
-L 276.030623 92.992201 
-L 257.288872 92.992201 
+L 276.030623 98.280747 
+L 257.288872 98.280747 
 z
-" clip-path="url(#pacddcd2959)" style="fill: url(#ha408b753a5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h38ce1ea292); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 332.255875 369.128 
 L 350.997626 369.128 
-L 350.997626 110.381911 
-L 332.255875 110.381911 
+L 350.997626 128.435046 
+L 332.255875 128.435046 
 z
-" clip-path="url(#pacddcd2959)" style="fill: url(#ha408b753a5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h38ce1ea292); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 407.222879 369.128 
 L 425.96463 369.128 
-L 425.96463 246.702841 
-L 407.222879 246.702841 
+L 425.96463 245.948673 
+L 407.222879 245.948673 
 z
-" clip-path="url(#pacddcd2959)" style="fill: url(#ha408b753a5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h38ce1ea292); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 482.189882 369.128 
 L 500.931633 369.128 
-L 500.931633 86.551046 
-L 482.189882 86.551046 
+L 500.931633 89.536601 
+L 482.189882 89.536601 
 z
-" clip-path="url(#pacddcd2959)" style="fill: url(#ha408b753a5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h38ce1ea292); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 557.156886 369.128 
 L 575.898636 369.128 
-L 575.898636 83.56056 
-L 557.156886 83.56056 
+L 575.898636 88.210582 
+L 557.156886 88.210582 
 z
-" clip-path="url(#pacddcd2959)" style="fill: url(#ha408b753a5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc6a2b314e1)" style="fill: url(#h38ce1ea292); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_32">
-    <!-- 12.7 s -->
-    <g transform="translate(269.419122 87.992201) rotate(-90) scale(0.1 -0.1)">
+    <!-- 12.2 s -->
+    <g transform="translate(269.419122 93.280747) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 11.9 s -->
-    <g transform="translate(344.386126 105.381911) rotate(-90) scale(0.1 -0.1)">
+    <!-- 10.9 s -->
+    <g transform="translate(344.386126 123.435046) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-39" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1636,34 +1638,34 @@ z
     </g>
    </g>
    <g id="text_34">
-    <!-- 5.61 s -->
-    <g transform="translate(419.353129 241.702841) rotate(-90) scale(0.1 -0.1)">
+    <!-- 5.57 s -->
+    <g transform="translate(419.353129 240.948673) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 13.0 s -->
-    <g transform="translate(494.320133 81.551046) rotate(-90) scale(0.1 -0.1)">
+    <!-- 12.6 s -->
+    <g transform="translate(494.320133 84.536601) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 13.1 s -->
-    <g transform="translate(569.287136 78.56056) rotate(-90) scale(0.1 -0.1)">
+    <!-- 12.7 s -->
+    <g transform="translate(569.287136 83.210582) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
@@ -1798,7 +1800,7 @@ L 73.57 268.588938
 L 73.57 261.588938 
 L 53.57 261.588938 
 z
-" style="fill: url(#h328bd54f9f); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h696baae134); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_39">
      <!-- mpl2005 corner_mask=False -->
@@ -1886,7 +1888,7 @@ L 73.57 298.223313
 L 73.57 291.223313 
 L 53.57 291.223313 
 z
-" style="fill: url(#h773ca735af); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h15f15791b3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_41">
      <!-- mpl2014 corner_mask=False -->
@@ -1924,7 +1926,7 @@ L 73.57 313.179563
 L 73.57 306.179563 
 L 53.57 306.179563 
 z
-" style="fill: url(#h4897a4e6e3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h777748339c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_42">
      <!-- mpl2014 corner_mask=True -->
@@ -1988,7 +1990,7 @@ L 73.57 342.813938
 L 73.57 335.813938 
 L 53.57 335.813938 
 z
-" style="fill: url(#hbf644ffdc4); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h8e7767736b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_44">
      <!-- serial corner_mask=False -->
@@ -2025,7 +2027,7 @@ L 73.57 357.770188
 L 73.57 350.770188 
 L 53.57 350.770188 
 z
-" style="fill: url(#ha408b753a5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h38ce1ea292); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_45">
      <!-- serial corner_mask=True -->
@@ -2059,12 +2061,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pacddcd2959">
+  <clipPath id="pc6a2b314e1">
    <rect x="44.57" y="26.88" width="556.63" height="342.248"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h328bd54f9f" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h696baae134" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2104,7 +2106,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h773ca735af" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h15f15791b3" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2144,7 +2146,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h4897a4e6e3" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h777748339c" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2186,7 +2188,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hbf644ffdc4" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h8e7767736b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2226,7 +2228,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="ha408b753a5" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h38ce1ea292" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/lines_simple_1000_dark.svg
+++ b/docs/_static/lines_simple_1000_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:04.493703</dc:date>
+    <dc:date>2024-05-06T19:15:00.377397</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m286ca38667" d="M 0 0 
+       <path id="m8f7bcccc98" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m286ca38667" x="106.527172" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m8f7bcccc98" x="106.527172" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -419,7 +419,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m286ca38667" x="180.221448" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m8f7bcccc98" x="180.221448" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -491,7 +491,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m286ca38667" x="253.915724" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m8f7bcccc98" x="253.915724" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -566,7 +566,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m286ca38667" x="327.61" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m8f7bcccc98" x="327.61" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -602,7 +602,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m286ca38667" x="401.304276" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m8f7bcccc98" x="401.304276" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -750,7 +750,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m286ca38667" x="474.998552" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m8f7bcccc98" x="474.998552" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -840,7 +840,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m286ca38667" x="548.692828" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m8f7bcccc98" x="548.692828" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -901,16 +901,16 @@ z
      <g id="line2d_8">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#pe7942cbb7c)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2f020773db)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <defs>
-       <path id="me22e57c2c0" d="M 0 0 
+       <path id="m4a343ff83c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me22e57c2c0" x="54.02" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m4a343ff83c" x="54.02" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -934,18 +934,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_10">
-      <path d="M 54.02 302.741323 
-L 601.2 302.741323 
-" clip-path="url(#pe7942cbb7c)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 301.536551 
+L 601.2 301.536551 
+" clip-path="url(#p2f020773db)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me22e57c2c0" x="54.02" y="302.741323" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m4a343ff83c" x="54.02" y="301.536551" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.05 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 306.540542) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 305.33577) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -955,18 +955,18 @@ L 601.2 302.741323
     </g>
     <g id="ytick_3">
      <g id="line2d_12">
-      <path d="M 54.02 236.354646 
-L 601.2 236.354646 
-" clip-path="url(#pe7942cbb7c)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 233.945102 
+L 601.2 233.945102 
+" clip-path="url(#p2f020773db)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#me22e57c2c0" x="54.02" y="236.354646" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m4a343ff83c" x="54.02" y="233.945102" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.10 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 240.153865) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 237.744321) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -976,18 +976,18 @@ L 601.2 236.354646
     </g>
     <g id="ytick_4">
      <g id="line2d_14">
-      <path d="M 54.02 169.967969 
-L 601.2 169.967969 
-" clip-path="url(#pe7942cbb7c)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 166.353654 
+L 601.2 166.353654 
+" clip-path="url(#p2f020773db)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#me22e57c2c0" x="54.02" y="169.967969" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m4a343ff83c" x="54.02" y="166.353654" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.15 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 173.767188) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 170.152872) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -997,18 +997,18 @@ L 601.2 169.967969
     </g>
     <g id="ytick_5">
      <g id="line2d_16">
-      <path d="M 54.02 103.581292 
-L 601.2 103.581292 
-" clip-path="url(#pe7942cbb7c)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 98.762205 
+L 601.2 98.762205 
+" clip-path="url(#p2f020773db)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#me22e57c2c0" x="54.02" y="103.581292" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m4a343ff83c" x="54.02" y="98.762205" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.20 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 107.380511) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 102.561424) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1018,18 +1018,18 @@ L 601.2 103.581292
     </g>
     <g id="ytick_6">
      <g id="line2d_18">
-      <path d="M 54.02 37.194615 
-L 601.2 37.194615 
-" clip-path="url(#pe7942cbb7c)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 31.170756 
+L 601.2 31.170756 
+" clip-path="url(#p2f020773db)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#me22e57c2c0" x="54.02" y="37.194615" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m4a343ff83c" x="54.02" y="31.170756" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.25 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 40.993834) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 34.969975) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1121,14 +1121,103 @@ z
    <g id="patch_3">
     <path d="M 78.891818 369.128 
 L 97.315387 369.128 
-L 97.315387 171.170378 
-L 78.891818 171.170378 
+L 97.315387 215.640229 
+L 78.891818 215.640229 
 z
-" clip-path="url(#pe7942cbb7c)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f020773db)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_15">
-    <!-- 149 ms -->
-    <g style="fill: #ffffff" transform="translate(90.862978 166.170378) rotate(-90) scale(0.1 -0.1)">
+    <!-- 114 ms -->
+    <g style="fill: #ffffff" transform="translate(90.862978 210.640229) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 97.315387 369.128 
+L 115.738956 369.128 
+L 115.738956 212.187778 
+L 97.315387 212.187778 
+z
+" clip-path="url(#p2f020773db)" style="fill: url(#h05df60a4fd); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_16">
+    <!-- 116 ms -->
+    <g style="fill: #ffffff" transform="translate(109.286547 207.187778) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 152.586094 369.128 
+L 171.009663 369.128 
+L 171.009663 83.780708 
+L 152.586094 83.780708 
+z
+" clip-path="url(#p2f020773db)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_17">
+    <!-- 211 ms -->
+    <g style="fill: #ffffff" transform="translate(164.557254 78.780708) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 171.009663 369.128 
+L 189.433232 369.128 
+L 189.433232 102.012081 
+L 171.009663 102.012081 
+z
+" clip-path="url(#p2f020773db)" style="fill: url(#h24a1e03fa0); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_18">
+    <!-- 198 ms -->
+    <g style="fill: #ffffff" transform="translate(182.980823 97.012081) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1160,264 +1249,6 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_4">
-    <path d="M 97.315387 369.128 
-L 115.738956 369.128 
-L 115.738956 163.982705 
-L 97.315387 163.982705 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#h6b507a9136); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_16">
-    <!-- 155 ms -->
-    <g style="fill: #ffffff" transform="translate(109.286547 158.982705) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 152.586094 369.128 
-L 171.009663 369.128 
-L 171.009663 72.809385 
-L 152.586094 72.809385 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_17">
-    <!-- 223 ms -->
-    <g style="fill: #ffffff" transform="translate(164.557254 67.809385) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 171.009663 369.128 
-L 189.433232 369.128 
-L 189.433232 102.755336 
-L 171.009663 102.755336 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#h979bbfd596); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_18">
-    <!-- 201 ms -->
-    <g style="fill: #ffffff" transform="translate(182.980823 97.755336) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 189.433232 369.128 
-L 207.856801 369.128 
-L 207.856801 78.673561 
-L 189.433232 78.673561 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#ha75518ce3d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 219 ms -->
-    <g style="fill: #ffffff" transform="translate(201.404392 73.673561) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 226.28037 369.128 
-L 244.703939 369.128 
-L 244.703939 204.208609 
-L 226.28037 204.208609 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 299.974646 369.128 
-L 318.398215 369.128 
-L 318.398215 204.288248 
-L 299.974646 204.288248 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 373.668923 369.128 
-L 392.092492 369.128 
-L 392.092492 203.743516 
-L 373.668923 203.743516 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 447.363199 369.128 
-L 465.786768 369.128 
-L 465.786768 204.765588 
-L 447.363199 204.765588 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 521.057475 369.128 
-L 539.481044 369.128 
-L 539.481044 204.287892 
-L 521.057475 204.287892 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(238.25153 199.208609) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(311.945806 199.288248) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 125 ms -->
-    <g style="fill: #ffffff" transform="translate(385.640082 198.743516) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(459.334358 199.765588) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(533.028634 199.287892) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_13">
-    <path d="M 244.703939 369.128 
-L 263.127508 369.128 
-L 263.127508 212.501698 
-L 244.703939 212.501698 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#hbcf6c3ce41); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 318.398215 369.128 
-L 336.821785 369.128 
-L 336.821785 212.582734 
-L 318.398215 212.582734 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#hbcf6c3ce41); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 392.092492 369.128 
-L 410.516061 369.128 
-L 410.516061 213.253939 
-L 392.092492 213.253939 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#hbcf6c3ce41); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 465.786768 369.128 
-L 484.210337 369.128 
-L 484.210337 212.732957 
-L 465.786768 212.732957 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#hbcf6c3ce41); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 539.481044 369.128 
-L 557.904613 369.128 
-L 557.904613 213.545139 
-L 539.481044 213.545139 
-z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#hbcf6c3ce41); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_25">
-    <!-- 118 ms -->
-    <g style="fill: #ffffff" transform="translate(256.675099 207.501698) rotate(-90) scale(0.1 -0.1)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1459,64 +1290,217 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 189.433232 369.128 
+L 207.856801 369.128 
+L 207.856801 72.809385 
+L 189.433232 72.809385 
+z
+" clip-path="url(#p2f020773db)" style="fill: url(#he2366db75c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 219 ms -->
+    <g style="fill: #ffffff" transform="translate(201.404392 67.809385) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 226.28037 369.128 
+L 244.703939 369.128 
+L 244.703939 207.418782 
+L 226.28037 207.418782 
+z
+" clip-path="url(#p2f020773db)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 299.974646 369.128 
+L 318.398215 369.128 
+L 318.398215 210.060564 
+L 299.974646 210.060564 
+z
+" clip-path="url(#p2f020773db)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 373.668923 369.128 
+L 392.092492 369.128 
+L 392.092492 207.679883 
+L 373.668923 207.679883 
+z
+" clip-path="url(#p2f020773db)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 447.363199 369.128 
+L 465.786768 369.128 
+L 465.786768 207.517233 
+L 447.363199 207.517233 
+z
+" clip-path="url(#p2f020773db)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 521.057475 369.128 
+L 539.481044 369.128 
+L 539.481044 207.883662 
+L 521.057475 207.883662 
+z
+" clip-path="url(#p2f020773db)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(238.25153 202.418782) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(311.945806 205.060564) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(385.640082 202.679883) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(459.334358 202.517233) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(533.028634 202.883662) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_13">
+    <path d="M 244.703939 369.128 
+L 263.127508 369.128 
+L 263.127508 219.517706 
+L 244.703939 219.517706 
+z
+" clip-path="url(#p2f020773db)" style="fill: url(#h438a3dc322); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 318.398215 369.128 
+L 336.821785 369.128 
+L 336.821785 218.471053 
+L 318.398215 218.471053 
+z
+" clip-path="url(#p2f020773db)" style="fill: url(#h438a3dc322); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 392.092492 369.128 
+L 410.516061 369.128 
+L 410.516061 220.148823 
+L 392.092492 220.148823 
+z
+" clip-path="url(#p2f020773db)" style="fill: url(#h438a3dc322); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 465.786768 369.128 
+L 484.210337 369.128 
+L 484.210337 220.326272 
+L 465.786768 220.326272 
+z
+" clip-path="url(#p2f020773db)" style="fill: url(#h438a3dc322); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 539.481044 369.128 
+L 557.904613 369.128 
+L 557.904613 219.880543 
+L 539.481044 219.880543 
+z
+" clip-path="url(#p2f020773db)" style="fill: url(#h438a3dc322); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_25">
+    <!-- 111 ms -->
+    <g style="fill: #ffffff" transform="translate(256.675099 214.517706) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 118 ms -->
-    <g style="fill: #ffffff" transform="translate(330.369375 207.582734) rotate(-90) scale(0.1 -0.1)">
+    <!-- 111 ms -->
+    <g style="fill: #ffffff" transform="translate(330.369375 213.471053) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- 117 ms -->
-    <g style="fill: #ffffff" transform="translate(404.063651 208.253939) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 110 ms -->
+    <g style="fill: #ffffff" transform="translate(404.063651 215.148823) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 118 ms -->
-    <g style="fill: #ffffff" transform="translate(477.757927 207.732957) rotate(-90) scale(0.1 -0.1)">
+    <!-- 110 ms -->
+    <g style="fill: #ffffff" transform="translate(477.757927 215.326272) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 117 ms -->
-    <g style="fill: #ffffff" transform="translate(551.452203 208.545139) rotate(-90) scale(0.1 -0.1)">
+    <!-- 110 ms -->
+    <g style="fill: #ffffff" transform="translate(551.452203 214.880543) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1525,93 +1509,127 @@ z
    <g id="patch_18">
     <path d="M 263.127508 369.128 
 L 281.551077 369.128 
-L 281.551077 210.272868 
-L 263.127508 210.272868 
+L 281.551077 217.92694 
+L 263.127508 217.92694 
 z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#h9fb15b8c3a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f020773db)" style="fill: url(#h0c36ae8cd3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 336.821785 369.128 
 L 355.245354 369.128 
-L 355.245354 210.122662 
-L 336.821785 210.122662 
+L 355.245354 216.913093 
+L 336.821785 216.913093 
 z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#h9fb15b8c3a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f020773db)" style="fill: url(#h0c36ae8cd3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 410.516061 369.128 
 L 428.93963 369.128 
-L 428.93963 210.832456 
-L 410.516061 210.832456 
+L 428.93963 218.806935 
+L 410.516061 218.806935 
 z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#h9fb15b8c3a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f020773db)" style="fill: url(#h0c36ae8cd3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 484.210337 369.128 
 L 502.633906 369.128 
-L 502.633906 210.248971 
-L 484.210337 210.248971 
+L 502.633906 218.394457 
+L 484.210337 218.394457 
 z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#h9fb15b8c3a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f020773db)" style="fill: url(#h0c36ae8cd3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 557.904613 369.128 
 L 576.328182 369.128 
-L 576.328182 210.915939 
-L 557.904613 210.915939 
+L 576.328182 219.091012 
+L 557.904613 219.091012 
 z
-" clip-path="url(#pe7942cbb7c)" style="fill: url(#h9fb15b8c3a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f020773db)" style="fill: url(#h0c36ae8cd3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_30">
-    <!-- 120 ms -->
-    <g style="fill: #ffffff" transform="translate(275.098668 205.272868) rotate(-90) scale(0.1 -0.1)">
+    <!-- 112 ms -->
+    <g style="fill: #ffffff" transform="translate(275.098668 212.92694) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 120 ms -->
-    <g style="fill: #ffffff" transform="translate(348.792944 205.122662) rotate(-90) scale(0.1 -0.1)">
+    <!-- 113 ms -->
+    <g style="fill: #ffffff" transform="translate(348.792944 211.913093) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 119 ms -->
-    <g style="fill: #ffffff" transform="translate(422.48722 205.832456) rotate(-90) scale(0.1 -0.1)">
+    <!-- 111 ms -->
+    <g style="fill: #ffffff" transform="translate(422.48722 213.806935) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 120 ms -->
-    <g style="fill: #ffffff" transform="translate(496.181496 205.248971) rotate(-90) scale(0.1 -0.1)">
+    <!-- 112 ms -->
+    <g style="fill: #ffffff" transform="translate(496.181496 213.394457) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 119 ms -->
-    <g style="fill: #ffffff" transform="translate(569.875772 205.915939) rotate(-90) scale(0.1 -0.1)">
+    <!-- 111 ms -->
+    <g style="fill: #ffffff" transform="translate(569.875772 214.091012) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1725,7 +1743,7 @@ L 439.19375 58.156563
 L 439.19375 51.156563 
 L 419.19375 51.156563 
 z
-" style="fill: url(#h6b507a9136); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h05df60a4fd); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_37">
      <!-- mpl2005 corner_mask=False -->
@@ -1813,7 +1831,7 @@ L 439.19375 87.790937
 L 439.19375 80.790937 
 L 419.19375 80.790937 
 z
-" style="fill: url(#h979bbfd596); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h24a1e03fa0); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_39">
      <!-- mpl2014 corner_mask=False -->
@@ -1851,7 +1869,7 @@ L 439.19375 102.747187
 L 439.19375 95.747187 
 L 419.19375 95.747187 
 z
-" style="fill: url(#ha75518ce3d); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#he2366db75c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_40">
      <!-- mpl2014 corner_mask=True -->
@@ -1915,7 +1933,7 @@ L 439.19375 132.381562
 L 439.19375 125.381562 
 L 419.19375 125.381562 
 z
-" style="fill: url(#hbcf6c3ce41); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h438a3dc322); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_42">
      <!-- serial corner_mask=False -->
@@ -1952,7 +1970,7 @@ L 439.19375 147.337812
 L 439.19375 140.337812 
 L 419.19375 140.337812 
 z
-" style="fill: url(#h9fb15b8c3a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h0c36ae8cd3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_43">
      <!-- serial corner_mask=True -->
@@ -1986,12 +2004,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pe7942cbb7c">
+  <clipPath id="p2f020773db">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h6b507a9136" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h05df60a4fd" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2031,7 +2049,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h979bbfd596" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h24a1e03fa0" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2071,7 +2089,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="ha75518ce3d" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="he2366db75c" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2113,7 +2131,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hbcf6c3ce41" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h438a3dc322" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2153,7 +2171,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h9fb15b8c3a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h0c36ae8cd3" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/lines_simple_1000_light.svg
+++ b/docs/_static/lines_simple_1000_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:04.309696</dc:date>
+    <dc:date>2024-05-06T19:15:00.200792</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m2b451f2e75" d="M 0 0 
+       <path id="mf50a8aaf5c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2b451f2e75" x="106.527172" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50a8aaf5c" x="106.527172" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -419,7 +419,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m2b451f2e75" x="180.221448" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50a8aaf5c" x="180.221448" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -491,7 +491,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m2b451f2e75" x="253.915724" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50a8aaf5c" x="253.915724" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -566,7 +566,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2b451f2e75" x="327.61" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50a8aaf5c" x="327.61" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -602,7 +602,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m2b451f2e75" x="401.304276" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50a8aaf5c" x="401.304276" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -750,7 +750,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2b451f2e75" x="474.998552" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50a8aaf5c" x="474.998552" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -840,7 +840,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m2b451f2e75" x="548.692828" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50a8aaf5c" x="548.692828" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -901,16 +901,16 @@ z
      <g id="line2d_8">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#p27d2368253)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p301bf1c536)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <defs>
-       <path id="m3af0ad7683" d="M 0 0 
+       <path id="m939371f7a7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3af0ad7683" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m939371f7a7" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -934,18 +934,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_10">
-      <path d="M 54.02 302.741323 
-L 601.2 302.741323 
-" clip-path="url(#p27d2368253)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 301.536551 
+L 601.2 301.536551 
+" clip-path="url(#p301bf1c536)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m3af0ad7683" x="54.02" y="302.741323" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m939371f7a7" x="54.02" y="301.536551" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.05 -->
-      <g transform="translate(24.754375 306.540542) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 305.33577) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -955,18 +955,18 @@ L 601.2 302.741323
     </g>
     <g id="ytick_3">
      <g id="line2d_12">
-      <path d="M 54.02 236.354646 
-L 601.2 236.354646 
-" clip-path="url(#p27d2368253)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 233.945102 
+L 601.2 233.945102 
+" clip-path="url(#p301bf1c536)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m3af0ad7683" x="54.02" y="236.354646" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m939371f7a7" x="54.02" y="233.945102" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.10 -->
-      <g transform="translate(24.754375 240.153865) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 237.744321) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -976,18 +976,18 @@ L 601.2 236.354646
     </g>
     <g id="ytick_4">
      <g id="line2d_14">
-      <path d="M 54.02 169.967969 
-L 601.2 169.967969 
-" clip-path="url(#p27d2368253)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 166.353654 
+L 601.2 166.353654 
+" clip-path="url(#p301bf1c536)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m3af0ad7683" x="54.02" y="169.967969" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m939371f7a7" x="54.02" y="166.353654" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.15 -->
-      <g transform="translate(24.754375 173.767188) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 170.152872) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -997,18 +997,18 @@ L 601.2 169.967969
     </g>
     <g id="ytick_5">
      <g id="line2d_16">
-      <path d="M 54.02 103.581292 
-L 601.2 103.581292 
-" clip-path="url(#p27d2368253)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 98.762205 
+L 601.2 98.762205 
+" clip-path="url(#p301bf1c536)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m3af0ad7683" x="54.02" y="103.581292" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m939371f7a7" x="54.02" y="98.762205" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.20 -->
-      <g transform="translate(24.754375 107.380511) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 102.561424) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1018,18 +1018,18 @@ L 601.2 103.581292
     </g>
     <g id="ytick_6">
      <g id="line2d_18">
-      <path d="M 54.02 37.194615 
-L 601.2 37.194615 
-" clip-path="url(#p27d2368253)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 31.170756 
+L 601.2 31.170756 
+" clip-path="url(#p301bf1c536)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m3af0ad7683" x="54.02" y="37.194615" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m939371f7a7" x="54.02" y="31.170756" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 40.993834) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 34.969975) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1121,14 +1121,103 @@ z
    <g id="patch_3">
     <path d="M 78.891818 369.128 
 L 97.315387 369.128 
-L 97.315387 171.170378 
-L 78.891818 171.170378 
+L 97.315387 215.640229 
+L 78.891818 215.640229 
 z
-" clip-path="url(#p27d2368253)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p301bf1c536)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_15">
-    <!-- 149 ms -->
-    <g transform="translate(90.862978 166.170378) rotate(-90) scale(0.1 -0.1)">
+    <!-- 114 ms -->
+    <g transform="translate(90.862978 210.640229) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 97.315387 369.128 
+L 115.738956 369.128 
+L 115.738956 212.187778 
+L 97.315387 212.187778 
+z
+" clip-path="url(#p301bf1c536)" style="fill: url(#h3f6cf264a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_16">
+    <!-- 116 ms -->
+    <g transform="translate(109.286547 207.187778) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 152.586094 369.128 
+L 171.009663 369.128 
+L 171.009663 83.780708 
+L 152.586094 83.780708 
+z
+" clip-path="url(#p301bf1c536)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_17">
+    <!-- 211 ms -->
+    <g transform="translate(164.557254 78.780708) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 171.009663 369.128 
+L 189.433232 369.128 
+L 189.433232 102.012081 
+L 171.009663 102.012081 
+z
+" clip-path="url(#p301bf1c536)" style="fill: url(#h68d34202d2); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_18">
+    <!-- 198 ms -->
+    <g transform="translate(182.980823 97.012081) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1160,264 +1249,6 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_4">
-    <path d="M 97.315387 369.128 
-L 115.738956 369.128 
-L 115.738956 163.982705 
-L 97.315387 163.982705 
-z
-" clip-path="url(#p27d2368253)" style="fill: url(#he609a545c3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_16">
-    <!-- 155 ms -->
-    <g transform="translate(109.286547 158.982705) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 152.586094 369.128 
-L 171.009663 369.128 
-L 171.009663 72.809385 
-L 152.586094 72.809385 
-z
-" clip-path="url(#p27d2368253)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_17">
-    <!-- 223 ms -->
-    <g transform="translate(164.557254 67.809385) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 171.009663 369.128 
-L 189.433232 369.128 
-L 189.433232 102.755336 
-L 171.009663 102.755336 
-z
-" clip-path="url(#p27d2368253)" style="fill: url(#h9639c63f73); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_18">
-    <!-- 201 ms -->
-    <g transform="translate(182.980823 97.755336) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 189.433232 369.128 
-L 207.856801 369.128 
-L 207.856801 78.673561 
-L 189.433232 78.673561 
-z
-" clip-path="url(#p27d2368253)" style="fill: url(#h4fa6d4fd8c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 219 ms -->
-    <g transform="translate(201.404392 73.673561) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 226.28037 369.128 
-L 244.703939 369.128 
-L 244.703939 204.208609 
-L 226.28037 204.208609 
-z
-" clip-path="url(#p27d2368253)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 299.974646 369.128 
-L 318.398215 369.128 
-L 318.398215 204.288248 
-L 299.974646 204.288248 
-z
-" clip-path="url(#p27d2368253)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_10">
-    <path d="M 373.668923 369.128 
-L 392.092492 369.128 
-L 392.092492 203.743516 
-L 373.668923 203.743516 
-z
-" clip-path="url(#p27d2368253)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_11">
-    <path d="M 447.363199 369.128 
-L 465.786768 369.128 
-L 465.786768 204.765588 
-L 447.363199 204.765588 
-z
-" clip-path="url(#p27d2368253)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_12">
-    <path d="M 521.057475 369.128 
-L 539.481044 369.128 
-L 539.481044 204.287892 
-L 521.057475 204.287892 
-z
-" clip-path="url(#p27d2368253)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 124 ms -->
-    <g transform="translate(238.25153 199.208609) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 124 ms -->
-    <g transform="translate(311.945806 199.288248) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 125 ms -->
-    <g transform="translate(385.640082 198.743516) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 124 ms -->
-    <g transform="translate(459.334358 199.765588) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 124 ms -->
-    <g transform="translate(533.028634 199.287892) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_13">
-    <path d="M 244.703939 369.128 
-L 263.127508 369.128 
-L 263.127508 212.501698 
-L 244.703939 212.501698 
-z
-" clip-path="url(#p27d2368253)" style="fill: url(#h72719eba07); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 318.398215 369.128 
-L 336.821785 369.128 
-L 336.821785 212.582734 
-L 318.398215 212.582734 
-z
-" clip-path="url(#p27d2368253)" style="fill: url(#h72719eba07); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 392.092492 369.128 
-L 410.516061 369.128 
-L 410.516061 213.253939 
-L 392.092492 213.253939 
-z
-" clip-path="url(#p27d2368253)" style="fill: url(#h72719eba07); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 465.786768 369.128 
-L 484.210337 369.128 
-L 484.210337 212.732957 
-L 465.786768 212.732957 
-z
-" clip-path="url(#p27d2368253)" style="fill: url(#h72719eba07); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 539.481044 369.128 
-L 557.904613 369.128 
-L 557.904613 213.545139 
-L 539.481044 213.545139 
-z
-" clip-path="url(#p27d2368253)" style="fill: url(#h72719eba07); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_25">
-    <!-- 118 ms -->
-    <g transform="translate(256.675099 207.501698) rotate(-90) scale(0.1 -0.1)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1459,64 +1290,217 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 189.433232 369.128 
+L 207.856801 369.128 
+L 207.856801 72.809385 
+L 189.433232 72.809385 
+z
+" clip-path="url(#p301bf1c536)" style="fill: url(#h2f0689ad3c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 219 ms -->
+    <g transform="translate(201.404392 67.809385) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 226.28037 369.128 
+L 244.703939 369.128 
+L 244.703939 207.418782 
+L 226.28037 207.418782 
+z
+" clip-path="url(#p301bf1c536)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 299.974646 369.128 
+L 318.398215 369.128 
+L 318.398215 210.060564 
+L 299.974646 210.060564 
+z
+" clip-path="url(#p301bf1c536)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 373.668923 369.128 
+L 392.092492 369.128 
+L 392.092492 207.679883 
+L 373.668923 207.679883 
+z
+" clip-path="url(#p301bf1c536)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 447.363199 369.128 
+L 465.786768 369.128 
+L 465.786768 207.517233 
+L 447.363199 207.517233 
+z
+" clip-path="url(#p301bf1c536)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 521.057475 369.128 
+L 539.481044 369.128 
+L 539.481044 207.883662 
+L 521.057475 207.883662 
+z
+" clip-path="url(#p301bf1c536)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 120 ms -->
+    <g transform="translate(238.25153 202.418782) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 118 ms -->
+    <g transform="translate(311.945806 205.060564) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 119 ms -->
+    <g transform="translate(385.640082 202.679883) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 120 ms -->
+    <g transform="translate(459.334358 202.517233) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 119 ms -->
+    <g transform="translate(533.028634 202.883662) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_13">
+    <path d="M 244.703939 369.128 
+L 263.127508 369.128 
+L 263.127508 219.517706 
+L 244.703939 219.517706 
+z
+" clip-path="url(#p301bf1c536)" style="fill: url(#hf92dca1c13); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 318.398215 369.128 
+L 336.821785 369.128 
+L 336.821785 218.471053 
+L 318.398215 218.471053 
+z
+" clip-path="url(#p301bf1c536)" style="fill: url(#hf92dca1c13); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 392.092492 369.128 
+L 410.516061 369.128 
+L 410.516061 220.148823 
+L 392.092492 220.148823 
+z
+" clip-path="url(#p301bf1c536)" style="fill: url(#hf92dca1c13); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 465.786768 369.128 
+L 484.210337 369.128 
+L 484.210337 220.326272 
+L 465.786768 220.326272 
+z
+" clip-path="url(#p301bf1c536)" style="fill: url(#hf92dca1c13); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 539.481044 369.128 
+L 557.904613 369.128 
+L 557.904613 219.880543 
+L 539.481044 219.880543 
+z
+" clip-path="url(#p301bf1c536)" style="fill: url(#hf92dca1c13); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_25">
+    <!-- 111 ms -->
+    <g transform="translate(256.675099 214.517706) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 118 ms -->
-    <g transform="translate(330.369375 207.582734) rotate(-90) scale(0.1 -0.1)">
+    <!-- 111 ms -->
+    <g transform="translate(330.369375 213.471053) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- 117 ms -->
-    <g transform="translate(404.063651 208.253939) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 110 ms -->
+    <g transform="translate(404.063651 215.148823) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 118 ms -->
-    <g transform="translate(477.757927 207.732957) rotate(-90) scale(0.1 -0.1)">
+    <!-- 110 ms -->
+    <g transform="translate(477.757927 215.326272) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 117 ms -->
-    <g transform="translate(551.452203 208.545139) rotate(-90) scale(0.1 -0.1)">
+    <!-- 110 ms -->
+    <g transform="translate(551.452203 214.880543) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1525,93 +1509,127 @@ z
    <g id="patch_18">
     <path d="M 263.127508 369.128 
 L 281.551077 369.128 
-L 281.551077 210.272868 
-L 263.127508 210.272868 
+L 281.551077 217.92694 
+L 263.127508 217.92694 
 z
-" clip-path="url(#p27d2368253)" style="fill: url(#h35456e72f5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p301bf1c536)" style="fill: url(#hd7398315e9); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 336.821785 369.128 
 L 355.245354 369.128 
-L 355.245354 210.122662 
-L 336.821785 210.122662 
+L 355.245354 216.913093 
+L 336.821785 216.913093 
 z
-" clip-path="url(#p27d2368253)" style="fill: url(#h35456e72f5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p301bf1c536)" style="fill: url(#hd7398315e9); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 410.516061 369.128 
 L 428.93963 369.128 
-L 428.93963 210.832456 
-L 410.516061 210.832456 
+L 428.93963 218.806935 
+L 410.516061 218.806935 
 z
-" clip-path="url(#p27d2368253)" style="fill: url(#h35456e72f5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p301bf1c536)" style="fill: url(#hd7398315e9); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 484.210337 369.128 
 L 502.633906 369.128 
-L 502.633906 210.248971 
-L 484.210337 210.248971 
+L 502.633906 218.394457 
+L 484.210337 218.394457 
 z
-" clip-path="url(#p27d2368253)" style="fill: url(#h35456e72f5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p301bf1c536)" style="fill: url(#hd7398315e9); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 557.904613 369.128 
 L 576.328182 369.128 
-L 576.328182 210.915939 
-L 557.904613 210.915939 
+L 576.328182 219.091012 
+L 557.904613 219.091012 
 z
-" clip-path="url(#p27d2368253)" style="fill: url(#h35456e72f5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p301bf1c536)" style="fill: url(#hd7398315e9); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_30">
-    <!-- 120 ms -->
-    <g transform="translate(275.098668 205.272868) rotate(-90) scale(0.1 -0.1)">
+    <!-- 112 ms -->
+    <g transform="translate(275.098668 212.92694) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 120 ms -->
-    <g transform="translate(348.792944 205.122662) rotate(-90) scale(0.1 -0.1)">
+    <!-- 113 ms -->
+    <g transform="translate(348.792944 211.913093) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 119 ms -->
-    <g transform="translate(422.48722 205.832456) rotate(-90) scale(0.1 -0.1)">
+    <!-- 111 ms -->
+    <g transform="translate(422.48722 213.806935) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 120 ms -->
-    <g transform="translate(496.181496 205.248971) rotate(-90) scale(0.1 -0.1)">
+    <!-- 112 ms -->
+    <g transform="translate(496.181496 213.394457) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 119 ms -->
-    <g transform="translate(569.875772 205.915939) rotate(-90) scale(0.1 -0.1)">
+    <!-- 111 ms -->
+    <g transform="translate(569.875772 214.091012) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1725,7 +1743,7 @@ L 439.19375 58.156563
 L 439.19375 51.156563 
 L 419.19375 51.156563 
 z
-" style="fill: url(#he609a545c3); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h3f6cf264a8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_37">
      <!-- mpl2005 corner_mask=False -->
@@ -1813,7 +1831,7 @@ L 439.19375 87.790937
 L 439.19375 80.790937 
 L 419.19375 80.790937 
 z
-" style="fill: url(#h9639c63f73); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h68d34202d2); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_39">
      <!-- mpl2014 corner_mask=False -->
@@ -1851,7 +1869,7 @@ L 439.19375 102.747187
 L 439.19375 95.747187 
 L 419.19375 95.747187 
 z
-" style="fill: url(#h4fa6d4fd8c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h2f0689ad3c); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_40">
      <!-- mpl2014 corner_mask=True -->
@@ -1915,7 +1933,7 @@ L 439.19375 132.381562
 L 439.19375 125.381562 
 L 419.19375 125.381562 
 z
-" style="fill: url(#h72719eba07); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hf92dca1c13); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_42">
      <!-- serial corner_mask=False -->
@@ -1952,7 +1970,7 @@ L 439.19375 147.337812
 L 439.19375 140.337812 
 L 419.19375 140.337812 
 z
-" style="fill: url(#h35456e72f5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hd7398315e9); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
     <g id="text_43">
      <!-- serial corner_mask=True -->
@@ -1986,12 +2004,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p27d2368253">
+  <clipPath id="p301bf1c536">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="he609a545c3" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h3f6cf264a8" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2031,7 +2049,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h9639c63f73" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h68d34202d2" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2071,7 +2089,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h4fa6d4fd8c" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h2f0689ad3c" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2113,7 +2131,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h72719eba07" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hf92dca1c13" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2153,7 +2171,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h35456e72f5" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hd7398315e9" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/lines_simple_1000_render_dark.svg
+++ b/docs/_static/lines_simple_1000_render_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:06.030270</dc:date>
+    <dc:date>2024-05-06T19:15:01.880580</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m492317c558" d="M 0 0 
+       <path id="m54430ea244" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m492317c558" x="106.527172" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m54430ea244" x="106.527172" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -419,7 +419,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m492317c558" x="180.221448" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m54430ea244" x="180.221448" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -491,7 +491,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m492317c558" x="253.915724" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m54430ea244" x="253.915724" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -566,7 +566,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m492317c558" x="327.61" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m54430ea244" x="327.61" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -602,7 +602,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m492317c558" x="401.304276" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m54430ea244" x="401.304276" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -750,7 +750,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m492317c558" x="474.998552" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m54430ea244" x="474.998552" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -840,7 +840,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m492317c558" x="548.692828" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m54430ea244" x="548.692828" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -901,16 +901,16 @@ z
      <g id="line2d_8">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#p32bfa5d618)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p1c3e141a42)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <defs>
-       <path id="m3bd8fb6f24" d="M 0 0 
+       <path id="m74cdd4dfe7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3bd8fb6f24" x="54.02" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m74cdd4dfe7" x="54.02" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -934,18 +934,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_10">
-      <path d="M 54.02 326.347 
-L 601.2 326.347 
-" clip-path="url(#p32bfa5d618)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 324.095368 
+L 601.2 324.095368 
+" clip-path="url(#p1c3e141a42)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m3bd8fb6f24" x="54.02" y="326.347" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m74cdd4dfe7" x="54.02" y="324.095368" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.05 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 330.146219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 327.894587) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -955,18 +955,18 @@ L 601.2 326.347
     </g>
     <g id="ytick_3">
      <g id="line2d_12">
-      <path d="M 54.02 283.566 
-L 601.2 283.566 
-" clip-path="url(#p32bfa5d618)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 279.062737 
+L 601.2 279.062737 
+" clip-path="url(#p1c3e141a42)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m3bd8fb6f24" x="54.02" y="283.566" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m74cdd4dfe7" x="54.02" y="279.062737" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.10 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 287.365219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 282.861956) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -976,18 +976,18 @@ L 601.2 283.566
     </g>
     <g id="ytick_4">
      <g id="line2d_14">
-      <path d="M 54.02 240.785 
-L 601.2 240.785 
-" clip-path="url(#p32bfa5d618)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 234.030105 
+L 601.2 234.030105 
+" clip-path="url(#p1c3e141a42)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m3bd8fb6f24" x="54.02" y="240.785" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m74cdd4dfe7" x="54.02" y="234.030105" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.15 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 244.584219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 237.829324) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -997,18 +997,18 @@ L 601.2 240.785
     </g>
     <g id="ytick_5">
      <g id="line2d_16">
-      <path d="M 54.02 198.004 
-L 601.2 198.004 
-" clip-path="url(#p32bfa5d618)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 188.997474 
+L 601.2 188.997474 
+" clip-path="url(#p1c3e141a42)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m3bd8fb6f24" x="54.02" y="198.004" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m74cdd4dfe7" x="54.02" y="188.997474" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.20 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 201.803219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 192.796692) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1018,18 +1018,18 @@ L 601.2 198.004
     </g>
     <g id="ytick_6">
      <g id="line2d_18">
-      <path d="M 54.02 155.223 
-L 601.2 155.223 
-" clip-path="url(#p32bfa5d618)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 143.964842 
+L 601.2 143.964842 
+" clip-path="url(#p1c3e141a42)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m3bd8fb6f24" x="54.02" y="155.223" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m74cdd4dfe7" x="54.02" y="143.964842" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.25 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 159.022219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 147.764061) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1039,18 +1039,18 @@ L 601.2 155.223
     </g>
     <g id="ytick_7">
      <g id="line2d_20">
-      <path d="M 54.02 112.442 
-L 601.2 112.442 
-" clip-path="url(#p32bfa5d618)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 98.932211 
+L 601.2 98.932211 
+" clip-path="url(#p1c3e141a42)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m3bd8fb6f24" x="54.02" y="112.442" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m74cdd4dfe7" x="54.02" y="98.932211" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.30 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 116.241219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 102.731429) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1094,18 +1094,18 @@ z
     </g>
     <g id="ytick_8">
      <g id="line2d_22">
-      <path d="M 54.02 69.661 
-L 601.2 69.661 
-" clip-path="url(#p32bfa5d618)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 53.899579 
+L 601.2 53.899579 
+" clip-path="url(#p1c3e141a42)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3bd8fb6f24" x="54.02" y="69.661" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m74cdd4dfe7" x="54.02" y="53.899579" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 0.35 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 73.460219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 57.698798) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-33" x="95.410156"/>
@@ -1113,28 +1113,7 @@ L 601.2 69.661
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_24">
-      <path d="M 54.02 26.88 
-L 601.2 26.88 
-" clip-path="url(#p32bfa5d618)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_25">
-      <g>
-       <use xlink:href="#m3bd8fb6f24" x="54.02" y="26.88" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_16">
-      <!-- 0.40 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 30.679219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-34" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_17">
+    <g id="text_16">
      <!-- Time (seconds) -->
      <g style="fill: #ffffff" transform="translate(18.674688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1218,14 +1197,163 @@ z
    <g id="patch_3">
     <path d="M 78.891818 369.128 
 L 97.315387 369.128 
-L 97.315387 137.676861 
-L 78.891818 137.676861 
+L 97.315387 163.586738 
+L 78.891818 163.586738 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_17">
+    <!-- 228 ms -->
+    <g style="fill: #ffffff" transform="translate(90.862978 158.586738) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 97.315387 369.128 
+L 115.738956 369.128 
+L 115.738956 167.764385 
+L 97.315387 167.764385 
+z
+" clip-path="url(#p1c3e141a42)" style="fill: url(#h6a86cc889e); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_18">
-    <!-- 271 ms -->
-    <g style="fill: #ffffff" transform="translate(90.862978 132.676861) rotate(-90) scale(0.1 -0.1)">
+    <!-- 224 ms -->
+    <g style="fill: #ffffff" transform="translate(109.286547 162.764385) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 152.586094 369.128 
+L 171.009663 369.128 
+L 171.009663 72.987834 
+L 152.586094 72.987834 
+z
+" clip-path="url(#p1c3e141a42)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 329 ms -->
+    <g style="fill: #ffffff" transform="translate(164.557254 67.987834) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 171.009663 369.128 
+L 189.433232 369.128 
+L 189.433232 94.586718 
+L 171.009663 94.586718 
+z
+" clip-path="url(#p1c3e141a42)" style="fill: url(#h4359337f75); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 305 ms -->
+    <g style="fill: #ffffff" transform="translate(182.980823 89.586718) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 189.433232 369.128 
+L 207.856801 369.128 
+L 207.856801 74.798541 
+L 189.433232 74.798541 
+z
+" clip-path="url(#p1c3e141a42)" style="fill: url(#h235a5a436a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 327 ms -->
+    <g style="fill: #ffffff" transform="translate(201.404392 69.798541) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1238,117 +1366,9 @@ L 525 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_4">
-    <path d="M 97.315387 369.128 
-L 115.738956 369.128 
-L 115.738956 140.477073 
-L 97.315387 140.477073 
-z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#h602bb7cf9a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 267 ms -->
-    <g style="fill: #ffffff" transform="translate(109.286547 135.477073) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 152.586094 369.128 
-L 171.009663 369.128 
-L 171.009663 74.607075 
-L 152.586094 74.607075 
-z
-" clip-path="url(#p32bfa5d618)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 344 ms -->
-    <g style="fill: #ffffff" transform="translate(164.557254 69.607075) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 171.009663 369.128 
-L 189.433232 369.128 
-L 189.433232 102.869794 
-L 171.009663 102.869794 
-z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#hb437f671b8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 311 ms -->
-    <g style="fill: #ffffff" transform="translate(182.980823 97.869794) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 189.433232 369.128 
-L 207.856801 369.128 
-L 207.856801 86.580249 
-L 189.433232 86.580249 
-z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#h2e8b6fb55a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 330 ms -->
-    <g style="fill: #ffffff" transform="translate(201.404392 81.580249) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1357,93 +1377,93 @@ z
    <g id="patch_8">
     <path d="M 226.28037 369.128 
 L 244.703939 369.128 
-L 244.703939 159.203658 
-L 226.28037 159.203658 
+L 244.703939 158.870487 
+L 226.28037 158.870487 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 299.974646 369.128 
 L 318.398215 369.128 
-L 318.398215 159.514852 
-L 299.974646 159.514852 
+L 318.398215 158.486193 
+L 299.974646 158.486193 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 373.668923 369.128 
 L 392.092492 369.128 
-L 392.092492 159.143482 
-L 373.668923 159.143482 
+L 392.092492 158.542052 
+L 373.668923 158.542052 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 447.363199 369.128 
 L 465.786768 369.128 
-L 465.786768 159.491093 
-L 447.363199 159.491093 
+L 465.786768 159.086347 
+L 447.363199 159.086347 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 521.057475 369.128 
 L 539.481044 369.128 
-L 539.481044 159.440348 
-L 521.057475 159.440348 
+L 539.481044 158.304146 
+L 521.057475 158.304146 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 233 ms -->
+    <g style="fill: #ffffff" transform="translate(238.25153 153.870487) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
    </g>
    <g id="text_23">
-    <!-- 245 ms -->
-    <g style="fill: #ffffff" transform="translate(238.25153 154.203658) rotate(-90) scale(0.1 -0.1)">
+    <!-- 234 ms -->
+    <g style="fill: #ffffff" transform="translate(311.945806 153.486193) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 245 ms -->
-    <g style="fill: #ffffff" transform="translate(311.945806 154.514852) rotate(-90) scale(0.1 -0.1)">
+    <!-- 234 ms -->
+    <g style="fill: #ffffff" transform="translate(385.640082 153.542052) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 245 ms -->
-    <g style="fill: #ffffff" transform="translate(385.640082 154.143482) rotate(-90) scale(0.1 -0.1)">
+    <!-- 233 ms -->
+    <g style="fill: #ffffff" transform="translate(459.334358 154.086347) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 245 ms -->
-    <g style="fill: #ffffff" transform="translate(459.334358 154.491093) rotate(-90) scale(0.1 -0.1)">
+    <!-- 234 ms -->
+    <g style="fill: #ffffff" transform="translate(533.028634 153.304146) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 245 ms -->
-    <g style="fill: #ffffff" transform="translate(533.028634 154.440348) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1452,93 +1472,93 @@ z
    <g id="patch_13">
     <path d="M 244.703939 369.128 
 L 263.127508 369.128 
-L 263.127508 171.248865 
-L 244.703939 171.248865 
+L 263.127508 172.700218 
+L 244.703939 172.700218 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#hb9ee1a3546); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: url(#h29167ac0ad); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 318.398215 369.128 
 L 336.821785 369.128 
-L 336.821785 170.997117 
-L 318.398215 170.997117 
+L 336.821785 172.80748 
+L 318.398215 172.80748 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#hb9ee1a3546); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: url(#h29167ac0ad); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 392.092492 369.128 
 L 410.516061 369.128 
-L 410.516061 171.363101 
-L 392.092492 171.363101 
+L 410.516061 172.888717 
+L 392.092492 172.888717 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#hb9ee1a3546); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: url(#h29167ac0ad); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 465.786768 369.128 
 L 484.210337 369.128 
-L 484.210337 171.765143 
-L 465.786768 171.765143 
+L 484.210337 172.792034 
+L 465.786768 172.792034 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#hb9ee1a3546); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: url(#h29167ac0ad); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 539.481044 369.128 
 L 557.904613 369.128 
-L 557.904613 171.521969 
-L 539.481044 171.521969 
+L 557.904613 172.275645 
+L 539.481044 172.275645 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#hb9ee1a3546); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: url(#h29167ac0ad); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_27">
+    <!-- 218 ms -->
+    <g style="fill: #ffffff" transform="translate(256.675099 167.700218) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
    </g>
    <g id="text_28">
-    <!-- 231 ms -->
-    <g style="fill: #ffffff" transform="translate(256.675099 166.248865) rotate(-90) scale(0.1 -0.1)">
+    <!-- 218 ms -->
+    <g style="fill: #ffffff" transform="translate(330.369375 167.80748) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 232 ms -->
-    <g style="fill: #ffffff" transform="translate(330.369375 165.997117) rotate(-90) scale(0.1 -0.1)">
+    <!-- 218 ms -->
+    <g style="fill: #ffffff" transform="translate(404.063651 167.888717) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 231 ms -->
-    <g style="fill: #ffffff" transform="translate(404.063651 166.363101) rotate(-90) scale(0.1 -0.1)">
+    <!-- 218 ms -->
+    <g style="fill: #ffffff" transform="translate(477.757927 167.792034) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 231 ms -->
-    <g style="fill: #ffffff" transform="translate(477.757927 166.765143) rotate(-90) scale(0.1 -0.1)">
+    <!-- 219 ms -->
+    <g style="fill: #ffffff" transform="translate(551.452203 167.275645) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 231 ms -->
-    <g style="fill: #ffffff" transform="translate(551.452203 166.521969) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1547,99 +1567,99 @@ z
    <g id="patch_18">
     <path d="M 263.127508 369.128 
 L 281.551077 369.128 
-L 281.551077 170.097019 
-L 263.127508 170.097019 
+L 281.551077 171.257271 
+L 263.127508 171.257271 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#h26d06c45b5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: url(#ha6bd4eb161); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 336.821785 369.128 
 L 355.245354 369.128 
-L 355.245354 169.591479 
-L 336.821785 169.591479 
+L 355.245354 171.225451 
+L 336.821785 171.225451 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#h26d06c45b5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: url(#ha6bd4eb161); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 410.516061 369.128 
 L 428.93963 369.128 
-L 428.93963 169.701459 
-L 410.516061 169.701459 
+L 428.93963 171.885892 
+L 410.516061 171.885892 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#h26d06c45b5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: url(#ha6bd4eb161); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 484.210337 369.128 
 L 502.633906 369.128 
-L 502.633906 170.20609 
-L 484.210337 170.20609 
+L 502.633906 172.010586 
+L 484.210337 172.010586 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#h26d06c45b5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: url(#ha6bd4eb161); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 557.904613 369.128 
 L 576.328182 369.128 
-L 576.328182 169.787423 
-L 557.904613 169.787423 
+L 576.328182 171.403994 
+L 557.904613 171.403994 
 z
-" clip-path="url(#p32bfa5d618)" style="fill: url(#h26d06c45b5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1c3e141a42)" style="fill: url(#ha6bd4eb161); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_32">
+    <!-- 220 ms -->
+    <g style="fill: #ffffff" transform="translate(275.098668 166.257271) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
    </g>
    <g id="text_33">
-    <!-- 233 ms -->
-    <g style="fill: #ffffff" transform="translate(275.098668 165.097019) rotate(-90) scale(0.1 -0.1)">
+    <!-- 220 ms -->
+    <g style="fill: #ffffff" transform="translate(348.792944 166.225451) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 233 ms -->
-    <g style="fill: #ffffff" transform="translate(348.792944 164.591479) rotate(-90) scale(0.1 -0.1)">
+    <!-- 219 ms -->
+    <g style="fill: #ffffff" transform="translate(422.48722 166.885892) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 233 ms -->
-    <g style="fill: #ffffff" transform="translate(422.48722 164.701459) rotate(-90) scale(0.1 -0.1)">
+    <!-- 219 ms -->
+    <g style="fill: #ffffff" transform="translate(496.181496 167.010586) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 232 ms -->
-    <g style="fill: #ffffff" transform="translate(496.181496 165.20609) rotate(-90) scale(0.1 -0.1)">
+    <!-- 220 ms -->
+    <g style="fill: #ffffff" transform="translate(569.875772 166.403994) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 233 ms -->
-    <g style="fill: #ffffff" transform="translate(569.875772 164.787423) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_38">
     <!-- lines simple n=1000 (calculate and render) -->
     <g style="fill: #ffffff" transform="translate(197.320938 20.88) scale(0.12 -0.12)">
      <defs>
@@ -1743,7 +1763,7 @@ L 419.19375 246.910813
 z
 " style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_39">
+    <g id="text_38">
      <!-- mpl2005 no mask -->
      <g style="fill: #ffffff" transform="translate(447.19375 253.910813) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1769,9 +1789,9 @@ L 439.19375 268.588938
 L 439.19375 261.588938 
 L 419.19375 261.588938 
 z
-" style="fill: url(#h602bb7cf9a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h6a86cc889e); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_40">
+    <g id="text_39">
      <!-- mpl2005 corner_mask=False -->
      <g style="fill: #ffffff" transform="translate(447.19375 268.588938) scale(0.1 -0.1)">
       <defs>
@@ -1831,7 +1851,7 @@ L 419.19375 276.545187
 z
 " style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_41">
+    <g id="text_40">
      <!-- mpl2014 no mask -->
      <g style="fill: #ffffff" transform="translate(447.19375 283.545187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1857,9 +1877,9 @@ L 439.19375 298.223313
 L 439.19375 291.223313 
 L 419.19375 291.223313 
 z
-" style="fill: url(#hb437f671b8); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h4359337f75); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_42">
+    <g id="text_41">
      <!-- mpl2014 corner_mask=False -->
      <g style="fill: #ffffff" transform="translate(447.19375 298.223313) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1895,9 +1915,9 @@ L 439.19375 313.179563
 L 439.19375 306.179563 
 L 419.19375 306.179563 
 z
-" style="fill: url(#h2e8b6fb55a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h235a5a436a); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_43">
+    <g id="text_42">
      <!-- mpl2014 corner_mask=True -->
      <g style="fill: #ffffff" transform="translate(447.19375 313.179563) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1934,7 +1954,7 @@ L 419.19375 321.135813
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_44">
+    <g id="text_43">
      <!-- serial no mask -->
      <g style="fill: #ffffff" transform="translate(447.19375 328.135813) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -1959,9 +1979,9 @@ L 439.19375 342.813938
 L 439.19375 335.813938 
 L 419.19375 335.813938 
 z
-" style="fill: url(#hb9ee1a3546); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h29167ac0ad); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_45">
+    <g id="text_44">
      <!-- serial corner_mask=False -->
      <g style="fill: #ffffff" transform="translate(447.19375 342.813938) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -1996,9 +2016,9 @@ L 439.19375 357.770188
 L 439.19375 350.770188 
 L 419.19375 350.770188 
 z
-" style="fill: url(#h26d06c45b5); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#ha6bd4eb161); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_46">
+    <g id="text_45">
      <!-- serial corner_mask=True -->
      <g style="fill: #ffffff" transform="translate(447.19375 357.770188) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2030,12 +2050,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p32bfa5d618">
+  <clipPath id="p1c3e141a42">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h602bb7cf9a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h6a86cc889e" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2075,7 +2095,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hb437f671b8" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h4359337f75" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2115,7 +2135,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h2e8b6fb55a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h235a5a436a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2157,7 +2177,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hb9ee1a3546" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h29167ac0ad" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2197,7 +2217,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h26d06c45b5" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="ha6bd4eb161" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/lines_simple_1000_render_light.svg
+++ b/docs/_static/lines_simple_1000_render_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:05.845926</dc:date>
+    <dc:date>2024-05-06T19:15:01.700099</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="ma14b17eea9" d="M 0 0 
+       <path id="m9e987bb09c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma14b17eea9" x="106.527172" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e987bb09c" x="106.527172" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -419,7 +419,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#ma14b17eea9" x="180.221448" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e987bb09c" x="180.221448" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -491,7 +491,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#ma14b17eea9" x="253.915724" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e987bb09c" x="253.915724" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -566,7 +566,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma14b17eea9" x="327.61" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e987bb09c" x="327.61" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -602,7 +602,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#ma14b17eea9" x="401.304276" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e987bb09c" x="401.304276" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -750,7 +750,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma14b17eea9" x="474.998552" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e987bb09c" x="474.998552" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -840,7 +840,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#ma14b17eea9" x="548.692828" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e987bb09c" x="548.692828" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -901,16 +901,16 @@ z
      <g id="line2d_8">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#p3f48b4f835)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pcb29d7d412)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <defs>
-       <path id="m27223fb0bc" d="M 0 0 
+       <path id="m0d2f14067a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m27223fb0bc" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d2f14067a" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -934,18 +934,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_10">
-      <path d="M 54.02 326.347 
-L 601.2 326.347 
-" clip-path="url(#p3f48b4f835)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 324.095368 
+L 601.2 324.095368 
+" clip-path="url(#pcb29d7d412)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m27223fb0bc" x="54.02" y="326.347" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d2f14067a" x="54.02" y="324.095368" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.05 -->
-      <g transform="translate(24.754375 330.146219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 327.894587) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
@@ -955,18 +955,18 @@ L 601.2 326.347
     </g>
     <g id="ytick_3">
      <g id="line2d_12">
-      <path d="M 54.02 283.566 
-L 601.2 283.566 
-" clip-path="url(#p3f48b4f835)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 279.062737 
+L 601.2 279.062737 
+" clip-path="url(#pcb29d7d412)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m27223fb0bc" x="54.02" y="283.566" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d2f14067a" x="54.02" y="279.062737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.10 -->
-      <g transform="translate(24.754375 287.365219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 282.861956) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -976,18 +976,18 @@ L 601.2 283.566
     </g>
     <g id="ytick_4">
      <g id="line2d_14">
-      <path d="M 54.02 240.785 
-L 601.2 240.785 
-" clip-path="url(#p3f48b4f835)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 234.030105 
+L 601.2 234.030105 
+" clip-path="url(#pcb29d7d412)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m27223fb0bc" x="54.02" y="240.785" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d2f14067a" x="54.02" y="234.030105" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.15 -->
-      <g transform="translate(24.754375 244.584219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 237.829324) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -997,18 +997,18 @@ L 601.2 240.785
     </g>
     <g id="ytick_5">
      <g id="line2d_16">
-      <path d="M 54.02 198.004 
-L 601.2 198.004 
-" clip-path="url(#p3f48b4f835)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 188.997474 
+L 601.2 188.997474 
+" clip-path="url(#pcb29d7d412)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m27223fb0bc" x="54.02" y="198.004" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d2f14067a" x="54.02" y="188.997474" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.20 -->
-      <g transform="translate(24.754375 201.803219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 192.796692) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1018,18 +1018,18 @@ L 601.2 198.004
     </g>
     <g id="ytick_6">
      <g id="line2d_18">
-      <path d="M 54.02 155.223 
-L 601.2 155.223 
-" clip-path="url(#p3f48b4f835)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 143.964842 
+L 601.2 143.964842 
+" clip-path="url(#pcb29d7d412)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m27223fb0bc" x="54.02" y="155.223" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d2f14067a" x="54.02" y="143.964842" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 159.022219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 147.764061) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -1039,18 +1039,18 @@ L 601.2 155.223
     </g>
     <g id="ytick_7">
      <g id="line2d_20">
-      <path d="M 54.02 112.442 
-L 601.2 112.442 
-" clip-path="url(#p3f48b4f835)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 98.932211 
+L 601.2 98.932211 
+" clip-path="url(#pcb29d7d412)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m27223fb0bc" x="54.02" y="112.442" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d2f14067a" x="54.02" y="98.932211" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.30 -->
-      <g transform="translate(24.754375 116.241219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 102.731429) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1094,18 +1094,18 @@ z
     </g>
     <g id="ytick_8">
      <g id="line2d_22">
-      <path d="M 54.02 69.661 
-L 601.2 69.661 
-" clip-path="url(#p3f48b4f835)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 53.899579 
+L 601.2 53.899579 
+" clip-path="url(#pcb29d7d412)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m27223fb0bc" x="54.02" y="69.661" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d2f14067a" x="54.02" y="53.899579" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 0.35 -->
-      <g transform="translate(24.754375 73.460219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 57.698798) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-33" x="95.410156"/>
@@ -1113,28 +1113,7 @@ L 601.2 69.661
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_24">
-      <path d="M 54.02 26.88 
-L 601.2 26.88 
-" clip-path="url(#p3f48b4f835)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_25">
-      <g>
-       <use xlink:href="#m27223fb0bc" x="54.02" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_16">
-      <!-- 0.40 -->
-      <g transform="translate(24.754375 30.679219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-34" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_17">
+    <g id="text_16">
      <!-- Time (seconds) -->
      <g transform="translate(18.674688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1218,14 +1197,163 @@ z
    <g id="patch_3">
     <path d="M 78.891818 369.128 
 L 97.315387 369.128 
-L 97.315387 137.676861 
-L 78.891818 137.676861 
+L 97.315387 163.586738 
+L 78.891818 163.586738 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_17">
+    <!-- 228 ms -->
+    <g transform="translate(90.862978 158.586738) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 97.315387 369.128 
+L 115.738956 369.128 
+L 115.738956 167.764385 
+L 97.315387 167.764385 
+z
+" clip-path="url(#pcb29d7d412)" style="fill: url(#hbea493fc30); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_18">
-    <!-- 271 ms -->
-    <g transform="translate(90.862978 132.676861) rotate(-90) scale(0.1 -0.1)">
+    <!-- 224 ms -->
+    <g transform="translate(109.286547 162.764385) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_5">
+    <path d="M 152.586094 369.128 
+L 171.009663 369.128 
+L 171.009663 72.987834 
+L 152.586094 72.987834 
+z
+" clip-path="url(#pcb29d7d412)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- 329 ms -->
+    <g transform="translate(164.557254 67.987834) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 171.009663 369.128 
+L 189.433232 369.128 
+L 189.433232 94.586718 
+L 171.009663 94.586718 
+z
+" clip-path="url(#pcb29d7d412)" style="fill: url(#hf8d89cf53f); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 305 ms -->
+    <g transform="translate(182.980823 89.586718) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 189.433232 369.128 
+L 207.856801 369.128 
+L 207.856801 74.798541 
+L 189.433232 74.798541 
+z
+" clip-path="url(#pcb29d7d412)" style="fill: url(#haa48990775); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 327 ms -->
+    <g transform="translate(201.404392 69.798541) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1238,117 +1366,9 @@ L 525 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_4">
-    <path d="M 97.315387 369.128 
-L 115.738956 369.128 
-L 115.738956 140.477073 
-L 97.315387 140.477073 
-z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#h79bcc6b9c0); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_19">
-    <!-- 267 ms -->
-    <g transform="translate(109.286547 135.477073) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-37" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_5">
-    <path d="M 152.586094 369.128 
-L 171.009663 369.128 
-L 171.009663 74.607075 
-L 152.586094 74.607075 
-z
-" clip-path="url(#p3f48b4f835)" style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_20">
-    <!-- 344 ms -->
-    <g transform="translate(164.557254 69.607075) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_6">
-    <path d="M 171.009663 369.128 
-L 189.433232 369.128 
-L 189.433232 102.869794 
-L 171.009663 102.869794 
-z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#hdb83627028); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 311 ms -->
-    <g transform="translate(182.980823 97.869794) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_7">
-    <path d="M 189.433232 369.128 
-L 207.856801 369.128 
-L 207.856801 86.580249 
-L 189.433232 86.580249 
-z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#hb26b2f2b58); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 330 ms -->
-    <g transform="translate(201.404392 81.580249) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1357,93 +1377,93 @@ z
    <g id="patch_8">
     <path d="M 226.28037 369.128 
 L 244.703939 369.128 
-L 244.703939 159.203658 
-L 226.28037 159.203658 
+L 244.703939 158.870487 
+L 226.28037 158.870487 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 299.974646 369.128 
 L 318.398215 369.128 
-L 318.398215 159.514852 
-L 299.974646 159.514852 
+L 318.398215 158.486193 
+L 299.974646 158.486193 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 373.668923 369.128 
 L 392.092492 369.128 
-L 392.092492 159.143482 
-L 373.668923 159.143482 
+L 392.092492 158.542052 
+L 373.668923 158.542052 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 447.363199 369.128 
 L 465.786768 369.128 
-L 465.786768 159.491093 
-L 447.363199 159.491093 
+L 465.786768 159.086347 
+L 447.363199 159.086347 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 521.057475 369.128 
 L 539.481044 369.128 
-L 539.481044 159.440348 
-L 521.057475 159.440348 
+L 539.481044 158.304146 
+L 521.057475 158.304146 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 233 ms -->
+    <g transform="translate(238.25153 153.870487) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
    </g>
    <g id="text_23">
-    <!-- 245 ms -->
-    <g transform="translate(238.25153 154.203658) rotate(-90) scale(0.1 -0.1)">
+    <!-- 234 ms -->
+    <g transform="translate(311.945806 153.486193) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 245 ms -->
-    <g transform="translate(311.945806 154.514852) rotate(-90) scale(0.1 -0.1)">
+    <!-- 234 ms -->
+    <g transform="translate(385.640082 153.542052) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 245 ms -->
-    <g transform="translate(385.640082 154.143482) rotate(-90) scale(0.1 -0.1)">
+    <!-- 233 ms -->
+    <g transform="translate(459.334358 154.086347) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- 245 ms -->
-    <g transform="translate(459.334358 154.491093) rotate(-90) scale(0.1 -0.1)">
+    <!-- 234 ms -->
+    <g transform="translate(533.028634 153.304146) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 245 ms -->
-    <g transform="translate(533.028634 154.440348) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1452,93 +1472,93 @@ z
    <g id="patch_13">
     <path d="M 244.703939 369.128 
 L 263.127508 369.128 
-L 263.127508 171.248865 
-L 244.703939 171.248865 
+L 263.127508 172.700218 
+L 244.703939 172.700218 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#hdcff39e3c7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: url(#hb6af9cf00b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 318.398215 369.128 
 L 336.821785 369.128 
-L 336.821785 170.997117 
-L 318.398215 170.997117 
+L 336.821785 172.80748 
+L 318.398215 172.80748 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#hdcff39e3c7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: url(#hb6af9cf00b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 392.092492 369.128 
 L 410.516061 369.128 
-L 410.516061 171.363101 
-L 392.092492 171.363101 
+L 410.516061 172.888717 
+L 392.092492 172.888717 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#hdcff39e3c7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: url(#hb6af9cf00b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 465.786768 369.128 
 L 484.210337 369.128 
-L 484.210337 171.765143 
-L 465.786768 171.765143 
+L 484.210337 172.792034 
+L 465.786768 172.792034 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#hdcff39e3c7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: url(#hb6af9cf00b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 539.481044 369.128 
 L 557.904613 369.128 
-L 557.904613 171.521969 
-L 539.481044 171.521969 
+L 557.904613 172.275645 
+L 539.481044 172.275645 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#hdcff39e3c7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: url(#hb6af9cf00b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_27">
+    <!-- 218 ms -->
+    <g transform="translate(256.675099 167.700218) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
    </g>
    <g id="text_28">
-    <!-- 231 ms -->
-    <g transform="translate(256.675099 166.248865) rotate(-90) scale(0.1 -0.1)">
+    <!-- 218 ms -->
+    <g transform="translate(330.369375 167.80748) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 232 ms -->
-    <g transform="translate(330.369375 165.997117) rotate(-90) scale(0.1 -0.1)">
+    <!-- 218 ms -->
+    <g transform="translate(404.063651 167.888717) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 231 ms -->
-    <g transform="translate(404.063651 166.363101) rotate(-90) scale(0.1 -0.1)">
+    <!-- 218 ms -->
+    <g transform="translate(477.757927 167.792034) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 231 ms -->
-    <g transform="translate(477.757927 166.765143) rotate(-90) scale(0.1 -0.1)">
+    <!-- 219 ms -->
+    <g transform="translate(551.452203 167.275645) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 231 ms -->
-    <g transform="translate(551.452203 166.521969) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1547,99 +1567,99 @@ z
    <g id="patch_18">
     <path d="M 263.127508 369.128 
 L 281.551077 369.128 
-L 281.551077 170.097019 
-L 263.127508 170.097019 
+L 281.551077 171.257271 
+L 263.127508 171.257271 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#h9cb0e2d0d1); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: url(#h63cb38eb11); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 336.821785 369.128 
 L 355.245354 369.128 
-L 355.245354 169.591479 
-L 336.821785 169.591479 
+L 355.245354 171.225451 
+L 336.821785 171.225451 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#h9cb0e2d0d1); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: url(#h63cb38eb11); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 410.516061 369.128 
 L 428.93963 369.128 
-L 428.93963 169.701459 
-L 410.516061 169.701459 
+L 428.93963 171.885892 
+L 410.516061 171.885892 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#h9cb0e2d0d1); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: url(#h63cb38eb11); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 484.210337 369.128 
 L 502.633906 369.128 
-L 502.633906 170.20609 
-L 484.210337 170.20609 
+L 502.633906 172.010586 
+L 484.210337 172.010586 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#h9cb0e2d0d1); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: url(#h63cb38eb11); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 557.904613 369.128 
 L 576.328182 369.128 
-L 576.328182 169.787423 
-L 557.904613 169.787423 
+L 576.328182 171.403994 
+L 557.904613 171.403994 
 z
-" clip-path="url(#p3f48b4f835)" style="fill: url(#h9cb0e2d0d1); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pcb29d7d412)" style="fill: url(#h63cb38eb11); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_32">
+    <!-- 220 ms -->
+    <g transform="translate(275.098668 166.257271) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
    </g>
    <g id="text_33">
-    <!-- 233 ms -->
-    <g transform="translate(275.098668 165.097019) rotate(-90) scale(0.1 -0.1)">
+    <!-- 220 ms -->
+    <g transform="translate(348.792944 166.225451) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 233 ms -->
-    <g transform="translate(348.792944 164.591479) rotate(-90) scale(0.1 -0.1)">
+    <!-- 219 ms -->
+    <g transform="translate(422.48722 166.885892) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 233 ms -->
-    <g transform="translate(422.48722 164.701459) rotate(-90) scale(0.1 -0.1)">
+    <!-- 219 ms -->
+    <g transform="translate(496.181496 167.010586) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 232 ms -->
-    <g transform="translate(496.181496 165.20609) rotate(-90) scale(0.1 -0.1)">
+    <!-- 220 ms -->
+    <g transform="translate(569.875772 166.403994) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 233 ms -->
-    <g transform="translate(569.875772 164.787423) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_38">
     <!-- lines simple n=1000 (calculate and render) -->
     <g transform="translate(197.320938 20.88) scale(0.12 -0.12)">
      <defs>
@@ -1743,7 +1763,7 @@ L 419.19375 246.910813
 z
 " style="fill: #eedd88; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_39">
+    <g id="text_38">
      <!-- mpl2005 no mask -->
      <g transform="translate(447.19375 253.910813) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1769,9 +1789,9 @@ L 439.19375 268.588938
 L 439.19375 261.588938 
 L 419.19375 261.588938 
 z
-" style="fill: url(#h79bcc6b9c0); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hbea493fc30); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_40">
+    <g id="text_39">
      <!-- mpl2005 corner_mask=False -->
      <g transform="translate(447.19375 268.588938) scale(0.1 -0.1)">
       <defs>
@@ -1831,7 +1851,7 @@ L 419.19375 276.545187
 z
 " style="fill: #ee8866; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_41">
+    <g id="text_40">
      <!-- mpl2014 no mask -->
      <g transform="translate(447.19375 283.545187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1857,9 +1877,9 @@ L 439.19375 298.223313
 L 439.19375 291.223313 
 L 419.19375 291.223313 
 z
-" style="fill: url(#hdb83627028); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hf8d89cf53f); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_42">
+    <g id="text_41">
      <!-- mpl2014 corner_mask=False -->
      <g transform="translate(447.19375 298.223313) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1895,9 +1915,9 @@ L 439.19375 313.179563
 L 439.19375 306.179563 
 L 419.19375 306.179563 
 z
-" style="fill: url(#hb26b2f2b58); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#haa48990775); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_43">
+    <g id="text_42">
      <!-- mpl2014 corner_mask=True -->
      <g transform="translate(447.19375 313.179563) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-6d"/>
@@ -1934,7 +1954,7 @@ L 419.19375 321.135813
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_44">
+    <g id="text_43">
      <!-- serial no mask -->
      <g transform="translate(447.19375 328.135813) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -1959,9 +1979,9 @@ L 439.19375 342.813938
 L 439.19375 335.813938 
 L 419.19375 335.813938 
 z
-" style="fill: url(#hdcff39e3c7); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#hb6af9cf00b); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_45">
+    <g id="text_44">
      <!-- serial corner_mask=False -->
      <g transform="translate(447.19375 342.813938) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -1996,9 +2016,9 @@ L 439.19375 357.770188
 L 439.19375 350.770188 
 L 419.19375 350.770188 
 z
-" style="fill: url(#h9cb0e2d0d1); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" style="fill: url(#h63cb38eb11); stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_46">
+    <g id="text_45">
      <!-- serial corner_mask=True -->
      <g transform="translate(447.19375 357.770188) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2030,12 +2050,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p3f48b4f835">
+  <clipPath id="pcb29d7d412">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h79bcc6b9c0" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hbea493fc30" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#eedd88"/>
    <path d="M 0 70 
 L 72 70 
@@ -2075,7 +2095,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hdb83627028" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hf8d89cf53f" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M 0 70 
 L 72 70 
@@ -2115,7 +2135,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hb26b2f2b58" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="haa48990775" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#ee8866"/>
    <path d="M -36 36 
 L 36 -36 
@@ -2157,7 +2177,7 @@ M 36 108
 L 108 36 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hdcff39e3c7" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hb6af9cf00b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M 0 70 
 L 72 70 
@@ -2197,7 +2217,7 @@ M 0 2
 L 72 2 
 " style="fill: #222222; stroke: #222222; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h9cb0e2d0d1" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h63cb38eb11" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#77aadd"/>
    <path d="M -36 36 
 L 36 -36 

--- a/docs/_static/threaded_filled_random_dark.svg
+++ b/docs/_static/threaded_filled_random_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:10.632150</dc:date>
+    <dc:date>2024-05-06T19:15:06.149369</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m2a9114b4ad" d="M 0 0 
+       <path id="m5ee7f02426" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2a9114b4ad" x="114.422987" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5ee7f02426" x="114.422987" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -250,7 +250,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m2a9114b4ad" x="199.697792" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5ee7f02426" x="199.697792" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -330,7 +330,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m2a9114b4ad" x="284.972597" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5ee7f02426" x="284.972597" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -490,7 +490,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2a9114b4ad" x="370.247403" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5ee7f02426" x="370.247403" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -527,7 +527,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m2a9114b4ad" x="455.522208" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5ee7f02426" x="455.522208" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -571,7 +571,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2a9114b4ad" x="540.797013" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5ee7f02426" x="540.797013" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -620,16 +620,16 @@ z
      <g id="line2d_7">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#p48edf79a44)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p1121c24646)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="mf4e4c6a40b" d="M 0 0 
+       <path id="m98c681c9f3" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf4e4c6a40b" x="54.02" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m98c681c9f3" x="54.02" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -674,18 +674,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 54.02 326.347 
-L 601.2 326.347 
-" clip-path="url(#p48edf79a44)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 324.095368 
+L 601.2 324.095368 
+" clip-path="url(#p1121c24646)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf4e4c6a40b" x="54.02" y="326.347" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m98c681c9f3" x="54.02" y="324.095368" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.25 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 330.146219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 327.894587) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -746,18 +746,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 54.02 283.566 
-L 601.2 283.566 
-" clip-path="url(#p48edf79a44)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 279.062737 
+L 601.2 279.062737 
+" clip-path="url(#p1121c24646)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mf4e4c6a40b" x="54.02" y="283.566" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m98c681c9f3" x="54.02" y="279.062737" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.50 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 287.365219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 282.861956) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -767,18 +767,18 @@ L 601.2 283.566
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 54.02 240.785 
-L 601.2 240.785 
-" clip-path="url(#p48edf79a44)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 234.030105 
+L 601.2 234.030105 
+" clip-path="url(#p1121c24646)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mf4e4c6a40b" x="54.02" y="240.785" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m98c681c9f3" x="54.02" y="234.030105" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.75 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 244.584219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 237.829324) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -800,18 +800,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 54.02 198.004 
-L 601.2 198.004 
-" clip-path="url(#p48edf79a44)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 188.997474 
+L 601.2 188.997474 
+" clip-path="url(#p1121c24646)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mf4e4c6a40b" x="54.02" y="198.004" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m98c681c9f3" x="54.02" y="188.997474" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.00 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 201.803219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 192.796692) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -837,18 +837,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 54.02 155.223 
-L 601.2 155.223 
-" clip-path="url(#p48edf79a44)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 143.964842 
+L 601.2 143.964842 
+" clip-path="url(#p1121c24646)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf4e4c6a40b" x="54.02" y="155.223" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m98c681c9f3" x="54.02" y="143.964842" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.25 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 159.022219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 147.764061) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -858,18 +858,18 @@ L 601.2 155.223
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 54.02 112.442 
-L 601.2 112.442 
-" clip-path="url(#p48edf79a44)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 98.932211 
+L 601.2 98.932211 
+" clip-path="url(#p1121c24646)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf4e4c6a40b" x="54.02" y="112.442" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m98c681c9f3" x="54.02" y="98.932211" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.50 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 116.241219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 102.731429) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -879,18 +879,18 @@ L 601.2 112.442
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 54.02 69.661 
-L 601.2 69.661 
-" clip-path="url(#p48edf79a44)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 53.899579 
+L 601.2 53.899579 
+" clip-path="url(#p1121c24646)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mf4e4c6a40b" x="54.02" y="69.661" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m98c681c9f3" x="54.02" y="53.899579" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 1.75 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 73.460219) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.754375 57.698798) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-37" x="95.410156"/>
@@ -898,28 +898,7 @@ L 601.2 69.661
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_23">
-      <path d="M 54.02 26.88 
-L 601.2 26.88 
-" clip-path="url(#p48edf79a44)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_24">
-      <g>
-       <use xlink:href="#mf4e4c6a40b" x="54.02" y="26.88" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 2.00 -->
-      <g style="fill: #ffffff" transform="translate(24.754375 30.679219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_16">
+    <g id="text_15">
      <!-- Time (seconds) -->
      <g style="fill: #ffffff" transform="translate(18.674688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1023,65 +1002,54 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 78.891818 369.128 
 L 93.104286 369.128 
-L 93.104286 74.470274 
-L 78.891818 74.470274 
+L 93.104286 69.853128 
+L 78.891818 69.853128 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 164.166623 369.128 
 L 178.379091 369.128 
-L 178.379091 81.493207 
-L 164.166623 81.493207 
+L 178.379091 73.416381 
+L 164.166623 73.416381 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 249.441429 369.128 
 L 263.653896 369.128 
-L 263.653896 200.140133 
-L 249.441429 200.140133 
+L 263.653896 201.469355 
+L 249.441429 201.469355 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 334.716234 369.128 
 L 348.928701 369.128 
-L 348.928701 200.625341 
-L 334.716234 200.625341 
+L 348.928701 200.550826 
+L 334.716234 200.550826 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 419.991039 369.128 
 L 434.203506 369.128 
-L 434.203506 191.469542 
-L 419.991039 191.469542 
+L 434.203506 197.485792 
+L 419.991039 197.485792 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 505.265844 369.128 
 L 519.478312 369.128 
-L 519.478312 192.264054 
-L 505.265844 192.264054 
+L 519.478312 196.639928 
+L 505.265844 196.639928 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_17">
-    <!-- 1.72 s -->
-    <g style="fill: #ffffff" transform="translate(88.757427 69.470274) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 1.68 s -->
-    <g style="fill: #ffffff" transform="translate(174.032232 76.493207) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_16">
+    <!-- 1.66 s -->
+    <g style="fill: #ffffff" transform="translate(88.757427 64.853128) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1113,6 +1081,148 @@ Q 2619 4750 2861 4703
 Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 1.64 s -->
+    <g style="fill: #ffffff" transform="translate(174.032232 68.416381) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 931 ms -->
+    <g style="fill: #ffffff" transform="translate(259.307037 196.469355) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 936 ms -->
+    <g style="fill: #ffffff" transform="translate(344.581843 195.550826) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 953 ms -->
+    <g style="fill: #ffffff" transform="translate(429.856648 192.485792) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 958 ms -->
+    <g style="fill: #ffffff" transform="translate(515.131453 191.639928) rotate(-90) scale(0.1 -0.1)">
+     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1153,351 +1263,220 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 988 ms -->
-    <g style="fill: #ffffff" transform="translate(259.307037 195.140133) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_20">
-    <!-- 985 ms -->
-    <g style="fill: #ffffff" transform="translate(344.581843 195.625341) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 1.04 s -->
-    <g style="fill: #ffffff" transform="translate(429.856648 186.469542) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 1.03 s -->
-    <g style="fill: #ffffff" transform="translate(515.131453 187.264054) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
    <g id="patch_13">
     <path d="M 93.104286 369.128 
 L 107.316753 369.128 
-L 107.316753 70.391101 
-L 93.104286 70.391101 
+L 107.316753 68.184944 
+L 93.104286 68.184944 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 107.316753 369.128 
 L 121.529221 369.128 
-L 121.529221 187.40138 
-L 107.316753 187.40138 
+L 121.529221 179.908071 
+L 107.316753 179.908071 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 121.529221 369.128 
 L 135.741688 369.128 
-L 135.741688 221.928875 
-L 121.529221 221.928875 
+L 135.741688 207.056525 
+L 121.529221 207.056525 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 135.741688 369.128 
 L 149.954156 369.128 
-L 149.954156 228.045305 
-L 135.741688 228.045305 
+L 149.954156 211.504172 
+L 135.741688 211.504172 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 178.379091 369.128 
 L 192.591558 369.128 
-L 192.591558 77.84371 
-L 178.379091 77.84371 
+L 192.591558 71.854023 
+L 178.379091 71.854023 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 192.591558 369.128 
 L 206.804026 369.128 
-L 206.804026 192.863446 
-L 192.591558 192.863446 
+L 206.804026 183.096734 
+L 192.591558 183.096734 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 206.804026 369.128 
 L 221.016494 369.128 
-L 221.016494 224.481683 
-L 206.804026 224.481683 
+L 221.016494 209.756026 
+L 206.804026 209.756026 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 221.016494 369.128 
 L 235.228961 369.128 
-L 235.228961 229.604912 
-L 221.016494 229.604912 
+L 235.228961 214.73 
+L 221.016494 214.73 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 263.653896 369.128 
 L 277.866364 369.128 
-L 277.866364 199.012129 
-L 263.653896 199.012129 
+L 277.866364 200.173065 
+L 263.653896 200.173065 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 277.866364 369.128 
 L 292.078831 369.128 
-L 292.078831 280.56539 
-L 277.866364 280.56539 
+L 292.078831 281.108689 
+L 277.866364 281.108689 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 292.078831 369.128 
 L 306.291299 369.128 
-L 306.291299 324.564598 
-L 292.078831 324.564598 
+L 306.291299 321.302726 
+L 292.078831 321.302726 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 306.291299 369.128 
 L 320.503766 369.128 
-L 320.503766 336.211644 
-L 306.291299 336.211644 
+L 320.503766 332.44108 
+L 306.291299 332.44108 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 348.928701 369.128 
 L 363.141169 369.128 
-L 363.141169 199.442816 
-L 348.928701 199.442816 
+L 363.141169 199.978061 
+L 348.928701 199.978061 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 363.141169 369.128 
 L 377.353636 369.128 
-L 377.353636 284.240205 
-L 363.141169 284.240205 
+L 377.353636 284.632194 
+L 363.141169 284.632194 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 377.353636 369.128 
 L 391.566104 369.128 
-L 391.566104 324.689758 
-L 377.353636 324.689758 
+L 391.566104 323.242912 
+L 377.353636 323.242912 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 391.566104 369.128 
 L 405.778571 369.128 
-L 405.778571 336.329903 
-L 391.566104 336.329903 
+L 405.778571 336.814598 
+L 391.566104 336.814598 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 434.203506 369.128 
 L 448.415974 369.128 
-L 448.415974 192.18236 
-L 434.203506 192.18236 
+L 448.415974 200.358959 
+L 434.203506 200.358959 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 448.415974 369.128 
 L 462.628442 369.128 
-L 462.628442 277.735518 
-L 448.415974 277.735518 
+L 462.628442 281.62605 
+L 448.415974 281.62605 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 462.628442 369.128 
 L 476.840909 369.128 
-L 476.840909 323.131613 
-L 462.628442 323.131613 
+L 476.840909 322.155543 
+L 462.628442 322.155543 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 476.840909 369.128 
 L 491.053377 369.128 
-L 491.053377 335.13719 
-L 476.840909 335.13719 
+L 491.053377 335.778681 
+L 476.840909 335.778681 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 519.478312 369.128 
 L 533.690779 369.128 
-L 533.690779 193.313499 
-L 519.478312 193.313499 
+L 533.690779 194.566482 
+L 519.478312 194.566482 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 533.690779 369.128 
 L 547.903247 369.128 
-L 547.903247 281.489662 
-L 533.690779 281.489662 
+L 547.903247 281.565323 
+L 533.690779 281.565323 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 547.903247 369.128 
 L 562.115714 369.128 
-L 562.115714 323.260058 
-L 547.903247 323.260058 
+L 562.115714 320.843494 
+L 547.903247 320.843494 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 562.115714 369.128 
 L 576.328182 369.128 
-L 576.328182 335.331437 
-L 562.115714 335.331437 
+L 576.328182 334.023526 
+L 562.115714 334.023526 
 z
-" clip-path="url(#p48edf79a44)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p1121c24646)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_23">
-    <!-- 1.75 s -->
-    <g style="fill: #ffffff" transform="translate(102.969894 65.391101) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_22">
+    <!-- 1.67 s -->
+    <g style="fill: #ffffff" transform="translate(102.969894 63.184944) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- 1.06 s (x 1.62) -->
-    <g style="fill: #ffffff" transform="translate(117.182362 182.40138) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_23">
+    <!-- 1.05 s (x 1.58) -->
+    <g style="fill: #ffffff" transform="translate(117.182362 174.908071) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
@@ -1518,7 +1497,7 @@ z
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
      <use xlink:href="#DejaVuSans-20" x="306.542969"/>
@@ -1527,17 +1506,210 @@ z
      <use xlink:href="#DejaVuSans-20" x="436.523438"/>
      <use xlink:href="#DejaVuSans-31" x="468.310547"/>
      <use xlink:href="#DejaVuSans-2e" x="531.933594"/>
-     <use xlink:href="#DejaVuSans-36" x="563.720703"/>
-     <use xlink:href="#DejaVuSans-32" x="627.34375"/>
+     <use xlink:href="#DejaVuSans-35" x="563.720703"/>
+     <use xlink:href="#DejaVuSans-38" x="627.34375"/>
      <use xlink:href="#DejaVuSans-29" x="690.966797"/>
     </g>
    </g>
-   <g id="text_25">
-    <!-- 860 ms (x 2.00) -->
-    <g style="fill: #ffffff" transform="translate(131.39483 216.928875) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+   <g id="text_24">
+    <!-- 900 ms (x 1.85) -->
+    <g style="fill: #ffffff" transform="translate(131.39483 202.056525) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 875 ms (x 1.90) -->
+    <g style="fill: #ffffff" transform="translate(145.607297 206.504172) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-30" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 1.65 s -->
+    <g style="fill: #ffffff" transform="translate(188.2447 66.854023) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- 1.03 s (x 1.59) -->
+    <g style="fill: #ffffff" transform="translate(202.457167 178.096734) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-20" x="306.542969"/>
+     <use xlink:href="#DejaVuSans-28" x="338.330078"/>
+     <use xlink:href="#DejaVuSans-78" x="377.34375"/>
+     <use xlink:href="#DejaVuSans-20" x="436.523438"/>
+     <use xlink:href="#DejaVuSans-31" x="468.310547"/>
+     <use xlink:href="#DejaVuSans-2e" x="531.933594"/>
+     <use xlink:href="#DejaVuSans-35" x="563.720703"/>
+     <use xlink:href="#DejaVuSans-39" x="627.34375"/>
+     <use xlink:href="#DejaVuSans-29" x="690.966797"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 885 ms (x 1.86) -->
+    <g style="fill: #ffffff" transform="translate(216.669635 204.756026) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 857 ms (x 1.92) -->
+    <g style="fill: #ffffff" transform="translate(230.882102 209.73) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 938 ms -->
+    <g style="fill: #ffffff" transform="translate(273.519505 195.173065) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 489 ms (x 1.90) -->
+    <g style="fill: #ffffff" transform="translate(287.731972 276.108689) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-30" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 266 ms (x 3.51) -->
+    <g style="fill: #ffffff" transform="translate(301.94444 316.302726) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-33" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-35" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- 204 ms (x 4.57) -->
+    <g style="fill: #ffffff" transform="translate(316.156907 327.44108) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-34" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-35" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 939 ms -->
+    <g style="fill: #ffffff" transform="translate(358.79431 194.978061) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 469 ms (x 2.00) -->
+    <g style="fill: #ffffff" transform="translate(373.006778 279.632194) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1552,134 +1724,12 @@ z
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- 824 ms (x 2.09) -->
-    <g style="fill: #ffffff" transform="translate(145.607297 223.045305) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-32" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 1.70 s -->
-    <g style="fill: #ffffff" transform="translate(188.2447 72.84371) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 1.03 s (x 1.63) -->
-    <g style="fill: #ffffff" transform="translate(202.457167 187.863446) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-20" x="306.542969"/>
-     <use xlink:href="#DejaVuSans-28" x="338.330078"/>
-     <use xlink:href="#DejaVuSans-78" x="377.34375"/>
-     <use xlink:href="#DejaVuSans-20" x="436.523438"/>
-     <use xlink:href="#DejaVuSans-31" x="468.310547"/>
-     <use xlink:href="#DejaVuSans-2e" x="531.933594"/>
-     <use xlink:href="#DejaVuSans-36" x="563.720703"/>
-     <use xlink:href="#DejaVuSans-33" x="627.34375"/>
-     <use xlink:href="#DejaVuSans-29" x="690.966797"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 845 ms (x 1.99) -->
-    <g style="fill: #ffffff" transform="translate(216.669635 219.481683) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 815 ms (x 2.06) -->
-    <g style="fill: #ffffff" transform="translate(230.882102 224.604912) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-32" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 994 ms -->
-    <g style="fill: #ffffff" transform="translate(273.519505 194.012129) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 518 ms (x 1.91) -->
-    <g style="fill: #ffffff" transform="translate(287.731972 275.56539) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- 260 ms (x 3.79) -->
-    <g style="fill: #ffffff" transform="translate(301.94444 319.564598) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_36">
+    <!-- 255 ms (x 3.67) -->
+    <g style="fill: #ffffff" transform="translate(387.219245 318.242912) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1689,17 +1739,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-37" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-36" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_34">
-    <!-- 192 ms (x 5.13) -->
-    <g style="fill: #ffffff" transform="translate(316.156907 331.211644) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_37">
+    <!-- 179 ms (x 5.22) -->
+    <g style="fill: #ffffff" transform="translate(401.431713 331.814598) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1709,27 +1759,27 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-35" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-31" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_35">
-    <!-- 992 ms -->
-    <g style="fill: #ffffff" transform="translate(358.79431 194.442816) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_38">
+    <!-- 937 ms -->
+    <g style="fill: #ffffff" transform="translate(444.069115 195.358959) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_36">
-    <!-- 496 ms (x 1.99) -->
-    <g style="fill: #ffffff" transform="translate(373.006778 279.240205) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_39">
+    <!-- 486 ms (x 1.96) -->
+    <g style="fill: #ffffff" transform="translate(458.281583 276.62605) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1741,16 +1791,16 @@ z
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_37">
-    <!-- 260 ms (x 3.79) -->
-    <g style="fill: #ffffff" transform="translate(387.219245 319.689758) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_40">
+    <!-- 261 ms (x 3.65) -->
+    <g style="fill: #ffffff" transform="translate(472.49405 317.155543) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1760,17 +1810,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-37" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-36" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_38">
-    <!-- 192 ms (x 5.14) -->
-    <g style="fill: #ffffff" transform="translate(401.431713 331.329903) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_41">
+    <!-- 185 ms (x 5.15) -->
+    <g style="fill: #ffffff" transform="translate(486.706518 330.778681) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1781,27 +1831,27 @@ z
      <use xlink:href="#DejaVuSans-35" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-31" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-35" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_39">
-    <!-- 1.03 s -->
-    <g style="fill: #ffffff" transform="translate(444.069115 187.18236) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+   <g id="text_42">
+    <!-- 969 ms -->
+    <g style="fill: #ffffff" transform="translate(529.34392 189.566482) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_40">
-    <!-- 534 ms (x 1.94) -->
-    <g style="fill: #ffffff" transform="translate(458.281583 272.735518) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+   <g id="text_43">
+    <!-- 486 ms (x 1.97) -->
+    <g style="fill: #ffffff" transform="translate(543.556388 276.565323) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1812,84 +1862,13 @@ z
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_41">
-    <!-- 269 ms (x 3.86) -->
-    <g style="fill: #ffffff" transform="translate(472.49405 318.131613) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-33" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_42">
-    <!-- 199 ms (x 5.23) -->
-    <g style="fill: #ffffff" transform="translate(486.706518 330.13719) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-35" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- 1.03 s -->
-    <g style="fill: #ffffff" transform="translate(529.34392 188.313499) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- 512 ms (x 2.02) -->
-    <g style="fill: #ffffff" transform="translate(543.556388 276.489662) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-32" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_45">
-    <!-- 268 ms (x 3.86) -->
-    <g style="fill: #ffffff" transform="translate(557.768856 318.260058) rotate(-90) scale(0.1 -0.1)">
+    <!-- 268 ms (x 3.57) -->
+    <g style="fill: #ffffff" transform="translate(557.768856 315.843494) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
@@ -1902,17 +1881,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-35" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_46">
-    <!-- 197 ms (x 5.23) -->
-    <g style="fill: #ffffff" transform="translate(571.981323 330.331437) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_45">
+    <!-- 195 ms (x 4.91) -->
+    <g style="fill: #ffffff" transform="translate(571.981323 329.023526) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1920,182 +1899,182 @@ z
      <use xlink:href="#DejaVuSans-28" x="403.955078"/>
      <use xlink:href="#DejaVuSans-78" x="442.96875"/>
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-35" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-34" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_47">
+   <g id="text_46">
     <!--  1 -->
     <g transform="translate(95.440207 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_48">
+   <g id="text_47">
     <!--  2 -->
     <g transform="translate(109.652675 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_49">
+   <g id="text_48">
     <!--  4 -->
     <g transform="translate(123.865142 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_50">
+   <g id="text_49">
     <!--  6 -->
     <g transform="translate(138.07761 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_51">
+   <g id="text_50">
     <!--  1 -->
     <g transform="translate(180.715012 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_52">
+   <g id="text_51">
     <!--  2 -->
     <g transform="translate(194.92748 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_53">
+   <g id="text_52">
     <!--  4 -->
     <g transform="translate(209.139947 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_54">
+   <g id="text_53">
     <!--  6 -->
     <g transform="translate(223.352415 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_55">
+   <g id="text_54">
     <!--  1 -->
     <g transform="translate(265.989817 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_56">
+   <g id="text_55">
     <!--  2 -->
     <g transform="translate(280.202285 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_57">
+   <g id="text_56">
     <!--  4 -->
     <g transform="translate(294.414752 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_58">
+   <g id="text_57">
     <!--  6 -->
     <g transform="translate(308.62722 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_59">
+   <g id="text_58">
     <!--  1 -->
     <g transform="translate(351.264623 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_60">
+   <g id="text_59">
     <!--  2 -->
     <g transform="translate(365.47709 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_61">
+   <g id="text_60">
     <!--  4 -->
     <g transform="translate(379.689558 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_62">
+   <g id="text_61">
     <!--  6 -->
     <g transform="translate(393.902025 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_63">
+   <g id="text_62">
     <!--  1 -->
     <g transform="translate(436.539428 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_64">
+   <g id="text_63">
     <!--  2 -->
     <g transform="translate(450.751895 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_65">
+   <g id="text_64">
     <!--  4 -->
     <g transform="translate(464.964363 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_66">
+   <g id="text_65">
     <!--  6 -->
     <g transform="translate(479.17683 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_67">
+   <g id="text_66">
     <!--  1 -->
     <g transform="translate(521.814233 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_68">
+   <g id="text_67">
     <!--  2 -->
     <g transform="translate(536.0267 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_69">
+   <g id="text_68">
     <!--  4 -->
     <g transform="translate(550.239168 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_70">
+   <g id="text_69">
     <!--  6 -->
     <g transform="translate(564.451636 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_71">
+   <g id="text_70">
     <!-- filled random n=1000 -->
     <g style="fill: #ffffff" transform="translate(261.811563 20.88) scale(0.12 -0.12)">
      <defs>
@@ -2197,7 +2176,7 @@ L 371.71875 36.478437
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_72">
+    <g id="text_71">
      <!-- serial no mask -->
      <g style="fill: #ffffff" transform="translate(399.71875 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2224,7 +2203,7 @@ L 371.71875 57.795312
 z
 " style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_73">
+    <g id="text_72">
      <!-- threaded no mask -->
      <g style="fill: #ffffff" transform="translate(399.71875 58.156562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-74"/>
@@ -2307,7 +2286,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p48edf79a44">
+  <clipPath id="p1121c24646">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>

--- a/docs/_static/threaded_filled_random_light.svg
+++ b/docs/_static/threaded_filled_random_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:10.420481</dc:date>
+    <dc:date>2024-05-06T19:15:05.923813</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m4a01393ce5" d="M 0 0 
+       <path id="m6265de522f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4a01393ce5" x="114.422987" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6265de522f" x="114.422987" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -250,7 +250,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m4a01393ce5" x="199.697792" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6265de522f" x="199.697792" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -330,7 +330,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m4a01393ce5" x="284.972597" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6265de522f" x="284.972597" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -490,7 +490,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4a01393ce5" x="370.247403" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6265de522f" x="370.247403" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -527,7 +527,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m4a01393ce5" x="455.522208" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6265de522f" x="455.522208" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -571,7 +571,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4a01393ce5" x="540.797013" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6265de522f" x="540.797013" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -620,16 +620,16 @@ z
      <g id="line2d_7">
       <path d="M 54.02 369.128 
 L 601.2 369.128 
-" clip-path="url(#pa4ffb5d320)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2f38490991)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="m310a16d11f" d="M 0 0 
+       <path id="m1cbc3e5f04" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m310a16d11f" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cbc3e5f04" x="54.02" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -674,18 +674,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 54.02 326.347 
-L 601.2 326.347 
-" clip-path="url(#pa4ffb5d320)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 324.095368 
+L 601.2 324.095368 
+" clip-path="url(#p2f38490991)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m310a16d11f" x="54.02" y="326.347" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cbc3e5f04" x="54.02" y="324.095368" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.25 -->
-      <g transform="translate(24.754375 330.146219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 327.894587) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -746,18 +746,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 54.02 283.566 
-L 601.2 283.566 
-" clip-path="url(#pa4ffb5d320)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 279.062737 
+L 601.2 279.062737 
+" clip-path="url(#p2f38490991)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m310a16d11f" x="54.02" y="283.566" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cbc3e5f04" x="54.02" y="279.062737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.50 -->
-      <g transform="translate(24.754375 287.365219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 282.861956) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -767,18 +767,18 @@ L 601.2 283.566
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 54.02 240.785 
-L 601.2 240.785 
-" clip-path="url(#pa4ffb5d320)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 234.030105 
+L 601.2 234.030105 
+" clip-path="url(#p2f38490991)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m310a16d11f" x="54.02" y="240.785" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cbc3e5f04" x="54.02" y="234.030105" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.75 -->
-      <g transform="translate(24.754375 244.584219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 237.829324) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -800,18 +800,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 54.02 198.004 
-L 601.2 198.004 
-" clip-path="url(#pa4ffb5d320)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 188.997474 
+L 601.2 188.997474 
+" clip-path="url(#p2f38490991)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m310a16d11f" x="54.02" y="198.004" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cbc3e5f04" x="54.02" y="188.997474" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.00 -->
-      <g transform="translate(24.754375 201.803219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 192.796692) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -837,18 +837,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 54.02 155.223 
-L 601.2 155.223 
-" clip-path="url(#pa4ffb5d320)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 143.964842 
+L 601.2 143.964842 
+" clip-path="url(#p2f38490991)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m310a16d11f" x="54.02" y="155.223" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cbc3e5f04" x="54.02" y="143.964842" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.25 -->
-      <g transform="translate(24.754375 159.022219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 147.764061) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -858,18 +858,18 @@ L 601.2 155.223
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 54.02 112.442 
-L 601.2 112.442 
-" clip-path="url(#pa4ffb5d320)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 98.932211 
+L 601.2 98.932211 
+" clip-path="url(#p2f38490991)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m310a16d11f" x="54.02" y="112.442" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cbc3e5f04" x="54.02" y="98.932211" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.50 -->
-      <g transform="translate(24.754375 116.241219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 102.731429) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-35" x="95.410156"/>
@@ -879,18 +879,18 @@ L 601.2 112.442
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 54.02 69.661 
-L 601.2 69.661 
-" clip-path="url(#pa4ffb5d320)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.02 53.899579 
+L 601.2 53.899579 
+" clip-path="url(#p2f38490991)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m310a16d11f" x="54.02" y="69.661" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cbc3e5f04" x="54.02" y="53.899579" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 1.75 -->
-      <g transform="translate(24.754375 73.460219) scale(0.1 -0.1)">
+      <g transform="translate(24.754375 57.698798) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-37" x="95.410156"/>
@@ -898,28 +898,7 @@ L 601.2 69.661
       </g>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_23">
-      <path d="M 54.02 26.88 
-L 601.2 26.88 
-" clip-path="url(#pa4ffb5d320)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_24">
-      <g>
-       <use xlink:href="#m310a16d11f" x="54.02" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_15">
-      <!-- 2.00 -->
-      <g transform="translate(24.754375 30.679219) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_16">
+    <g id="text_15">
      <!-- Time (seconds) -->
      <g transform="translate(18.674688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1023,65 +1002,54 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 78.891818 369.128 
 L 93.104286 369.128 
-L 93.104286 74.470274 
-L 78.891818 74.470274 
+L 93.104286 69.853128 
+L 78.891818 69.853128 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 164.166623 369.128 
 L 178.379091 369.128 
-L 178.379091 81.493207 
-L 164.166623 81.493207 
+L 178.379091 73.416381 
+L 164.166623 73.416381 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 249.441429 369.128 
 L 263.653896 369.128 
-L 263.653896 200.140133 
-L 249.441429 200.140133 
+L 263.653896 201.469355 
+L 249.441429 201.469355 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 334.716234 369.128 
 L 348.928701 369.128 
-L 348.928701 200.625341 
-L 334.716234 200.625341 
+L 348.928701 200.550826 
+L 334.716234 200.550826 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 419.991039 369.128 
 L 434.203506 369.128 
-L 434.203506 191.469542 
-L 419.991039 191.469542 
+L 434.203506 197.485792 
+L 419.991039 197.485792 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 505.265844 369.128 
 L 519.478312 369.128 
-L 519.478312 192.264054 
-L 505.265844 192.264054 
+L 519.478312 196.639928 
+L 505.265844 196.639928 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_17">
-    <!-- 1.72 s -->
-    <g transform="translate(88.757427 69.470274) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 1.68 s -->
-    <g transform="translate(174.032232 76.493207) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_16">
+    <!-- 1.66 s -->
+    <g transform="translate(88.757427 64.853128) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1113,6 +1081,148 @@ Q 2619 4750 2861 4703
 Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 1.64 s -->
+    <g transform="translate(174.032232 68.416381) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 931 ms -->
+    <g transform="translate(259.307037 196.469355) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 936 ms -->
+    <g transform="translate(344.581843 195.550826) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 953 ms -->
+    <g transform="translate(429.856648 192.485792) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 958 ms -->
+    <g transform="translate(515.131453 191.639928) rotate(-90) scale(0.1 -0.1)">
+     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1153,351 +1263,220 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 988 ms -->
-    <g transform="translate(259.307037 195.140133) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_20">
-    <!-- 985 ms -->
-    <g transform="translate(344.581843 195.625341) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 1.04 s -->
-    <g transform="translate(429.856648 186.469542) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 1.03 s -->
-    <g transform="translate(515.131453 187.264054) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
    <g id="patch_13">
     <path d="M 93.104286 369.128 
 L 107.316753 369.128 
-L 107.316753 70.391101 
-L 93.104286 70.391101 
+L 107.316753 68.184944 
+L 93.104286 68.184944 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 107.316753 369.128 
 L 121.529221 369.128 
-L 121.529221 187.40138 
-L 107.316753 187.40138 
+L 121.529221 179.908071 
+L 107.316753 179.908071 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 121.529221 369.128 
 L 135.741688 369.128 
-L 135.741688 221.928875 
-L 121.529221 221.928875 
+L 135.741688 207.056525 
+L 121.529221 207.056525 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 135.741688 369.128 
 L 149.954156 369.128 
-L 149.954156 228.045305 
-L 135.741688 228.045305 
+L 149.954156 211.504172 
+L 135.741688 211.504172 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 178.379091 369.128 
 L 192.591558 369.128 
-L 192.591558 77.84371 
-L 178.379091 77.84371 
+L 192.591558 71.854023 
+L 178.379091 71.854023 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 192.591558 369.128 
 L 206.804026 369.128 
-L 206.804026 192.863446 
-L 192.591558 192.863446 
+L 206.804026 183.096734 
+L 192.591558 183.096734 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 206.804026 369.128 
 L 221.016494 369.128 
-L 221.016494 224.481683 
-L 206.804026 224.481683 
+L 221.016494 209.756026 
+L 206.804026 209.756026 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 221.016494 369.128 
 L 235.228961 369.128 
-L 235.228961 229.604912 
-L 221.016494 229.604912 
+L 235.228961 214.73 
+L 221.016494 214.73 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 263.653896 369.128 
 L 277.866364 369.128 
-L 277.866364 199.012129 
-L 263.653896 199.012129 
+L 277.866364 200.173065 
+L 263.653896 200.173065 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 277.866364 369.128 
 L 292.078831 369.128 
-L 292.078831 280.56539 
-L 277.866364 280.56539 
+L 292.078831 281.108689 
+L 277.866364 281.108689 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 292.078831 369.128 
 L 306.291299 369.128 
-L 306.291299 324.564598 
-L 292.078831 324.564598 
+L 306.291299 321.302726 
+L 292.078831 321.302726 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 306.291299 369.128 
 L 320.503766 369.128 
-L 320.503766 336.211644 
-L 306.291299 336.211644 
+L 320.503766 332.44108 
+L 306.291299 332.44108 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 348.928701 369.128 
 L 363.141169 369.128 
-L 363.141169 199.442816 
-L 348.928701 199.442816 
+L 363.141169 199.978061 
+L 348.928701 199.978061 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 363.141169 369.128 
 L 377.353636 369.128 
-L 377.353636 284.240205 
-L 363.141169 284.240205 
+L 377.353636 284.632194 
+L 363.141169 284.632194 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 377.353636 369.128 
 L 391.566104 369.128 
-L 391.566104 324.689758 
-L 377.353636 324.689758 
+L 391.566104 323.242912 
+L 377.353636 323.242912 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 391.566104 369.128 
 L 405.778571 369.128 
-L 405.778571 336.329903 
-L 391.566104 336.329903 
+L 405.778571 336.814598 
+L 391.566104 336.814598 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 434.203506 369.128 
 L 448.415974 369.128 
-L 448.415974 192.18236 
-L 434.203506 192.18236 
+L 448.415974 200.358959 
+L 434.203506 200.358959 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 448.415974 369.128 
 L 462.628442 369.128 
-L 462.628442 277.735518 
-L 448.415974 277.735518 
+L 462.628442 281.62605 
+L 448.415974 281.62605 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 462.628442 369.128 
 L 476.840909 369.128 
-L 476.840909 323.131613 
-L 462.628442 323.131613 
+L 476.840909 322.155543 
+L 462.628442 322.155543 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 476.840909 369.128 
 L 491.053377 369.128 
-L 491.053377 335.13719 
-L 476.840909 335.13719 
+L 491.053377 335.778681 
+L 476.840909 335.778681 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 519.478312 369.128 
 L 533.690779 369.128 
-L 533.690779 193.313499 
-L 519.478312 193.313499 
+L 533.690779 194.566482 
+L 519.478312 194.566482 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 533.690779 369.128 
 L 547.903247 369.128 
-L 547.903247 281.489662 
-L 533.690779 281.489662 
+L 547.903247 281.565323 
+L 533.690779 281.565323 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 547.903247 369.128 
 L 562.115714 369.128 
-L 562.115714 323.260058 
-L 547.903247 323.260058 
+L 562.115714 320.843494 
+L 547.903247 320.843494 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 562.115714 369.128 
 L 576.328182 369.128 
-L 576.328182 335.331437 
-L 562.115714 335.331437 
+L 576.328182 334.023526 
+L 562.115714 334.023526 
 z
-" clip-path="url(#pa4ffb5d320)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f38490991)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_23">
-    <!-- 1.75 s -->
-    <g transform="translate(102.969894 65.391101) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_22">
+    <!-- 1.67 s -->
+    <g transform="translate(102.969894 63.184944) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- 1.06 s (x 1.62) -->
-    <g transform="translate(117.182362 182.40138) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_23">
+    <!-- 1.05 s (x 1.58) -->
+    <g transform="translate(117.182362 174.908071) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
@@ -1518,7 +1497,7 @@ z
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
      <use xlink:href="#DejaVuSans-20" x="306.542969"/>
@@ -1527,17 +1506,210 @@ z
      <use xlink:href="#DejaVuSans-20" x="436.523438"/>
      <use xlink:href="#DejaVuSans-31" x="468.310547"/>
      <use xlink:href="#DejaVuSans-2e" x="531.933594"/>
-     <use xlink:href="#DejaVuSans-36" x="563.720703"/>
-     <use xlink:href="#DejaVuSans-32" x="627.34375"/>
+     <use xlink:href="#DejaVuSans-35" x="563.720703"/>
+     <use xlink:href="#DejaVuSans-38" x="627.34375"/>
      <use xlink:href="#DejaVuSans-29" x="690.966797"/>
     </g>
    </g>
-   <g id="text_25">
-    <!-- 860 ms (x 2.00) -->
-    <g transform="translate(131.39483 216.928875) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+   <g id="text_24">
+    <!-- 900 ms (x 1.85) -->
+    <g transform="translate(131.39483 202.056525) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 875 ms (x 1.90) -->
+    <g transform="translate(145.607297 206.504172) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-30" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 1.65 s -->
+    <g transform="translate(188.2447 66.854023) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- 1.03 s (x 1.59) -->
+    <g transform="translate(202.457167 178.096734) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-20" x="306.542969"/>
+     <use xlink:href="#DejaVuSans-28" x="338.330078"/>
+     <use xlink:href="#DejaVuSans-78" x="377.34375"/>
+     <use xlink:href="#DejaVuSans-20" x="436.523438"/>
+     <use xlink:href="#DejaVuSans-31" x="468.310547"/>
+     <use xlink:href="#DejaVuSans-2e" x="531.933594"/>
+     <use xlink:href="#DejaVuSans-35" x="563.720703"/>
+     <use xlink:href="#DejaVuSans-39" x="627.34375"/>
+     <use xlink:href="#DejaVuSans-29" x="690.966797"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 885 ms (x 1.86) -->
+    <g transform="translate(216.669635 204.756026) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 857 ms (x 1.92) -->
+    <g transform="translate(230.882102 209.73) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 938 ms -->
+    <g transform="translate(273.519505 195.173065) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 489 ms (x 1.90) -->
+    <g transform="translate(287.731972 276.108689) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-30" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 266 ms (x 3.51) -->
+    <g transform="translate(301.94444 316.302726) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-33" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-35" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- 204 ms (x 4.57) -->
+    <g transform="translate(316.156907 327.44108) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-34" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-35" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 939 ms -->
+    <g transform="translate(358.79431 194.978061) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 469 ms (x 2.00) -->
+    <g transform="translate(373.006778 279.632194) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1552,134 +1724,12 @@ z
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- 824 ms (x 2.09) -->
-    <g transform="translate(145.607297 223.045305) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-32" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 1.70 s -->
-    <g transform="translate(188.2447 72.84371) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 1.03 s (x 1.63) -->
-    <g transform="translate(202.457167 187.863446) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-20" x="306.542969"/>
-     <use xlink:href="#DejaVuSans-28" x="338.330078"/>
-     <use xlink:href="#DejaVuSans-78" x="377.34375"/>
-     <use xlink:href="#DejaVuSans-20" x="436.523438"/>
-     <use xlink:href="#DejaVuSans-31" x="468.310547"/>
-     <use xlink:href="#DejaVuSans-2e" x="531.933594"/>
-     <use xlink:href="#DejaVuSans-36" x="563.720703"/>
-     <use xlink:href="#DejaVuSans-33" x="627.34375"/>
-     <use xlink:href="#DejaVuSans-29" x="690.966797"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 845 ms (x 1.99) -->
-    <g transform="translate(216.669635 219.481683) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 815 ms (x 2.06) -->
-    <g transform="translate(230.882102 224.604912) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-32" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 994 ms -->
-    <g transform="translate(273.519505 194.012129) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 518 ms (x 1.91) -->
-    <g transform="translate(287.731972 275.56539) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- 260 ms (x 3.79) -->
-    <g transform="translate(301.94444 319.564598) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_36">
+    <!-- 255 ms (x 3.67) -->
+    <g transform="translate(387.219245 318.242912) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1689,17 +1739,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-37" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-36" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_34">
-    <!-- 192 ms (x 5.13) -->
-    <g transform="translate(316.156907 331.211644) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_37">
+    <!-- 179 ms (x 5.22) -->
+    <g transform="translate(401.431713 331.814598) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1709,27 +1759,27 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-35" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-31" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_35">
-    <!-- 992 ms -->
-    <g transform="translate(358.79431 194.442816) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_38">
+    <!-- 937 ms -->
+    <g transform="translate(444.069115 195.358959) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_36">
-    <!-- 496 ms (x 1.99) -->
-    <g transform="translate(373.006778 279.240205) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_39">
+    <!-- 486 ms (x 1.96) -->
+    <g transform="translate(458.281583 276.62605) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1741,16 +1791,16 @@ z
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_37">
-    <!-- 260 ms (x 3.79) -->
-    <g transform="translate(387.219245 319.689758) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_40">
+    <!-- 261 ms (x 3.65) -->
+    <g transform="translate(472.49405 317.155543) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1760,17 +1810,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-37" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-36" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_38">
-    <!-- 192 ms (x 5.14) -->
-    <g transform="translate(401.431713 331.329903) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_41">
+    <!-- 185 ms (x 5.15) -->
+    <g transform="translate(486.706518 330.778681) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1781,27 +1831,27 @@ z
      <use xlink:href="#DejaVuSans-35" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-31" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-35" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_39">
-    <!-- 1.03 s -->
-    <g transform="translate(444.069115 187.18236) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+   <g id="text_42">
+    <!-- 969 ms -->
+    <g transform="translate(529.34392 189.566482) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_40">
-    <!-- 534 ms (x 1.94) -->
-    <g transform="translate(458.281583 272.735518) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
+   <g id="text_43">
+    <!-- 486 ms (x 1.97) -->
+    <g transform="translate(543.556388 276.565323) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1812,84 +1862,13 @@ z
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_41">
-    <!-- 269 ms (x 3.86) -->
-    <g transform="translate(472.49405 318.131613) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-33" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_42">
-    <!-- 199 ms (x 5.23) -->
-    <g transform="translate(486.706518 330.13719) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-35" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- 1.03 s -->
-    <g transform="translate(529.34392 188.313499) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- 512 ms (x 2.02) -->
-    <g transform="translate(543.556388 276.489662) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-32" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_45">
-    <!-- 268 ms (x 3.86) -->
-    <g transform="translate(557.768856 318.260058) rotate(-90) scale(0.1 -0.1)">
+    <!-- 268 ms (x 3.57) -->
+    <g transform="translate(557.768856 315.843494) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-38" x="127.246094"/>
@@ -1902,17 +1881,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-35" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_46">
-    <!-- 197 ms (x 5.23) -->
-    <g transform="translate(571.981323 330.331437) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_45">
+    <!-- 195 ms (x 4.91) -->
+    <g transform="translate(571.981323 329.023526) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1920,182 +1899,182 @@ z
      <use xlink:href="#DejaVuSans-28" x="403.955078"/>
      <use xlink:href="#DejaVuSans-78" x="442.96875"/>
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-35" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-34" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_47">
+   <g id="text_46">
     <!--  1 -->
     <g transform="translate(95.440207 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_48">
+   <g id="text_47">
     <!--  2 -->
     <g transform="translate(109.652675 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_49">
+   <g id="text_48">
     <!--  4 -->
     <g transform="translate(123.865142 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_50">
+   <g id="text_49">
     <!--  6 -->
     <g transform="translate(138.07761 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_51">
+   <g id="text_50">
     <!--  1 -->
     <g transform="translate(180.715012 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_52">
+   <g id="text_51">
     <!--  2 -->
     <g transform="translate(194.92748 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_53">
+   <g id="text_52">
     <!--  4 -->
     <g transform="translate(209.139947 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_54">
+   <g id="text_53">
     <!--  6 -->
     <g transform="translate(223.352415 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_55">
+   <g id="text_54">
     <!--  1 -->
     <g transform="translate(265.989817 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_56">
+   <g id="text_55">
     <!--  2 -->
     <g transform="translate(280.202285 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_57">
+   <g id="text_56">
     <!--  4 -->
     <g transform="translate(294.414752 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_58">
+   <g id="text_57">
     <!--  6 -->
     <g transform="translate(308.62722 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_59">
+   <g id="text_58">
     <!--  1 -->
     <g transform="translate(351.264623 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_60">
+   <g id="text_59">
     <!--  2 -->
     <g transform="translate(365.47709 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_61">
+   <g id="text_60">
     <!--  4 -->
     <g transform="translate(379.689558 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_62">
+   <g id="text_61">
     <!--  6 -->
     <g transform="translate(393.902025 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_63">
+   <g id="text_62">
     <!--  1 -->
     <g transform="translate(436.539428 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_64">
+   <g id="text_63">
     <!--  2 -->
     <g transform="translate(450.751895 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_65">
+   <g id="text_64">
     <!--  4 -->
     <g transform="translate(464.964363 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_66">
+   <g id="text_65">
     <!--  6 -->
     <g transform="translate(479.17683 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_67">
+   <g id="text_66">
     <!--  1 -->
     <g transform="translate(521.814233 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_68">
+   <g id="text_67">
     <!--  2 -->
     <g transform="translate(536.0267 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_69">
+   <g id="text_68">
     <!--  4 -->
     <g transform="translate(550.239168 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_70">
+   <g id="text_69">
     <!--  6 -->
     <g transform="translate(564.451636 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
-   <g id="text_71">
+   <g id="text_70">
     <!-- filled random n=1000 -->
     <g transform="translate(261.811563 20.88) scale(0.12 -0.12)">
      <defs>
@@ -2197,7 +2176,7 @@ L 371.71875 36.478437
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_72">
+    <g id="text_71">
      <!-- serial no mask -->
      <g transform="translate(399.71875 43.478437) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-73"/>
@@ -2224,7 +2203,7 @@ L 371.71875 57.795312
 z
 " style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_73">
+    <g id="text_72">
      <!-- threaded no mask -->
      <g transform="translate(399.71875 58.156562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-74"/>
@@ -2307,7 +2286,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pa4ffb5d320">
+  <clipPath id="p2f38490991">
    <rect x="54.02" y="26.88" width="547.18" height="342.248"/>
   </clipPath>
  </defs>

--- a/docs/_static/threaded_filled_simple_dark.svg
+++ b/docs/_static/threaded_filled_simple_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:10.209086</dc:date>
+    <dc:date>2024-05-06T19:15:05.714980</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -31,11 +31,11 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 60.32 369.128 
+    <path d="M 54.11 369.128 
 L 601.2 369.128 
 L 601.2 26.88 
-L 60.32 26.88 
-L 60.32 369.128 
+L 54.11 26.88 
+L 54.11 369.128 
 z
 " style="fill: none"/>
    </g>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m89cf19cb77" d="M 0 0 
+       <path id="m79806af08c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m89cf19cb77" x="120.027532" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m79806af08c" x="114.503052" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Outer -->
-      <g style="fill: #ffffff" transform="translate(105.830657 383.726438) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(100.306177 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -169,7 +169,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g style="fill: #ffffff" transform="translate(107.22597 394.92425) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(101.701489 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -250,12 +250,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m89cf19cb77" x="204.320519" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m79806af08c" x="199.763831" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Outer -->
-      <g style="fill: #ffffff" transform="translate(190.123644 383.726438) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(185.566956 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -263,7 +263,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Offset -->
-      <g style="fill: #ffffff" transform="translate(189.222863 394.92425) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(184.666175 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -330,12 +330,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m89cf19cb77" x="288.613506" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m79806af08c" x="285.02461" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g style="fill: #ffffff" transform="translate(272.720538 383.726438) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(269.131642 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -397,7 +397,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g style="fill: #ffffff" transform="translate(263.2096 394.92425) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(259.620704 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -479,7 +479,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g style="fill: #ffffff" transform="translate(275.811944 406.122063) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(272.223048 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -490,12 +490,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m89cf19cb77" x="372.906494" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m79806af08c" x="370.28539" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g style="fill: #ffffff" transform="translate(357.013525 383.726438) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(354.392421 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -503,7 +503,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g style="fill: #ffffff" transform="translate(347.502587 394.92425) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(344.881483 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -514,7 +514,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g style="fill: #ffffff" transform="translate(357.808837 406.122063) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(355.187733 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -527,12 +527,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m89cf19cb77" x="457.199481" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m79806af08c" x="455.546169" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Chunk -->
-      <g style="fill: #ffffff" transform="translate(441.306512 383.726438) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(439.6532 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -540,7 +540,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g style="fill: #ffffff" transform="translate(431.795574 394.92425) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(430.142263 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -551,14 +551,14 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g style="fill: #ffffff" transform="translate(444.397918 406.122063) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(442.744606 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
        <use xlink:href="#DejaVuSans-65" x="194.482422"/>
       </g>
       <!-- Offset -->
-      <g style="fill: #ffffff" transform="translate(442.101824 417.319875) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(440.448513 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -571,12 +571,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m89cf19cb77" x="541.492468" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m79806af08c" x="540.806948" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Chunk -->
-      <g style="fill: #ffffff" transform="translate(525.599499 383.726438) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(524.913979 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -584,7 +584,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g style="fill: #ffffff" transform="translate(516.088561 394.92425) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(515.403042 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -595,7 +595,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g style="fill: #ffffff" transform="translate(526.394811 406.122063) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(525.709292 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -604,7 +604,7 @@ z
        <use xlink:href="#DejaVuSans-74" x="262.744141"/>
       </g>
       <!-- Offset -->
-      <g style="fill: #ffffff" transform="translate(526.394811 417.319875) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(525.709292 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -618,23 +618,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_7">
-      <path d="M 60.32 369.128 
+      <path d="M 54.11 369.128 
 L 601.2 369.128 
-" clip-path="url(#p31789c5ad8)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p8f0a1026e2)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="m96b16286ba" d="M 0 0 
+       <path id="m0a327757f9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m96b16286ba" x="60.32" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0a327757f9" x="54.11" y="369.128" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
-      <!-- 0.000 -->
-      <g style="fill: #ffffff" transform="translate(24.691875 372.927219) scale(0.1 -0.1)">
+      <!-- 0.00 -->
+      <g style="fill: #ffffff" transform="translate(24.844375 372.927219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -669,24 +669,23 @@ z
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
        <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 60.32 323.240155 
-L 601.2 323.240155 
-" clip-path="url(#p31789c5ad8)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 327.248264 
+L 601.2 327.248264 
+" clip-path="url(#p8f0a1026e2)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m96b16286ba" x="60.32" y="323.240155" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0a327757f9" x="54.11" y="327.248264" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
-      <!-- 0.025 -->
-      <g style="fill: #ffffff" transform="translate(24.691875 327.039374) scale(0.1 -0.1)">
+      <!-- 0.02 -->
+      <g style="fill: #ffffff" transform="translate(24.844375 331.047483) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -712,110 +711,185 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
-        <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
        <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 60.32 277.35231 
-L 601.2 277.35231 
-" clip-path="url(#p31789c5ad8)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 285.368528 
+L 601.2 285.368528 
+" clip-path="url(#p8f0a1026e2)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m96b16286ba" x="60.32" y="277.35231" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0a327757f9" x="54.11" y="285.368528" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
-      <!-- 0.050 -->
-      <g style="fill: #ffffff" transform="translate(24.691875 281.151529) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_4">
-     <g id="line2d_13">
-      <path d="M 60.32 231.464466 
-L 601.2 231.464466 
-" clip-path="url(#p31789c5ad8)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_14">
-      <g>
-       <use xlink:href="#m96b16286ba" x="60.32" y="231.464466" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_10">
-      <!-- 0.075 -->
-      <g style="fill: #ffffff" transform="translate(24.691875 235.263684) scale(0.1 -0.1)">
+      <!-- 0.04 -->
+      <g style="fill: #ffffff" transform="translate(24.844375 289.167747) scale(0.1 -0.1)">
        <defs>
-        <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
 z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_13">
+      <path d="M 54.11 243.488793 
+L 601.2 243.488793 
+" clip-path="url(#p8f0a1026e2)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m0a327757f9" x="54.11" y="243.488793" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.06 -->
+      <g style="fill: #ffffff" transform="translate(24.844375 247.288011) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-36" x="159.033203"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 60.32 185.576621 
-L 601.2 185.576621 
-" clip-path="url(#p31789c5ad8)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 201.609057 
+L 601.2 201.609057 
+" clip-path="url(#p8f0a1026e2)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m96b16286ba" x="60.32" y="185.576621" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0a327757f9" x="54.11" y="201.609057" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
-      <!-- 0.100 -->
-      <g style="fill: #ffffff" transform="translate(24.691875 189.37584) scale(0.1 -0.1)">
+      <!-- 0.08 -->
+      <g style="fill: #ffffff" transform="translate(24.844375 205.408275) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_17">
+      <path d="M 54.11 159.729321 
+L 601.2 159.729321 
+" clip-path="url(#p8f0a1026e2)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m0a327757f9" x="54.11" y="159.729321" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.10 -->
+      <g style="fill: #ffffff" transform="translate(24.844375 163.52854) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -836,79 +910,75 @@ z
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
        <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_17">
-      <path d="M 60.32 139.688776 
-L 601.2 139.688776 
-" clip-path="url(#p31789c5ad8)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_18">
-      <g>
-       <use xlink:href="#m96b16286ba" x="60.32" y="139.688776" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_12">
-      <!-- 0.125 -->
-      <g style="fill: #ffffff" transform="translate(24.691875 143.487995) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 60.32 93.800931 
-L 601.2 93.800931 
-" clip-path="url(#p31789c5ad8)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 117.849585 
+L 601.2 117.849585 
+" clip-path="url(#p8f0a1026e2)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m96b16286ba" x="60.32" y="93.800931" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0a327757f9" x="54.11" y="117.849585" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
-      <!-- 0.150 -->
-      <g style="fill: #ffffff" transform="translate(24.691875 97.60015) scale(0.1 -0.1)">
+      <!-- 0.12 -->
+      <g style="fill: #ffffff" transform="translate(24.844375 121.648804) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-32" x="159.033203"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 60.32 47.913086 
-L 601.2 47.913086 
-" clip-path="url(#p31789c5ad8)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 75.969849 
+L 601.2 75.969849 
+" clip-path="url(#p8f0a1026e2)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m96b16286ba" x="60.32" y="47.913086" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m0a327757f9" x="54.11" y="75.969849" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <!-- 0.175 -->
-      <g style="fill: #ffffff" transform="translate(24.691875 51.712305) scale(0.1 -0.1)">
+      <!-- 0.14 -->
+      <g style="fill: #ffffff" transform="translate(24.844375 79.769068) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-34" x="159.033203"/>
       </g>
      </g>
     </g>
-    <g id="text_15">
+    <g id="ytick_9">
+     <g id="line2d_23">
+      <path d="M 54.11 34.090113 
+L 601.2 34.090113 
+" clip-path="url(#p8f0a1026e2)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m0a327757f9" x="54.11" y="34.090113" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0.16 -->
+      <g style="fill: #ffffff" transform="translate(24.844375 37.889332) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
      <!-- Time (seconds) -->
-     <g style="fill: #ffffff" transform="translate(18.612188 236.165719) rotate(-90) scale(0.1 -0.1)">
+     <g style="fill: #ffffff" transform="translate(18.764688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -988,8 +1058,8 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 60.32 369.128 
-L 60.32 26.88 
+    <path d="M 54.11 369.128 
+L 54.11 26.88 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
@@ -998,67 +1068,684 @@ L 601.2 26.88
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 60.32 369.128 
+    <path d="M 54.11 369.128 
 L 601.2 369.128 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 60.32 26.88 
+    <path d="M 54.11 26.88 
 L 601.2 26.88 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 84.905455 369.128 
-L 98.954286 369.128 
-L 98.954286 124.068037 
-L 84.905455 124.068037 
+    <path d="M 78.977727 369.128 
+L 93.187857 369.128 
+L 93.187857 122.636406 
+L 78.977727 122.636406 
 z
-" clip-path="url(#p31789c5ad8)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0a1026e2)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 169.198442 369.128 
-L 183.247273 369.128 
-L 183.247273 122.48943 
-L 169.198442 122.48943 
+    <path d="M 164.238506 369.128 
+L 178.448636 369.128 
+L 178.448636 122.386498 
+L 164.238506 122.386498 
 z
-" clip-path="url(#p31789c5ad8)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0a1026e2)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 253.491429 369.128 
-L 267.54026 369.128 
-L 267.54026 126.143891 
-L 253.491429 126.143891 
+    <path d="M 249.499286 369.128 
+L 263.709416 369.128 
+L 263.709416 124.189004 
+L 249.499286 124.189004 
 z
-" clip-path="url(#p31789c5ad8)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0a1026e2)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 337.784416 369.128 
-L 351.833247 369.128 
-L 351.833247 123.812646 
-L 337.784416 123.812646 
+    <path d="M 334.760065 369.128 
+L 348.970195 369.128 
+L 348.970195 122.195821 
+L 334.760065 122.195821 
 z
-" clip-path="url(#p31789c5ad8)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0a1026e2)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 422.077403 369.128 
-L 436.126234 369.128 
-L 436.126234 125.262046 
-L 422.077403 125.262046 
+    <path d="M 420.020844 369.128 
+L 434.230974 369.128 
+L 434.230974 123.007042 
+L 420.020844 123.007042 
 z
-" clip-path="url(#p31789c5ad8)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0a1026e2)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 506.37039 369.128 
-L 520.419221 369.128 
-L 520.419221 124.943867 
-L 506.37039 124.943867 
+    <path d="M 505.281623 369.128 
+L 519.491753 369.128 
+L 519.491753 123.908157 
+L 505.281623 123.908157 
 z
-" clip-path="url(#p31789c5ad8)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0a1026e2)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_16">
-    <!-- 134 ms -->
-    <g style="fill: #ffffff" transform="translate(94.689245 119.068037) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_17">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(88.842167 117.636406) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(174.102946 117.386498) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 117 ms -->
+    <g style="fill: #ffffff" transform="translate(259.363726 119.189004) rotate(-90) scale(0.1 -0.1)">
      <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(344.624505 117.195821) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 118 ms -->
+    <g style="fill: #ffffff" transform="translate(429.885284 118.007042) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 117 ms -->
+    <g style="fill: #ffffff" transform="translate(515.146063 118.908157) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_13">
+    <path d="M 93.187857 369.128 
+L 107.397987 369.128 
+L 107.397987 123.895186 
+L 93.187857 123.895186 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 107.397987 369.128 
+L 121.608117 369.128 
+L 121.608117 199.370368 
+L 107.397987 199.370368 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 121.608117 369.128 
+L 135.818247 369.128 
+L 135.818247 253.688486 
+L 121.608117 253.688486 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 135.818247 369.128 
+L 150.028377 369.128 
+L 150.028377 269.601138 
+L 135.818247 269.601138 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 178.448636 369.128 
+L 192.658766 369.128 
+L 192.658766 123.579977 
+L 178.448636 123.579977 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 192.658766 369.128 
+L 206.868896 369.128 
+L 206.868896 199.990698 
+L 192.658766 199.990698 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 206.868896 369.128 
+L 221.079026 369.128 
+L 221.079026 253.838057 
+L 206.868896 253.838057 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 221.079026 369.128 
+L 235.289156 369.128 
+L 235.289156 269.672276 
+L 221.079026 269.672276 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 263.709416 369.128 
+L 277.919545 369.128 
+L 277.919545 123.635275 
+L 263.709416 123.635275 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 277.919545 369.128 
+L 292.129675 369.128 
+L 292.129675 199.485439 
+L 277.919545 199.485439 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 292.129675 369.128 
+L 306.339805 369.128 
+L 306.339805 252.34442 
+L 292.129675 252.34442 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 306.339805 369.128 
+L 320.549935 369.128 
+L 320.549935 266.978265 
+L 306.339805 266.978265 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 348.970195 369.128 
+L 363.180325 369.128 
+L 363.180325 124.41462 
+L 348.970195 124.41462 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 363.180325 369.128 
+L 377.390455 369.128 
+L 377.390455 197.735656 
+L 363.180325 197.735656 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 377.390455 369.128 
+L 391.600584 369.128 
+L 391.600584 248.947244 
+L 377.390455 248.947244 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 391.600584 369.128 
+L 405.810714 369.128 
+L 405.810714 264.558194 
+L 391.600584 264.558194 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 434.230974 369.128 
+L 448.441104 369.128 
+L 448.441104 123.115191 
+L 434.230974 123.115191 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 448.441104 369.128 
+L 462.651234 369.128 
+L 462.651234 198.90643 
+L 448.441104 198.90643 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 462.651234 369.128 
+L 476.861364 369.128 
+L 476.861364 251.809866 
+L 462.651234 251.809866 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 476.861364 369.128 
+L 491.071494 369.128 
+L 491.071494 266.995385 
+L 476.861364 266.995385 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 519.491753 369.128 
+L 533.701883 369.128 
+L 533.701883 124.384494 
+L 519.491753 124.384494 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 533.701883 369.128 
+L 547.912013 369.128 
+L 547.912013 196.069617 
+L 533.701883 196.069617 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 547.912013 369.128 
+L 562.122143 369.128 
+L 562.122143 249.041196 
+L 547.912013 249.041196 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 562.122143 369.128 
+L 576.332273 369.128 
+L 576.332273 264.567439 
+L 562.122143 264.567439 
+z
+" clip-path="url(#p8f0a1026e2)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_23">
+    <!-- 117 ms -->
+    <g style="fill: #ffffff" transform="translate(103.052297 118.895186) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 81.1 ms (x 1.45) -->
+    <g style="fill: #ffffff" transform="translate(117.262427 194.370368) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 55.1 ms (x 2.14) -->
+    <g style="fill: #ffffff" transform="translate(131.472557 248.688486) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 47.5 ms (x 2.48) -->
+    <g style="fill: #ffffff" transform="translate(145.682687 264.601138) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- 117 ms -->
+    <g style="fill: #ffffff" transform="translate(188.313076 118.579977) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 80.8 ms (x 1.46) -->
+    <g style="fill: #ffffff" transform="translate(202.523206 194.990698) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 55.1 ms (x 2.14) -->
+    <g style="fill: #ffffff" transform="translate(216.733336 248.838057) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 47.5 ms (x 2.48) -->
+    <g style="fill: #ffffff" transform="translate(230.943466 264.672276) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 117 ms -->
+    <g style="fill: #ffffff" transform="translate(273.573856 118.635275) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 81.0 ms (x 1.44) -->
+    <g style="fill: #ffffff" transform="translate(287.783985 194.485439) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- 55.8 ms (x 2.10) -->
+    <g style="fill: #ffffff" transform="translate(301.994115 247.34442) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 48.8 ms (x 2.40) -->
+    <g style="fill: #ffffff" transform="translate(316.204245 261.978265) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 117 ms -->
+    <g style="fill: #ffffff" transform="translate(358.834635 119.41462) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 81.8 ms (x 1.44) -->
+    <g style="fill: #ffffff" transform="translate(373.044765 192.735656) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- 57.4 ms (x 2.05) -->
+    <g style="fill: #ffffff" transform="translate(387.254894 243.947244) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-30" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- 49.9 ms (x 2.36) -->
+    <g style="fill: #ffffff" transform="translate(401.465024 259.558194) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1091,512 +1778,9 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_17">
-    <!-- 134 ms -->
-    <g style="fill: #ffffff" transform="translate(178.982232 117.48943) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 132 ms -->
-    <g style="fill: #ffffff" transform="translate(263.275219 121.143891) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 134 ms -->
-    <g style="fill: #ffffff" transform="translate(347.568206 118.812646) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(431.861193 120.262046) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(516.15418 119.943867) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_13">
-    <path d="M 98.954286 369.128 
-L 113.003117 369.128 
-L 113.003117 127.397312 
-L 98.954286 127.397312 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 113.003117 369.128 
-L 127.051948 369.128 
-L 127.051948 208.842394 
-L 113.003117 208.842394 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 127.051948 369.128 
-L 141.100779 369.128 
-L 141.100779 257.723843 
-L 127.051948 257.723843 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 141.100779 369.128 
-L 155.14961 369.128 
-L 155.14961 273.522369 
-L 141.100779 273.522369 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 183.247273 369.128 
-L 197.296104 369.128 
-L 197.296104 122.195821 
-L 183.247273 122.195821 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 197.296104 369.128 
-L 211.344935 369.128 
-L 211.344935 207.028445 
-L 197.296104 207.028445 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 211.344935 369.128 
-L 225.393766 369.128 
-L 225.393766 257.340494 
-L 211.344935 257.340494 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 225.393766 369.128 
-L 239.442597 369.128 
-L 239.442597 273.36274 
-L 225.393766 273.36274 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 267.54026 369.128 
-L 281.589091 369.128 
-L 281.589091 126.364875 
-L 267.54026 126.364875 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_22">
-    <path d="M 281.589091 369.128 
-L 295.637922 369.128 
-L 295.637922 205.487023 
-L 281.589091 205.487023 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_23">
-    <path d="M 295.637922 369.128 
-L 309.686753 369.128 
-L 309.686753 257.157642 
-L 295.637922 257.157642 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 309.686753 369.128 
-L 323.735584 369.128 
-L 323.735584 271.828328 
-L 309.686753 271.828328 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 351.833247 369.128 
-L 365.882078 369.128 
-L 365.882078 126.038469 
-L 351.833247 126.038469 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 365.882078 369.128 
-L 379.930909 369.128 
-L 379.930909 205.728859 
-L 365.882078 205.728859 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 379.930909 369.128 
-L 393.97974 369.128 
-L 393.97974 256.803376 
-L 379.930909 256.803376 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 393.97974 369.128 
-L 408.028571 369.128 
-L 408.028571 272.594693 
-L 393.97974 272.594693 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_29">
-    <path d="M 436.126234 369.128 
-L 450.175065 369.128 
-L 450.175065 128.783682 
-L 436.126234 128.783682 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_30">
-    <path d="M 450.175065 369.128 
-L 464.223896 369.128 
-L 464.223896 209.335399 
-L 450.175065 209.335399 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_31">
-    <path d="M 464.223896 369.128 
-L 478.272727 369.128 
-L 478.272727 256.102669 
-L 464.223896 256.102669 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_32">
-    <path d="M 478.272727 369.128 
-L 492.321558 369.128 
-L 492.321558 271.547191 
-L 478.272727 271.547191 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_33">
-    <path d="M 520.419221 369.128 
-L 534.468052 369.128 
-L 534.468052 125.202657 
-L 520.419221 125.202657 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_34">
-    <path d="M 534.468052 369.128 
-L 548.516883 369.128 
-L 548.516883 205.684416 
-L 534.468052 205.684416 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_35">
-    <path d="M 548.516883 369.128 
-L 562.565714 369.128 
-L 562.565714 257.202462 
-L 548.516883 257.202462 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_36">
-    <path d="M 562.565714 369.128 
-L 576.614545 369.128 
-L 576.614545 272.252027 
-L 562.565714 272.252027 
-z
-" clip-path="url(#p31789c5ad8)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 132 ms -->
-    <g style="fill: #ffffff" transform="translate(108.738076 122.397312) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 87.3 ms (x 1.53) -->
-    <g style="fill: #ffffff" transform="translate(122.786907 203.842394) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 60.7 ms (x 2.20) -->
-    <g style="fill: #ffffff" transform="translate(136.835739 252.723843) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-32" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 52.1 ms (x 2.56) -->
-    <g style="fill: #ffffff" transform="translate(150.88457 268.522369) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 135 ms -->
-    <g style="fill: #ffffff" transform="translate(193.031063 117.195821) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 88.3 ms (x 1.52) -->
-    <g style="fill: #ffffff" transform="translate(207.079894 202.028445) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 60.9 ms (x 2.21) -->
-    <g style="fill: #ffffff" transform="translate(221.128726 252.340494) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-39" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1608,50 +1792,29 @@ z
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-32" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_29">
-    <!-- 52.2 ms (x 2.58) -->
-    <g style="fill: #ffffff" transform="translate(235.177557 268.36274) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 132 ms -->
-    <g style="fill: #ffffff" transform="translate(277.32405 121.364875) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_39">
+    <!-- 117 ms -->
+    <g style="fill: #ffffff" transform="translate(444.095414 118.115191) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- 89.2 ms (x 1.48) -->
-    <g style="fill: #ffffff" transform="translate(291.372881 200.487023) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_40">
+    <!-- 81.3 ms (x 1.45) -->
+    <g style="fill: #ffffff" transform="translate(458.305544 193.90643) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1662,186 +1825,17 @@ z
      <use xlink:href="#DejaVuSans-31" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 61.0 ms (x 2.17) -->
-    <g style="fill: #ffffff" transform="translate(305.421713 252.157642) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- 53.0 ms (x 2.50) -->
-    <g style="fill: #ffffff" transform="translate(319.470544 266.828328) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- 132 ms -->
-    <g style="fill: #ffffff" transform="translate(361.617037 121.038469) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 89.0 ms (x 1.50) -->
-    <g style="fill: #ffffff" transform="translate(375.665869 200.728859) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 61.2 ms (x 2.18) -->
-    <g style="fill: #ffffff" transform="translate(389.7147 251.803376) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- 52.6 ms (x 2.54) -->
-    <g style="fill: #ffffff" transform="translate(403.763531 267.594693) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- 131 ms -->
-    <g style="fill: #ffffff" transform="translate(445.910024 123.783682) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- 87.1 ms (x 1.53) -->
-    <g style="fill: #ffffff" transform="translate(459.958856 204.335399) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- 61.6 ms (x 2.16) -->
-    <g style="fill: #ffffff" transform="translate(474.007687 251.102669) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- 53.2 ms (x 2.50) -->
-    <g style="fill: #ffffff" transform="translate(488.056518 266.547191) rotate(-90) scale(0.1 -0.1)">
+    <!-- 56.0 ms (x 2.10) -->
+    <g style="fill: #ffffff" transform="translate(472.515674 246.809866) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1851,69 +1845,16 @@ z
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
      <use xlink:href="#DejaVuSans-30" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
    <g id="text_42">
-    <!-- 133 ms -->
-    <g style="fill: #ffffff" transform="translate(530.203011 120.202657) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- 89.0 ms (x 1.49) -->
-    <g style="fill: #ffffff" transform="translate(544.251843 200.684416) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-39" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_44">
-    <!-- 61.0 ms (x 2.18) -->
-    <g style="fill: #ffffff" transform="translate(558.300674 252.202462) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_45">
-    <!-- 52.8 ms (x 2.52) -->
-    <g style="fill: #ffffff" transform="translate(572.349505 267.252027) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+    <!-- 48.8 ms (x 2.41) -->
+    <g style="fill: #ffffff" transform="translate(486.725804 261.995385) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-38" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1925,182 +1866,256 @@ z
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- 117 ms -->
+    <g style="fill: #ffffff" transform="translate(529.356193 119.384494) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_44">
+    <!-- 82.6 ms (x 1.42) -->
+    <g style="fill: #ffffff" transform="translate(543.566323 191.069617) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
      <use xlink:href="#DejaVuSans-32" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
+   <g id="text_45">
+    <!-- 57.3 ms (x 2.04) -->
+    <g style="fill: #ffffff" transform="translate(557.776453 244.041196) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-30" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
    <g id="text_46">
-    <!--  1 -->
-    <g transform="translate(101.208389 367.048313) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    <!-- 49.9 ms (x 2.35) -->
+    <g style="fill: #ffffff" transform="translate(571.986583 259.567439) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
    <g id="text_47">
-    <!--  2 -->
-    <g transform="translate(115.25722 367.048313) scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(95.52261 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_48">
-    <!--  4 -->
-    <g transform="translate(129.306051 367.048313) scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(109.732739 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_49">
-    <!--  6 -->
-    <g transform="translate(143.354882 367.048313) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(123.942869 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_50">
-    <!--  1 -->
-    <g transform="translate(185.501376 367.048313) scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(138.152999 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_51">
-    <!--  2 -->
-    <g transform="translate(199.550207 367.048313) scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(180.783389 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_52">
-    <!--  4 -->
-    <g transform="translate(213.599038 367.048313) scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(194.993519 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_53">
-    <!--  6 -->
-    <g transform="translate(227.647869 367.048313) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(209.203649 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_54">
-    <!--  1 -->
-    <g transform="translate(269.794363 367.048313) scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(223.413778 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_55">
-    <!--  2 -->
-    <g transform="translate(283.843194 367.048313) scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(266.044168 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_56">
-    <!--  4 -->
-    <g transform="translate(297.892025 367.048313) scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(280.254298 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_57">
-    <!--  6 -->
-    <g transform="translate(311.940856 367.048313) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(294.464428 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_58">
-    <!--  1 -->
-    <g transform="translate(354.08735 367.048313) scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(308.674558 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_59">
-    <!--  2 -->
-    <g transform="translate(368.136181 367.048313) scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(351.304947 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_60">
-    <!--  4 -->
-    <g transform="translate(382.185012 367.048313) scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(365.515077 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_61">
-    <!--  6 -->
-    <g transform="translate(396.233843 367.048313) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(379.725207 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_62">
-    <!--  1 -->
-    <g transform="translate(438.380337 367.048313) scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(393.935337 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_63">
-    <!--  2 -->
-    <g transform="translate(452.429168 367.048313) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_64">
-    <!--  4 -->
-    <g transform="translate(466.477999 367.048313) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_65">
-    <!--  6 -->
-    <g transform="translate(480.52683 367.048313) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_66">
     <!--  1 -->
-    <g transform="translate(522.673324 367.048313) scale(0.1 -0.1)">
+    <g transform="translate(436.565726 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_67">
+   <g id="text_64">
     <!--  2 -->
-    <g transform="translate(536.722155 367.048313) scale(0.1 -0.1)">
+    <g transform="translate(450.775856 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_68">
+   <g id="text_65">
     <!--  4 -->
-    <g transform="translate(550.770986 367.048313) scale(0.1 -0.1)">
+    <g transform="translate(464.985986 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_69">
+   <g id="text_66">
     <!--  6 -->
-    <g transform="translate(564.819817 367.048313) scale(0.1 -0.1)">
+    <g transform="translate(479.196116 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
+   <g id="text_67">
+    <!--  1 -->
+    <g transform="translate(521.826506 367.048313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_68">
+    <!--  2 -->
+    <g transform="translate(536.036636 367.048313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_69">
+    <!--  4 -->
+    <g transform="translate(550.246765 367.048313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+    </g>
+   </g>
    <g id="text_70">
+    <!--  6 -->
+    <g transform="translate(564.456895 367.048313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_71">
     <!-- filled simple n=1000 -->
-    <g style="fill: #ffffff" transform="translate(268.4275 20.88) scale(0.12 -0.12)">
+    <g style="fill: #ffffff" transform="translate(265.3225 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -2193,7 +2208,7 @@ L 371.71875 36.478437
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_71">
+    <g id="text_72">
      <!-- serial no mask -->
      <g style="fill: #ffffff" transform="translate(399.71875 43.478437) scale(0.1 -0.1)">
       <defs>
@@ -2255,7 +2270,7 @@ L 371.71875 57.795312
 z
 " style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_72">
+    <g id="text_73">
      <!-- threaded no mask -->
      <g style="fill: #ffffff" transform="translate(399.71875 58.156562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-74"/>
@@ -2338,8 +2353,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p31789c5ad8">
-   <rect x="60.32" y="26.88" width="540.88" height="342.248"/>
+  <clipPath id="p8f0a1026e2">
+   <rect x="54.11" y="26.88" width="547.09" height="342.248"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/_static/threaded_filled_simple_light.svg
+++ b/docs/_static/threaded_filled_simple_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:10.000108</dc:date>
+    <dc:date>2024-05-06T19:15:05.508405</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -31,11 +31,11 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 60.32 369.128 
+    <path d="M 54.11 369.128 
 L 601.2 369.128 
 L 601.2 26.88 
-L 60.32 26.88 
-L 60.32 369.128 
+L 54.11 26.88 
+L 54.11 369.128 
 z
 " style="fill: none"/>
    </g>
@@ -43,17 +43,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m60f0e968d8" d="M 0 0 
+       <path id="m79d1233d67" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m60f0e968d8" x="120.027532" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79d1233d67" x="114.503052" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- Outer -->
-      <g transform="translate(105.830657 383.726438) scale(0.1 -0.1)">
+      <g transform="translate(100.306177 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -169,7 +169,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Code -->
-      <g transform="translate(107.22597 394.92425) scale(0.1 -0.1)">
+      <g transform="translate(101.701489 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-43" d="M 4122 4306 
 L 4122 3641 
@@ -250,12 +250,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m60f0e968d8" x="204.320519" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79d1233d67" x="199.763831" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- Outer -->
-      <g transform="translate(190.123644 383.726438) scale(0.1 -0.1)">
+      <g transform="translate(185.566956 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-75" x="78.710938"/>
        <use xlink:href="#DejaVuSans-74" x="142.089844"/>
@@ -263,7 +263,7 @@ z
        <use xlink:href="#DejaVuSans-72" x="242.822266"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(189.222863 394.92425) scale(0.1 -0.1)">
+      <g transform="translate(184.666175 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -330,12 +330,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m60f0e968d8" x="288.613506" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79d1233d67" x="285.02461" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- Chunk -->
-      <g transform="translate(272.720538 383.726438) scale(0.1 -0.1)">
+      <g transform="translate(269.131642 383.726438) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -397,7 +397,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(263.2096 394.92425) scale(0.1 -0.1)">
+      <g transform="translate(259.620704 394.92425) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -479,7 +479,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(275.811944 406.122063) scale(0.1 -0.1)">
+      <g transform="translate(272.223048 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
@@ -490,12 +490,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m60f0e968d8" x="372.906494" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79d1233d67" x="370.28539" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- Chunk -->
-      <g transform="translate(357.013525 383.726438) scale(0.1 -0.1)">
+      <g transform="translate(354.392421 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -503,7 +503,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(347.502587 394.92425) scale(0.1 -0.1)">
+      <g transform="translate(344.881483 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -514,7 +514,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(357.808837 406.122063) scale(0.1 -0.1)">
+      <g transform="translate(355.187733 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -527,12 +527,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m60f0e968d8" x="457.199481" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79d1233d67" x="455.546169" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- Chunk -->
-      <g transform="translate(441.306512 383.726438) scale(0.1 -0.1)">
+      <g transform="translate(439.6532 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -540,7 +540,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(431.795574 394.92425) scale(0.1 -0.1)">
+      <g transform="translate(430.142263 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -551,14 +551,14 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Code -->
-      <g transform="translate(444.397918 406.122063) scale(0.1 -0.1)">
+      <g transform="translate(442.744606 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-64" x="131.005859"/>
        <use xlink:href="#DejaVuSans-65" x="194.482422"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(442.101824 417.319875) scale(0.1 -0.1)">
+      <g transform="translate(440.448513 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -571,12 +571,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m60f0e968d8" x="541.492468" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79d1233d67" x="540.806948" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- Chunk -->
-      <g transform="translate(525.599499 383.726438) scale(0.1 -0.1)">
+      <g transform="translate(524.913979 383.726438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-68" x="69.824219"/>
        <use xlink:href="#DejaVuSans-75" x="133.203125"/>
@@ -584,7 +584,7 @@ z
        <use xlink:href="#DejaVuSans-6b" x="259.960938"/>
       </g>
       <!-- Combined -->
-      <g transform="translate(516.088561 394.92425) scale(0.1 -0.1)">
+      <g transform="translate(515.403042 394.92425) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-43"/>
        <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
        <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
@@ -595,7 +595,7 @@ z
        <use xlink:href="#DejaVuSans-64" x="444.580078"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(526.394811 406.122063) scale(0.1 -0.1)">
+      <g transform="translate(525.709292 406.122063) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -604,7 +604,7 @@ z
        <use xlink:href="#DejaVuSans-74" x="262.744141"/>
       </g>
       <!-- Offset -->
-      <g transform="translate(526.394811 417.319875) scale(0.1 -0.1)">
+      <g transform="translate(525.709292 417.319875) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-4f"/>
        <use xlink:href="#DejaVuSans-66" x="78.710938"/>
        <use xlink:href="#DejaVuSans-66" x="113.916016"/>
@@ -618,23 +618,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_7">
-      <path d="M 60.32 369.128 
+      <path d="M 54.11 369.128 
 L 601.2 369.128 
-" clip-path="url(#pb5d3fbc335)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p64b0d6694f)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="m26d0d89595" d="M 0 0 
+       <path id="ma99d3cdbd1" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m26d0d89595" x="60.32" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma99d3cdbd1" x="54.11" y="369.128" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
-      <!-- 0.000 -->
-      <g transform="translate(24.691875 372.927219) scale(0.1 -0.1)">
+      <!-- 0.00 -->
+      <g transform="translate(24.844375 372.927219) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -669,24 +669,23 @@ z
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
        <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 60.32 323.240155 
-L 601.2 323.240155 
-" clip-path="url(#pb5d3fbc335)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 327.248264 
+L 601.2 327.248264 
+" clip-path="url(#p64b0d6694f)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m26d0d89595" x="60.32" y="323.240155" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma99d3cdbd1" x="54.11" y="327.248264" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
-      <!-- 0.025 -->
-      <g transform="translate(24.691875 327.039374) scale(0.1 -0.1)">
+      <!-- 0.02 -->
+      <g transform="translate(24.844375 331.047483) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -712,110 +711,185 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
-        <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
        <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 60.32 277.35231 
-L 601.2 277.35231 
-" clip-path="url(#pb5d3fbc335)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 285.368528 
+L 601.2 285.368528 
+" clip-path="url(#p64b0d6694f)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m26d0d89595" x="60.32" y="277.35231" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma99d3cdbd1" x="54.11" y="285.368528" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
-      <!-- 0.050 -->
-      <g transform="translate(24.691875 281.151529) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_4">
-     <g id="line2d_13">
-      <path d="M 60.32 231.464466 
-L 601.2 231.464466 
-" clip-path="url(#pb5d3fbc335)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_14">
-      <g>
-       <use xlink:href="#m26d0d89595" x="60.32" y="231.464466" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_10">
-      <!-- 0.075 -->
-      <g transform="translate(24.691875 235.263684) scale(0.1 -0.1)">
+      <!-- 0.04 -->
+      <g transform="translate(24.844375 289.167747) scale(0.1 -0.1)">
        <defs>
-        <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
 z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_13">
+      <path d="M 54.11 243.488793 
+L 601.2 243.488793 
+" clip-path="url(#p64b0d6694f)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#ma99d3cdbd1" x="54.11" y="243.488793" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.06 -->
+      <g transform="translate(24.844375 247.288011) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-36" x="159.033203"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 60.32 185.576621 
-L 601.2 185.576621 
-" clip-path="url(#pb5d3fbc335)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 201.609057 
+L 601.2 201.609057 
+" clip-path="url(#p64b0d6694f)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m26d0d89595" x="60.32" y="185.576621" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma99d3cdbd1" x="54.11" y="201.609057" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
-      <!-- 0.100 -->
-      <g transform="translate(24.691875 189.37584) scale(0.1 -0.1)">
+      <!-- 0.08 -->
+      <g transform="translate(24.844375 205.408275) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_17">
+      <path d="M 54.11 159.729321 
+L 601.2 159.729321 
+" clip-path="url(#p64b0d6694f)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#ma99d3cdbd1" x="54.11" y="159.729321" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.10 -->
+      <g transform="translate(24.844375 163.52854) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -836,79 +910,75 @@ z
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
        <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_6">
-     <g id="line2d_17">
-      <path d="M 60.32 139.688776 
-L 601.2 139.688776 
-" clip-path="url(#pb5d3fbc335)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_18">
-      <g>
-       <use xlink:href="#m26d0d89595" x="60.32" y="139.688776" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_12">
-      <!-- 0.125 -->
-      <g transform="translate(24.691875 143.487995) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_19">
-      <path d="M 60.32 93.800931 
-L 601.2 93.800931 
-" clip-path="url(#pb5d3fbc335)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 117.849585 
+L 601.2 117.849585 
+" clip-path="url(#p64b0d6694f)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m26d0d89595" x="60.32" y="93.800931" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma99d3cdbd1" x="54.11" y="117.849585" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
-      <!-- 0.150 -->
-      <g transform="translate(24.691875 97.60015) scale(0.1 -0.1)">
+      <!-- 0.12 -->
+      <g transform="translate(24.844375 121.648804) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-32" x="159.033203"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_21">
-      <path d="M 60.32 47.913086 
-L 601.2 47.913086 
-" clip-path="url(#pb5d3fbc335)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 75.969849 
+L 601.2 75.969849 
+" clip-path="url(#p64b0d6694f)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m26d0d89595" x="60.32" y="47.913086" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma99d3cdbd1" x="54.11" y="75.969849" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <!-- 0.175 -->
-      <g transform="translate(24.691875 51.712305) scale(0.1 -0.1)">
+      <!-- 0.14 -->
+      <g transform="translate(24.844375 79.769068) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
-       <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-       <use xlink:href="#DejaVuSans-35" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-34" x="159.033203"/>
       </g>
      </g>
     </g>
-    <g id="text_15">
+    <g id="ytick_9">
+     <g id="line2d_23">
+      <path d="M 54.11 34.090113 
+L 601.2 34.090113 
+" clip-path="url(#p64b0d6694f)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#ma99d3cdbd1" x="54.11" y="34.090113" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0.16 -->
+      <g transform="translate(24.844375 37.889332) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
      <!-- Time (seconds) -->
-     <g transform="translate(18.612188 236.165719) rotate(-90) scale(0.1 -0.1)">
+     <g transform="translate(18.764688 236.165719) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -988,8 +1058,8 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 60.32 369.128 
-L 60.32 26.88 
+    <path d="M 54.11 369.128 
+L 54.11 26.88 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
@@ -998,67 +1068,684 @@ L 601.2 26.88
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 60.32 369.128 
+    <path d="M 54.11 369.128 
 L 601.2 369.128 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 60.32 26.88 
+    <path d="M 54.11 26.88 
 L 601.2 26.88 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 84.905455 369.128 
-L 98.954286 369.128 
-L 98.954286 124.068037 
-L 84.905455 124.068037 
+    <path d="M 78.977727 369.128 
+L 93.187857 369.128 
+L 93.187857 122.636406 
+L 78.977727 122.636406 
 z
-" clip-path="url(#pb5d3fbc335)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p64b0d6694f)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 169.198442 369.128 
-L 183.247273 369.128 
-L 183.247273 122.48943 
-L 169.198442 122.48943 
+    <path d="M 164.238506 369.128 
+L 178.448636 369.128 
+L 178.448636 122.386498 
+L 164.238506 122.386498 
 z
-" clip-path="url(#pb5d3fbc335)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p64b0d6694f)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 253.491429 369.128 
-L 267.54026 369.128 
-L 267.54026 126.143891 
-L 253.491429 126.143891 
+    <path d="M 249.499286 369.128 
+L 263.709416 369.128 
+L 263.709416 124.189004 
+L 249.499286 124.189004 
 z
-" clip-path="url(#pb5d3fbc335)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p64b0d6694f)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 337.784416 369.128 
-L 351.833247 369.128 
-L 351.833247 123.812646 
-L 337.784416 123.812646 
+    <path d="M 334.760065 369.128 
+L 348.970195 369.128 
+L 348.970195 122.195821 
+L 334.760065 122.195821 
 z
-" clip-path="url(#pb5d3fbc335)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p64b0d6694f)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 422.077403 369.128 
-L 436.126234 369.128 
-L 436.126234 125.262046 
-L 422.077403 125.262046 
+    <path d="M 420.020844 369.128 
+L 434.230974 369.128 
+L 434.230974 123.007042 
+L 420.020844 123.007042 
 z
-" clip-path="url(#pb5d3fbc335)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p64b0d6694f)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 506.37039 369.128 
-L 520.419221 369.128 
-L 520.419221 124.943867 
-L 506.37039 124.943867 
+    <path d="M 505.281623 369.128 
+L 519.491753 369.128 
+L 519.491753 123.908157 
+L 505.281623 123.908157 
 z
-" clip-path="url(#pb5d3fbc335)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p64b0d6694f)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
-   <g id="text_16">
-    <!-- 134 ms -->
-    <g transform="translate(94.689245 119.068037) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_17">
+    <!-- 118 ms -->
+    <g transform="translate(88.842167 117.636406) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 118 ms -->
+    <g transform="translate(174.102946 117.386498) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 117 ms -->
+    <g transform="translate(259.363726 119.189004) rotate(-90) scale(0.1 -0.1)">
      <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 118 ms -->
+    <g transform="translate(344.624505 117.195821) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 118 ms -->
+    <g transform="translate(429.885284 118.007042) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 117 ms -->
+    <g transform="translate(515.146063 118.908157) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_13">
+    <path d="M 93.187857 369.128 
+L 107.397987 369.128 
+L 107.397987 123.895186 
+L 93.187857 123.895186 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 107.397987 369.128 
+L 121.608117 369.128 
+L 121.608117 199.370368 
+L 107.397987 199.370368 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 121.608117 369.128 
+L 135.818247 369.128 
+L 135.818247 253.688486 
+L 121.608117 253.688486 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 135.818247 369.128 
+L 150.028377 369.128 
+L 150.028377 269.601138 
+L 135.818247 269.601138 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 178.448636 369.128 
+L 192.658766 369.128 
+L 192.658766 123.579977 
+L 178.448636 123.579977 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 192.658766 369.128 
+L 206.868896 369.128 
+L 206.868896 199.990698 
+L 192.658766 199.990698 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 206.868896 369.128 
+L 221.079026 369.128 
+L 221.079026 253.838057 
+L 206.868896 253.838057 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 221.079026 369.128 
+L 235.289156 369.128 
+L 235.289156 269.672276 
+L 221.079026 269.672276 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 263.709416 369.128 
+L 277.919545 369.128 
+L 277.919545 123.635275 
+L 263.709416 123.635275 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 277.919545 369.128 
+L 292.129675 369.128 
+L 292.129675 199.485439 
+L 277.919545 199.485439 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 292.129675 369.128 
+L 306.339805 369.128 
+L 306.339805 252.34442 
+L 292.129675 252.34442 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 306.339805 369.128 
+L 320.549935 369.128 
+L 320.549935 266.978265 
+L 306.339805 266.978265 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 348.970195 369.128 
+L 363.180325 369.128 
+L 363.180325 124.41462 
+L 348.970195 124.41462 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 363.180325 369.128 
+L 377.390455 369.128 
+L 377.390455 197.735656 
+L 363.180325 197.735656 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 377.390455 369.128 
+L 391.600584 369.128 
+L 391.600584 248.947244 
+L 377.390455 248.947244 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 391.600584 369.128 
+L 405.810714 369.128 
+L 405.810714 264.558194 
+L 391.600584 264.558194 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 434.230974 369.128 
+L 448.441104 369.128 
+L 448.441104 123.115191 
+L 434.230974 123.115191 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 448.441104 369.128 
+L 462.651234 369.128 
+L 462.651234 198.90643 
+L 448.441104 198.90643 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 462.651234 369.128 
+L 476.861364 369.128 
+L 476.861364 251.809866 
+L 462.651234 251.809866 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 476.861364 369.128 
+L 491.071494 369.128 
+L 491.071494 266.995385 
+L 476.861364 266.995385 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 519.491753 369.128 
+L 533.701883 369.128 
+L 533.701883 124.384494 
+L 519.491753 124.384494 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 533.701883 369.128 
+L 547.912013 369.128 
+L 547.912013 196.069617 
+L 533.701883 196.069617 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 547.912013 369.128 
+L 562.122143 369.128 
+L 562.122143 249.041196 
+L 547.912013 249.041196 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 562.122143 369.128 
+L 576.332273 369.128 
+L 576.332273 264.567439 
+L 562.122143 264.567439 
+z
+" clip-path="url(#p64b0d6694f)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_23">
+    <!-- 117 ms -->
+    <g transform="translate(103.052297 118.895186) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 81.1 ms (x 1.45) -->
+    <g transform="translate(117.262427 194.370368) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 55.1 ms (x 2.14) -->
+    <g transform="translate(131.472557 248.688486) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 47.5 ms (x 2.48) -->
+    <g transform="translate(145.682687 264.601138) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- 117 ms -->
+    <g transform="translate(188.313076 118.579977) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 80.8 ms (x 1.46) -->
+    <g transform="translate(202.523206 194.990698) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 55.1 ms (x 2.14) -->
+    <g transform="translate(216.733336 248.838057) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 47.5 ms (x 2.48) -->
+    <g transform="translate(230.943466 264.672276) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 117 ms -->
+    <g transform="translate(273.573856 118.635275) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 81.0 ms (x 1.44) -->
+    <g transform="translate(287.783985 194.485439) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- 55.8 ms (x 2.10) -->
+    <g transform="translate(301.994115 247.34442) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 48.8 ms (x 2.40) -->
+    <g transform="translate(316.204245 261.978265) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 117 ms -->
+    <g transform="translate(358.834635 119.41462) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 81.8 ms (x 1.44) -->
+    <g transform="translate(373.044765 192.735656) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- 57.4 ms (x 2.05) -->
+    <g transform="translate(387.254894 243.947244) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-30" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- 49.9 ms (x 2.36) -->
+    <g transform="translate(401.465024 259.558194) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1091,512 +1778,9 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_17">
-    <!-- 134 ms -->
-    <g transform="translate(178.982232 117.48943) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 132 ms -->
-    <g transform="translate(263.275219 121.143891) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 134 ms -->
-    <g transform="translate(347.568206 118.812646) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 133 ms -->
-    <g transform="translate(431.861193 120.262046) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 133 ms -->
-    <g transform="translate(516.15418 119.943867) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_13">
-    <path d="M 98.954286 369.128 
-L 113.003117 369.128 
-L 113.003117 127.397312 
-L 98.954286 127.397312 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 113.003117 369.128 
-L 127.051948 369.128 
-L 127.051948 208.842394 
-L 113.003117 208.842394 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 127.051948 369.128 
-L 141.100779 369.128 
-L 141.100779 257.723843 
-L 127.051948 257.723843 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 141.100779 369.128 
-L 155.14961 369.128 
-L 155.14961 273.522369 
-L 141.100779 273.522369 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 183.247273 369.128 
-L 197.296104 369.128 
-L 197.296104 122.195821 
-L 183.247273 122.195821 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 197.296104 369.128 
-L 211.344935 369.128 
-L 211.344935 207.028445 
-L 197.296104 207.028445 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 211.344935 369.128 
-L 225.393766 369.128 
-L 225.393766 257.340494 
-L 211.344935 257.340494 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 225.393766 369.128 
-L 239.442597 369.128 
-L 239.442597 273.36274 
-L 225.393766 273.36274 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 267.54026 369.128 
-L 281.589091 369.128 
-L 281.589091 126.364875 
-L 267.54026 126.364875 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_22">
-    <path d="M 281.589091 369.128 
-L 295.637922 369.128 
-L 295.637922 205.487023 
-L 281.589091 205.487023 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_23">
-    <path d="M 295.637922 369.128 
-L 309.686753 369.128 
-L 309.686753 257.157642 
-L 295.637922 257.157642 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 309.686753 369.128 
-L 323.735584 369.128 
-L 323.735584 271.828328 
-L 309.686753 271.828328 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 351.833247 369.128 
-L 365.882078 369.128 
-L 365.882078 126.038469 
-L 351.833247 126.038469 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 365.882078 369.128 
-L 379.930909 369.128 
-L 379.930909 205.728859 
-L 365.882078 205.728859 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 379.930909 369.128 
-L 393.97974 369.128 
-L 393.97974 256.803376 
-L 379.930909 256.803376 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 393.97974 369.128 
-L 408.028571 369.128 
-L 408.028571 272.594693 
-L 393.97974 272.594693 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_29">
-    <path d="M 436.126234 369.128 
-L 450.175065 369.128 
-L 450.175065 128.783682 
-L 436.126234 128.783682 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_30">
-    <path d="M 450.175065 369.128 
-L 464.223896 369.128 
-L 464.223896 209.335399 
-L 450.175065 209.335399 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_31">
-    <path d="M 464.223896 369.128 
-L 478.272727 369.128 
-L 478.272727 256.102669 
-L 464.223896 256.102669 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_32">
-    <path d="M 478.272727 369.128 
-L 492.321558 369.128 
-L 492.321558 271.547191 
-L 478.272727 271.547191 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_33">
-    <path d="M 520.419221 369.128 
-L 534.468052 369.128 
-L 534.468052 125.202657 
-L 520.419221 125.202657 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_34">
-    <path d="M 534.468052 369.128 
-L 548.516883 369.128 
-L 548.516883 205.684416 
-L 534.468052 205.684416 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_35">
-    <path d="M 548.516883 369.128 
-L 562.565714 369.128 
-L 562.565714 257.202462 
-L 548.516883 257.202462 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_36">
-    <path d="M 562.565714 369.128 
-L 576.614545 369.128 
-L 576.614545 272.252027 
-L 562.565714 272.252027 
-z
-" clip-path="url(#pb5d3fbc335)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_22">
-    <!-- 132 ms -->
-    <g transform="translate(108.738076 122.397312) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 87.3 ms (x 1.53) -->
-    <g transform="translate(122.786907 203.842394) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 60.7 ms (x 2.20) -->
-    <g transform="translate(136.835739 252.723843) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-32" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 52.1 ms (x 2.56) -->
-    <g transform="translate(150.88457 268.522369) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 135 ms -->
-    <g transform="translate(193.031063 117.195821) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 88.3 ms (x 1.52) -->
-    <g transform="translate(207.079894 202.028445) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 60.9 ms (x 2.21) -->
-    <g transform="translate(221.128726 252.340494) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-39" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1608,50 +1792,29 @@ z
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-32" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_29">
-    <!-- 52.2 ms (x 2.58) -->
-    <g transform="translate(235.177557 268.36274) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 132 ms -->
-    <g transform="translate(277.32405 121.364875) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_39">
+    <!-- 117 ms -->
+    <g transform="translate(444.095414 118.115191) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- 89.2 ms (x 1.48) -->
-    <g transform="translate(291.372881 200.487023) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_40">
+    <!-- 81.3 ms (x 1.45) -->
+    <g transform="translate(458.305544 193.90643) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1662,186 +1825,17 @@ z
      <use xlink:href="#DejaVuSans-31" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 61.0 ms (x 2.17) -->
-    <g transform="translate(305.421713 252.157642) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- 53.0 ms (x 2.50) -->
-    <g transform="translate(319.470544 266.828328) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- 132 ms -->
-    <g transform="translate(361.617037 121.038469) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 89.0 ms (x 1.50) -->
-    <g transform="translate(375.665869 200.728859) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 61.2 ms (x 2.18) -->
-    <g transform="translate(389.7147 251.803376) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- 52.6 ms (x 2.54) -->
-    <g transform="translate(403.763531 267.594693) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- 131 ms -->
-    <g transform="translate(445.910024 123.783682) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- 87.1 ms (x 1.53) -->
-    <g transform="translate(459.958856 204.335399) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- 61.6 ms (x 2.16) -->
-    <g transform="translate(474.007687 251.102669) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- 53.2 ms (x 2.50) -->
-    <g transform="translate(488.056518 266.547191) rotate(-90) scale(0.1 -0.1)">
+    <!-- 56.0 ms (x 2.10) -->
+    <g transform="translate(472.515674 246.809866) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1851,69 +1845,16 @@ z
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
      <use xlink:href="#DejaVuSans-30" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
    <g id="text_42">
-    <!-- 133 ms -->
-    <g transform="translate(530.203011 120.202657) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- 89.0 ms (x 1.49) -->
-    <g transform="translate(544.251843 200.684416) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-39" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_44">
-    <!-- 61.0 ms (x 2.18) -->
-    <g transform="translate(558.300674 252.202462) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_45">
-    <!-- 52.8 ms (x 2.52) -->
-    <g transform="translate(572.349505 267.252027) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+    <!-- 48.8 ms (x 2.41) -->
+    <g transform="translate(486.725804 261.995385) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-38" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1925,182 +1866,256 @@ z
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- 117 ms -->
+    <g transform="translate(529.356193 119.384494) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_44">
+    <!-- 82.6 ms (x 1.42) -->
+    <g transform="translate(543.566323 191.069617) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
      <use xlink:href="#DejaVuSans-32" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
+   <g id="text_45">
+    <!-- 57.3 ms (x 2.04) -->
+    <g transform="translate(557.776453 244.041196) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-30" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
    <g id="text_46">
-    <!--  1 -->
-    <g transform="translate(101.208389 367.048313) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    <!-- 49.9 ms (x 2.35) -->
+    <g transform="translate(571.986583 259.567439) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
    <g id="text_47">
-    <!--  2 -->
-    <g transform="translate(115.25722 367.048313) scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(95.52261 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_48">
-    <!--  4 -->
-    <g transform="translate(129.306051 367.048313) scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(109.732739 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_49">
-    <!--  6 -->
-    <g transform="translate(143.354882 367.048313) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(123.942869 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_50">
-    <!--  1 -->
-    <g transform="translate(185.501376 367.048313) scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(138.152999 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_51">
-    <!--  2 -->
-    <g transform="translate(199.550207 367.048313) scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(180.783389 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_52">
-    <!--  4 -->
-    <g transform="translate(213.599038 367.048313) scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(194.993519 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_53">
-    <!--  6 -->
-    <g transform="translate(227.647869 367.048313) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(209.203649 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_54">
-    <!--  1 -->
-    <g transform="translate(269.794363 367.048313) scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(223.413778 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_55">
-    <!--  2 -->
-    <g transform="translate(283.843194 367.048313) scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(266.044168 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_56">
-    <!--  4 -->
-    <g transform="translate(297.892025 367.048313) scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(280.254298 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_57">
-    <!--  6 -->
-    <g transform="translate(311.940856 367.048313) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(294.464428 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_58">
-    <!--  1 -->
-    <g transform="translate(354.08735 367.048313) scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(308.674558 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_59">
-    <!--  2 -->
-    <g transform="translate(368.136181 367.048313) scale(0.1 -0.1)">
+    <!--  1 -->
+    <g transform="translate(351.304947 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
    <g id="text_60">
-    <!--  4 -->
-    <g transform="translate(382.185012 367.048313) scale(0.1 -0.1)">
+    <!--  2 -->
+    <g transform="translate(365.515077 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
    <g id="text_61">
-    <!--  6 -->
-    <g transform="translate(396.233843 367.048313) scale(0.1 -0.1)">
+    <!--  4 -->
+    <g transform="translate(379.725207 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
    <g id="text_62">
-    <!--  1 -->
-    <g transform="translate(438.380337 367.048313) scale(0.1 -0.1)">
+    <!--  6 -->
+    <g transform="translate(393.935337 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
    <g id="text_63">
-    <!--  2 -->
-    <g transform="translate(452.429168 367.048313) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_64">
-    <!--  4 -->
-    <g transform="translate(466.477999 367.048313) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_65">
-    <!--  6 -->
-    <g transform="translate(480.52683 367.048313) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-20"/>
-     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
-    </g>
-   </g>
-   <g id="text_66">
     <!--  1 -->
-    <g transform="translate(522.673324 367.048313) scale(0.1 -0.1)">
+    <g transform="translate(436.565726 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-31" x="31.787109"/>
     </g>
    </g>
-   <g id="text_67">
+   <g id="text_64">
     <!--  2 -->
-    <g transform="translate(536.722155 367.048313) scale(0.1 -0.1)">
+    <g transform="translate(450.775856 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-32" x="31.787109"/>
     </g>
    </g>
-   <g id="text_68">
+   <g id="text_65">
     <!--  4 -->
-    <g transform="translate(550.770986 367.048313) scale(0.1 -0.1)">
+    <g transform="translate(464.985986 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-34" x="31.787109"/>
     </g>
    </g>
-   <g id="text_69">
+   <g id="text_66">
     <!--  6 -->
-    <g transform="translate(564.819817 367.048313) scale(0.1 -0.1)">
+    <g transform="translate(479.196116 367.048313) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-20"/>
      <use xlink:href="#DejaVuSans-36" x="31.787109"/>
     </g>
    </g>
+   <g id="text_67">
+    <!--  1 -->
+    <g transform="translate(521.826506 367.048313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-31" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_68">
+    <!--  2 -->
+    <g transform="translate(536.036636 367.048313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-32" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_69">
+    <!--  4 -->
+    <g transform="translate(550.246765 367.048313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-34" x="31.787109"/>
+    </g>
+   </g>
    <g id="text_70">
+    <!--  6 -->
+    <g transform="translate(564.456895 367.048313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-36" x="31.787109"/>
+    </g>
+   </g>
+   <g id="text_71">
     <!-- filled simple n=1000 -->
-    <g transform="translate(268.4275 20.88) scale(0.12 -0.12)">
+    <g transform="translate(265.3225 20.88) scale(0.12 -0.12)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -2193,7 +2208,7 @@ L 371.71875 36.478437
 z
 " style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_71">
+    <g id="text_72">
      <!-- serial no mask -->
      <g transform="translate(399.71875 43.478437) scale(0.1 -0.1)">
       <defs>
@@ -2255,7 +2270,7 @@ L 371.71875 57.795312
 z
 " style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
     </g>
-    <g id="text_72">
+    <g id="text_73">
      <!-- threaded no mask -->
      <g transform="translate(399.71875 58.156562) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-74"/>
@@ -2338,8 +2353,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pb5d3fbc335">
-   <rect x="60.32" y="26.88" width="540.88" height="342.248"/>
+  <clipPath id="p64b0d6694f">
+   <rect x="54.11" y="26.88" width="547.09" height="342.248"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/_static/threaded_lines_random_dark.svg
+++ b/docs/_static/threaded_lines_random_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:09.798103</dc:date>
+    <dc:date>2024-05-06T19:15:05.307915</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="maeea4a9e0b" d="M 0 0 
+       <path id="m2852af0950" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#maeea4a9e0b" x="116.254357" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2852af0950" x="116.254357" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -223,7 +223,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#maeea4a9e0b" x="220.357179" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2852af0950" x="220.357179" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -320,7 +320,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#maeea4a9e0b" x="324.46" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2852af0950" x="324.46" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -502,7 +502,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#maeea4a9e0b" x="428.562821" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2852af0950" x="428.562821" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -614,7 +614,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#maeea4a9e0b" x="532.665643" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m2852af0950" x="532.665643" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -666,16 +666,16 @@ z
      <g id="line2d_6">
       <path d="M 47.72 380.792 
 L 601.2 380.792 
-" clip-path="url(#p73dc130f04)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="ma90ca7df4f" d="M 0 0 
+       <path id="ma36857ec7b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma90ca7df4f" x="47.72" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma36857ec7b" x="47.72" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -719,18 +719,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_8">
-      <path d="M 47.72 331.293818 
-L 601.2 331.293818 
-" clip-path="url(#p73dc130f04)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 330.233143 
+L 601.2 330.233143 
+" clip-path="url(#p2f32ed5e08)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#ma90ca7df4f" x="47.72" y="331.293818" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma36857ec7b" x="47.72" y="330.233143" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.2 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 335.093037) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 334.032362) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -765,18 +765,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_10">
-      <path d="M 47.72 281.795636 
-L 601.2 281.795636 
-" clip-path="url(#p73dc130f04)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 279.674286 
+L 601.2 279.674286 
+" clip-path="url(#p2f32ed5e08)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#ma90ca7df4f" x="47.72" y="281.795636" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma36857ec7b" x="47.72" y="279.674286" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.4 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 285.594855) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 283.473504) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -806,18 +806,18 @@ z
     </g>
     <g id="ytick_4">
      <g id="line2d_12">
-      <path d="M 47.72 232.297455 
-L 601.2 232.297455 
-" clip-path="url(#p73dc130f04)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 229.115429 
+L 601.2 229.115429 
+" clip-path="url(#p2f32ed5e08)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#ma90ca7df4f" x="47.72" y="232.297455" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma36857ec7b" x="47.72" y="229.115429" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.6 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 236.096673) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 232.914647) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -858,18 +858,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_14">
-      <path d="M 47.72 182.799273 
-L 601.2 182.799273 
-" clip-path="url(#p73dc130f04)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 178.556571 
+L 601.2 178.556571 
+" clip-path="url(#p2f32ed5e08)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#ma90ca7df4f" x="47.72" y="182.799273" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma36857ec7b" x="47.72" y="178.556571" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.8 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 186.598491) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 182.35579) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -919,18 +919,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_16">
-      <path d="M 47.72 133.301091 
-L 601.2 133.301091 
-" clip-path="url(#p73dc130f04)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 127.997714 
+L 601.2 127.997714 
+" clip-path="url(#p2f32ed5e08)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#ma90ca7df4f" x="47.72" y="133.301091" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma36857ec7b" x="47.72" y="127.997714" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.0 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 137.10031) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 131.796933) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -955,18 +955,18 @@ z
     </g>
     <g id="ytick_7">
      <g id="line2d_18">
-      <path d="M 47.72 83.802909 
-L 601.2 83.802909 
-" clip-path="url(#p73dc130f04)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 77.438857 
+L 601.2 77.438857 
+" clip-path="url(#p2f32ed5e08)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#ma90ca7df4f" x="47.72" y="83.802909" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma36857ec7b" x="47.72" y="77.438857" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.2 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 87.602128) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 81.238076) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -975,18 +975,18 @@ L 601.2 83.802909
     </g>
     <g id="ytick_8">
      <g id="line2d_20">
-      <path d="M 47.72 34.304727 
-L 601.2 34.304727 
-" clip-path="url(#p73dc130f04)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 26.88 
+L 601.2 26.88 
+" clip-path="url(#p2f32ed5e08)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#ma90ca7df4f" x="47.72" y="34.304727" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#ma36857ec7b" x="47.72" y="26.88" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.4 -->
-      <g style="fill: #ffffff" transform="translate(24.816875 38.103946) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.816875 30.679219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -1097,138 +1097,46 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 72.878182 380.792 
 L 90.228652 380.792 
-L 90.228652 169.083402 
-L 72.878182 169.083402 
+L 90.228652 169.127807 
+L 72.878182 169.127807 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 176.981003 380.792 
 L 194.331473 380.792 
-L 194.331473 74.00737 
-L 176.981003 74.00737 
+L 194.331473 74.728487 
+L 176.981003 74.728487 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 281.083824 380.792 
 L 298.434295 380.792 
-L 298.434295 244.953088 
-L 281.083824 244.953088 
+L 298.434295 246.967525 
+L 281.083824 246.967525 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 385.186646 380.792 
 L 402.537116 380.792 
-L 402.537116 248.749249 
-L 385.186646 248.749249 
+L 402.537116 248.370683 
+L 385.186646 248.370683 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 489.289467 380.792 
 L 506.639937 380.792 
-L 506.639937 245.09308 
-L 489.289467 245.09308 
+L 506.639937 247.099142 
+L 489.289467 247.099142 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_15">
-    <!-- 855 ms -->
-    <g style="fill: #ffffff" transform="translate(84.312792 164.083402) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_16">
-    <!-- 1.24 s -->
-    <g style="fill: #ffffff" transform="translate(188.415613 69.00737) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_17">
-    <!-- 549 ms -->
-    <g style="fill: #ffffff" transform="translate(292.518435 239.953088) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 534 ms -->
-    <g style="fill: #ffffff" transform="translate(396.621256 243.749249) rotate(-90) scale(0.1 -0.1)">
+    <!-- 837 ms -->
+    <g style="fill: #ffffff" transform="translate(84.312792 164.127807) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1262,9 +1170,109 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 1.21 s -->
+    <g style="fill: #ffffff" transform="translate(188.415613 69.728487) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 529 ms -->
+    <g style="fill: #ffffff" transform="translate(292.518435 241.967525) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 524 ms -->
+    <g style="fill: #ffffff" transform="translate(396.621256 243.370683) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1272,11 +1280,11 @@ z
     </g>
    </g>
    <g id="text_19">
-    <!-- 548 ms -->
-    <g style="fill: #ffffff" transform="translate(500.724077 240.09308) rotate(-90) scale(0.1 -0.1)">
+    <!-- 529 ms -->
+    <g style="fill: #ffffff" transform="translate(500.724077 242.099142) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1285,177 +1293,177 @@ z
    <g id="patch_12">
     <path d="M 90.228652 380.792 
 L 107.579122 380.792 
-L 107.579122 166.037852 
-L 90.228652 166.037852 
+L 107.579122 166.596699 
+L 90.228652 166.596699 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 107.579122 380.792 
 L 124.929592 380.792 
-L 124.929592 251.891161 
-L 107.579122 251.891161 
+L 124.929592 249.726549 
+L 107.579122 249.726549 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 124.929592 380.792 
 L 142.280063 380.792 
-L 142.280063 275.479891 
-L 124.929592 275.479891 
+L 142.280063 266.721405 
+L 124.929592 266.721405 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 142.280063 380.792 
 L 159.630533 380.792 
-L 159.630533 278.684765 
-L 142.280063 278.684765 
+L 159.630533 269.281638 
+L 142.280063 269.281638 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 194.331473 380.792 
 L 211.681944 380.792 
-L 211.681944 74.842448 
-L 194.331473 74.842448 
+L 211.681944 73.460172 
+L 194.331473 73.460172 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 211.681944 380.792 
 L 229.032414 380.792 
-L 229.032414 173.024486 
-L 211.681944 173.024486 
+L 229.032414 163.615624 
+L 211.681944 163.615624 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 229.032414 380.792 
 L 246.382884 380.792 
-L 246.382884 189.589383 
-L 229.032414 189.589383 
+L 246.382884 170.991784 
+L 229.032414 170.991784 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 246.382884 380.792 
 L 263.733354 380.792 
-L 263.733354 192.775358 
-L 246.382884 192.775358 
+L 263.733354 173.362063 
+L 246.382884 173.362063 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 298.434295 380.792 
 L 315.784765 380.792 
-L 315.784765 243.827768 
-L 298.434295 243.827768 
+L 315.784765 245.66658 
+L 298.434295 245.66658 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 315.784765 380.792 
 L 333.135235 380.792 
-L 333.135235 311.018731 
-L 315.784765 311.018731 
+L 333.135235 308.611195 
+L 315.784765 308.611195 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 333.135235 380.792 
 L 350.485705 380.792 
-L 350.485705 341.196392 
-L 333.135235 341.196392 
+L 350.485705 339.825481 
+L 333.135235 339.825481 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 350.485705 380.792 
 L 367.836176 380.792 
-L 367.836176 349.879627 
-L 350.485705 349.879627 
+L 367.836176 349.089331 
+L 350.485705 349.089331 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 402.537116 380.792 
 L 419.887586 380.792 
-L 419.887586 248.152086 
-L 402.537116 248.152086 
+L 419.887586 247.678667 
+L 402.537116 247.678667 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 419.887586 380.792 
 L 437.238056 380.792 
-L 437.238056 312.212639 
-L 419.887586 312.212639 
+L 437.238056 311.646463 
+L 419.887586 311.646463 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 437.238056 380.792 
 L 454.588527 380.792 
-L 454.588527 342.110307 
-L 437.238056 342.110307 
+L 454.588527 341.459062 
+L 437.238056 341.459062 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 454.588527 380.792 
 L 471.938997 380.792 
-L 471.938997 350.638271 
-L 454.588527 350.638271 
+L 471.938997 351.591892 
+L 454.588527 351.591892 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 506.639937 380.792 
 L 523.990408 380.792 
-L 523.990408 244.495675 
-L 506.639937 244.495675 
+L 523.990408 246.41166 
+L 506.639937 246.41166 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 523.990408 380.792 
 L 541.340878 380.792 
-L 541.340878 311.614689 
-L 523.990408 311.614689 
+L 541.340878 308.021789 
+L 523.990408 308.021789 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 541.340878 380.792 
 L 558.691348 380.792 
-L 558.691348 341.866603 
-L 541.340878 341.866603 
+L 558.691348 339.834925 
+L 541.340878 339.834925 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 558.691348 380.792 
 L 576.041818 380.792 
-L 576.041818 350.544003 
-L 558.691348 350.544003 
+L 576.041818 349.198028 
+L 558.691348 349.198028 
 z
-" clip-path="url(#p73dc130f04)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p2f32ed5e08)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_20">
-    <!-- 868 ms -->
-    <g style="fill: #ffffff" transform="translate(101.663262 161.037852) rotate(-90) scale(0.1 -0.1)">
+    <!-- 847 ms -->
+    <g style="fill: #ffffff" transform="translate(101.663262 161.596699) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- 521 ms (x 1.64) -->
-    <g style="fill: #ffffff" transform="translate(119.013732 246.891161) rotate(-90) scale(0.1 -0.1)">
+    <!-- 518 ms (x 1.61) -->
+    <g style="fill: #ffffff" transform="translate(119.013732 244.726549) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
@@ -1474,8 +1482,8 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1486,48 +1494,16 @@ z
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-36" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 426 ms (x 2.01) -->
-    <g style="fill: #ffffff" transform="translate(136.364203 270.479891) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-32" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-30" x="629.345703"/>
      <use xlink:href="#DejaVuSans-31" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_23">
-    <!-- 413 ms (x 2.07) -->
-    <g style="fill: #ffffff" transform="translate(153.714673 273.684765) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+   <g id="text_22">
+    <!-- 451 ms (x 1.86) -->
+    <g style="fill: #ffffff" transform="translate(136.364203 261.721405) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1535,30 +1511,90 @@ z
      <use xlink:href="#DejaVuSans-28" x="403.955078"/>
      <use xlink:href="#DejaVuSans-78" x="442.96875"/>
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-32" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 441 ms (x 1.90) -->
+    <g style="fill: #ffffff" transform="translate(153.714673 264.281638) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-30" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 1.24 s -->
-    <g style="fill: #ffffff" transform="translate(205.766083 69.842448) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.22 s -->
+    <g style="fill: #ffffff" transform="translate(205.766083 68.460172) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 839 ms (x 1.48) -->
-    <g style="fill: #ffffff" transform="translate(223.116554 168.024486) rotate(-90) scale(0.1 -0.1)">
+    <!-- 859 ms (x 1.41) -->
+    <g style="fill: #ffffff" transform="translate(223.116554 158.615624) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 830 ms (x 1.46) -->
+    <g style="fill: #ffffff" transform="translate(240.467024 165.991784) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- 821 ms (x 1.48) -->
+    <g style="fill: #ffffff" transform="translate(257.817494 168.362063) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1573,63 +1609,23 @@ z
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- 773 ms (x 1.60) -->
-    <g style="fill: #ffffff" transform="translate(240.467024 184.589383) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-36" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-30" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 760 ms (x 1.63) -->
-    <g style="fill: #ffffff" transform="translate(257.817494 187.775358) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-36" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
    <g id="text_28">
-    <!-- 553 ms -->
-    <g style="fill: #ffffff" transform="translate(309.868905 238.827768) rotate(-90) scale(0.1 -0.1)">
+    <!-- 535 ms -->
+    <g style="fill: #ffffff" transform="translate(309.868905 240.66658) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 282 ms (x 1.95) -->
-    <g style="fill: #ffffff" transform="translate(327.219375 306.018731) rotate(-90) scale(0.1 -0.1)">
+    <!-- 286 ms (x 1.85) -->
+    <g style="fill: #ffffff" transform="translate(327.219375 303.611195) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1639,17 +1635,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
      <use xlink:href="#DejaVuSans-35" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 160 ms (x 3.43) -->
-    <g style="fill: #ffffff" transform="translate(344.569845 336.196392) rotate(-90) scale(0.1 -0.1)">
+    <!-- 162 ms (x 3.27) -->
+    <g style="fill: #ffffff" transform="translate(344.569845 334.825481) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1659,14 +1655,14 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 125 ms (x 4.39) -->
-    <g style="fill: #ffffff" transform="translate(361.920315 344.879627) rotate(-90) scale(0.1 -0.1)">
+    <!-- 125 ms (x 4.22) -->
+    <g style="fill: #ffffff" transform="translate(361.920315 344.089331) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
@@ -1679,28 +1675,28 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-34" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-33" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 536 ms -->
-    <g style="fill: #ffffff" transform="translate(413.971726 243.152086) rotate(-90) scale(0.1 -0.1)">
+    <!-- 527 ms -->
+    <g style="fill: #ffffff" transform="translate(413.971726 242.678667) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 277 ms (x 1.93) -->
-    <g style="fill: #ffffff" transform="translate(431.322196 307.212639) rotate(-90) scale(0.1 -0.1)">
+    <!-- 274 ms (x 1.92) -->
+    <g style="fill: #ffffff" transform="translate(431.322196 306.646463) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1711,13 +1707,13 @@ z
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 156 ms (x 3.41) -->
-    <g style="fill: #ffffff" transform="translate(448.672667 337.110307) rotate(-90) scale(0.1 -0.1)">
+    <!-- 156 ms (x 3.37) -->
+    <g style="fill: #ffffff" transform="translate(448.672667 336.459062) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="127.246094"/>
@@ -1730,17 +1726,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-33" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 122 ms (x 4.38) -->
-    <g style="fill: #ffffff" transform="translate(466.023137 345.638271) rotate(-90) scale(0.1 -0.1)">
+    <!-- 116 ms (x 4.53) -->
+    <g style="fill: #ffffff" transform="translate(466.023137 346.591892) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1750,28 +1746,28 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-34" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-33" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-38" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-35" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 551 ms -->
-    <g style="fill: #ffffff" transform="translate(518.074547 239.495675) rotate(-90) scale(0.1 -0.1)">
+    <!-- 532 ms -->
+    <g style="fill: #ffffff" transform="translate(518.074547 241.41166) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 280 ms (x 1.96) -->
-    <g style="fill: #ffffff" transform="translate(535.425018 306.614689) rotate(-90) scale(0.1 -0.1)">
+    <!-- 288 ms (x 1.84) -->
+    <g style="fill: #ffffff" transform="translate(535.425018 303.021789) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1781,17 +1777,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 157 ms (x 3.49) -->
-    <g style="fill: #ffffff" transform="translate(552.775488 336.866603) rotate(-90) scale(0.1 -0.1)">
+    <!-- 162 ms (x 3.26) -->
+    <g style="fill: #ffffff" transform="translate(552.775488 334.834925) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1801,17 +1797,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 122 ms (x 4.49) -->
-    <g style="fill: #ffffff" transform="translate(570.125958 345.544003) rotate(-90) scale(0.1 -0.1)">
+    <!-- 125 ms (x 4.23) -->
+    <g style="fill: #ffffff" transform="translate(570.125958 344.198028) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1821,8 +1817,8 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-34" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
@@ -2144,7 +2140,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p73dc130f04">
+  <clipPath id="p2f32ed5e08">
    <rect x="47.72" y="26.88" width="553.48" height="353.912"/>
   </clipPath>
  </defs>

--- a/docs/_static/threaded_lines_random_light.svg
+++ b/docs/_static/threaded_lines_random_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:09.607336</dc:date>
+    <dc:date>2024-05-06T19:15:05.117428</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="maeeb61b813" d="M 0 0 
+       <path id="m48765240cb" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#maeeb61b813" x="116.254357" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48765240cb" x="116.254357" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -223,7 +223,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#maeeb61b813" x="220.357179" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48765240cb" x="220.357179" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -320,7 +320,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#maeeb61b813" x="324.46" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48765240cb" x="324.46" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -502,7 +502,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#maeeb61b813" x="428.562821" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48765240cb" x="428.562821" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -614,7 +614,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#maeeb61b813" x="532.665643" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48765240cb" x="532.665643" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -666,16 +666,16 @@ z
      <g id="line2d_6">
       <path d="M 47.72 380.792 
 L 601.2 380.792 
-" clip-path="url(#pabcc9c31f3)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pc28d0783bd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="m66a98efc32" d="M 0 0 
+       <path id="m5d4e8bdc64" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m66a98efc32" x="47.72" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d4e8bdc64" x="47.72" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -719,18 +719,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_8">
-      <path d="M 47.72 331.293818 
-L 601.2 331.293818 
-" clip-path="url(#pabcc9c31f3)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 330.233143 
+L 601.2 330.233143 
+" clip-path="url(#pc28d0783bd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m66a98efc32" x="47.72" y="331.293818" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d4e8bdc64" x="47.72" y="330.233143" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.2 -->
-      <g transform="translate(24.816875 335.093037) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 334.032362) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -765,18 +765,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_10">
-      <path d="M 47.72 281.795636 
-L 601.2 281.795636 
-" clip-path="url(#pabcc9c31f3)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 279.674286 
+L 601.2 279.674286 
+" clip-path="url(#pc28d0783bd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m66a98efc32" x="47.72" y="281.795636" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d4e8bdc64" x="47.72" y="279.674286" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.4 -->
-      <g transform="translate(24.816875 285.594855) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 283.473504) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -806,18 +806,18 @@ z
     </g>
     <g id="ytick_4">
      <g id="line2d_12">
-      <path d="M 47.72 232.297455 
-L 601.2 232.297455 
-" clip-path="url(#pabcc9c31f3)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 229.115429 
+L 601.2 229.115429 
+" clip-path="url(#pc28d0783bd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m66a98efc32" x="47.72" y="232.297455" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d4e8bdc64" x="47.72" y="229.115429" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.6 -->
-      <g transform="translate(24.816875 236.096673) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 232.914647) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -858,18 +858,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_14">
-      <path d="M 47.72 182.799273 
-L 601.2 182.799273 
-" clip-path="url(#pabcc9c31f3)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 178.556571 
+L 601.2 178.556571 
+" clip-path="url(#pc28d0783bd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m66a98efc32" x="47.72" y="182.799273" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d4e8bdc64" x="47.72" y="178.556571" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.8 -->
-      <g transform="translate(24.816875 186.598491) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 182.35579) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -919,18 +919,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_16">
-      <path d="M 47.72 133.301091 
-L 601.2 133.301091 
-" clip-path="url(#pabcc9c31f3)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 127.997714 
+L 601.2 127.997714 
+" clip-path="url(#pc28d0783bd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m66a98efc32" x="47.72" y="133.301091" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d4e8bdc64" x="47.72" y="127.997714" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1.0 -->
-      <g transform="translate(24.816875 137.10031) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 131.796933) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -955,18 +955,18 @@ z
     </g>
     <g id="ytick_7">
      <g id="line2d_18">
-      <path d="M 47.72 83.802909 
-L 601.2 83.802909 
-" clip-path="url(#pabcc9c31f3)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 77.438857 
+L 601.2 77.438857 
+" clip-path="url(#pc28d0783bd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m66a98efc32" x="47.72" y="83.802909" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d4e8bdc64" x="47.72" y="77.438857" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.2 -->
-      <g transform="translate(24.816875 87.602128) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 81.238076) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -975,18 +975,18 @@ L 601.2 83.802909
     </g>
     <g id="ytick_8">
      <g id="line2d_20">
-      <path d="M 47.72 34.304727 
-L 601.2 34.304727 
-" clip-path="url(#pabcc9c31f3)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 47.72 26.88 
+L 601.2 26.88 
+" clip-path="url(#pc28d0783bd)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m66a98efc32" x="47.72" y="34.304727" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d4e8bdc64" x="47.72" y="26.88" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.4 -->
-      <g transform="translate(24.816875 38.103946) scale(0.1 -0.1)">
+      <g transform="translate(24.816875 30.679219) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -1097,138 +1097,46 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 72.878182 380.792 
 L 90.228652 380.792 
-L 90.228652 169.083402 
-L 72.878182 169.083402 
+L 90.228652 169.127807 
+L 72.878182 169.127807 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 176.981003 380.792 
 L 194.331473 380.792 
-L 194.331473 74.00737 
-L 176.981003 74.00737 
+L 194.331473 74.728487 
+L 176.981003 74.728487 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 281.083824 380.792 
 L 298.434295 380.792 
-L 298.434295 244.953088 
-L 281.083824 244.953088 
+L 298.434295 246.967525 
+L 281.083824 246.967525 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 385.186646 380.792 
 L 402.537116 380.792 
-L 402.537116 248.749249 
-L 385.186646 248.749249 
+L 402.537116 248.370683 
+L 385.186646 248.370683 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 489.289467 380.792 
 L 506.639937 380.792 
-L 506.639937 245.09308 
-L 489.289467 245.09308 
+L 506.639937 247.099142 
+L 489.289467 247.099142 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_15">
-    <!-- 855 ms -->
-    <g transform="translate(84.312792 164.083402) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_16">
-    <!-- 1.24 s -->
-    <g transform="translate(188.415613 69.00737) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
-    </g>
-   </g>
-   <g id="text_17">
-    <!-- 549 ms -->
-    <g transform="translate(292.518435 239.953088) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 534 ms -->
-    <g transform="translate(396.621256 243.749249) rotate(-90) scale(0.1 -0.1)">
+    <!-- 837 ms -->
+    <g transform="translate(84.312792 164.127807) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1262,9 +1170,109 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 1.21 s -->
+    <g transform="translate(188.415613 69.728487) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="254.443359"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 529 ms -->
+    <g transform="translate(292.518435 241.967525) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 524 ms -->
+    <g transform="translate(396.621256 243.370683) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
@@ -1272,11 +1280,11 @@ z
     </g>
    </g>
    <g id="text_19">
-    <!-- 548 ms -->
-    <g transform="translate(500.724077 240.09308) rotate(-90) scale(0.1 -0.1)">
+    <!-- 529 ms -->
+    <g transform="translate(500.724077 242.099142) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1285,177 +1293,177 @@ z
    <g id="patch_12">
     <path d="M 90.228652 380.792 
 L 107.579122 380.792 
-L 107.579122 166.037852 
-L 90.228652 166.037852 
+L 107.579122 166.596699 
+L 90.228652 166.596699 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 107.579122 380.792 
 L 124.929592 380.792 
-L 124.929592 251.891161 
-L 107.579122 251.891161 
+L 124.929592 249.726549 
+L 107.579122 249.726549 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 124.929592 380.792 
 L 142.280063 380.792 
-L 142.280063 275.479891 
-L 124.929592 275.479891 
+L 142.280063 266.721405 
+L 124.929592 266.721405 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 142.280063 380.792 
 L 159.630533 380.792 
-L 159.630533 278.684765 
-L 142.280063 278.684765 
+L 159.630533 269.281638 
+L 142.280063 269.281638 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 194.331473 380.792 
 L 211.681944 380.792 
-L 211.681944 74.842448 
-L 194.331473 74.842448 
+L 211.681944 73.460172 
+L 194.331473 73.460172 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 211.681944 380.792 
 L 229.032414 380.792 
-L 229.032414 173.024486 
-L 211.681944 173.024486 
+L 229.032414 163.615624 
+L 211.681944 163.615624 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 229.032414 380.792 
 L 246.382884 380.792 
-L 246.382884 189.589383 
-L 229.032414 189.589383 
+L 246.382884 170.991784 
+L 229.032414 170.991784 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 246.382884 380.792 
 L 263.733354 380.792 
-L 263.733354 192.775358 
-L 246.382884 192.775358 
+L 263.733354 173.362063 
+L 246.382884 173.362063 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 298.434295 380.792 
 L 315.784765 380.792 
-L 315.784765 243.827768 
-L 298.434295 243.827768 
+L 315.784765 245.66658 
+L 298.434295 245.66658 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 315.784765 380.792 
 L 333.135235 380.792 
-L 333.135235 311.018731 
-L 315.784765 311.018731 
+L 333.135235 308.611195 
+L 315.784765 308.611195 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 333.135235 380.792 
 L 350.485705 380.792 
-L 350.485705 341.196392 
-L 333.135235 341.196392 
+L 350.485705 339.825481 
+L 333.135235 339.825481 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
     <path d="M 350.485705 380.792 
 L 367.836176 380.792 
-L 367.836176 349.879627 
-L 350.485705 349.879627 
+L 367.836176 349.089331 
+L 350.485705 349.089331 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
     <path d="M 402.537116 380.792 
 L 419.887586 380.792 
-L 419.887586 248.152086 
-L 402.537116 248.152086 
+L 419.887586 247.678667 
+L 402.537116 247.678667 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
     <path d="M 419.887586 380.792 
 L 437.238056 380.792 
-L 437.238056 312.212639 
-L 419.887586 312.212639 
+L 437.238056 311.646463 
+L 419.887586 311.646463 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 437.238056 380.792 
 L 454.588527 380.792 
-L 454.588527 342.110307 
-L 437.238056 342.110307 
+L 454.588527 341.459062 
+L 437.238056 341.459062 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 454.588527 380.792 
 L 471.938997 380.792 
-L 471.938997 350.638271 
-L 454.588527 350.638271 
+L 471.938997 351.591892 
+L 454.588527 351.591892 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 506.639937 380.792 
 L 523.990408 380.792 
-L 523.990408 244.495675 
-L 506.639937 244.495675 
+L 523.990408 246.41166 
+L 506.639937 246.41166 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 523.990408 380.792 
 L 541.340878 380.792 
-L 541.340878 311.614689 
-L 523.990408 311.614689 
+L 541.340878 308.021789 
+L 523.990408 308.021789 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 541.340878 380.792 
 L 558.691348 380.792 
-L 558.691348 341.866603 
-L 541.340878 341.866603 
+L 558.691348 339.834925 
+L 541.340878 339.834925 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 558.691348 380.792 
 L 576.041818 380.792 
-L 576.041818 350.544003 
-L 558.691348 350.544003 
+L 576.041818 349.198028 
+L 558.691348 349.198028 
 z
-" clip-path="url(#pabcc9c31f3)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#pc28d0783bd)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_20">
-    <!-- 868 ms -->
-    <g transform="translate(101.663262 161.037852) rotate(-90) scale(0.1 -0.1)">
+    <!-- 847 ms -->
+    <g transform="translate(101.663262 161.596699) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- 521 ms (x 1.64) -->
-    <g transform="translate(119.013732 246.891161) rotate(-90) scale(0.1 -0.1)">
+    <!-- 518 ms (x 1.61) -->
+    <g transform="translate(119.013732 244.726549) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
@@ -1474,8 +1482,8 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1486,48 +1494,16 @@ z
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-36" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 426 ms (x 2.01) -->
-    <g transform="translate(136.364203 270.479891) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-32" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-30" x="629.345703"/>
      <use xlink:href="#DejaVuSans-31" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_23">
-    <!-- 413 ms (x 2.07) -->
-    <g transform="translate(153.714673 273.684765) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+   <g id="text_22">
+    <!-- 451 ms (x 1.86) -->
+    <g transform="translate(136.364203 261.721405) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1535,30 +1511,90 @@ z
      <use xlink:href="#DejaVuSans-28" x="403.955078"/>
      <use xlink:href="#DejaVuSans-78" x="442.96875"/>
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-32" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-30" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 441 ms (x 1.90) -->
+    <g transform="translate(153.714673 264.281638) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-30" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 1.24 s -->
-    <g transform="translate(205.766083 69.842448) rotate(-90) scale(0.1 -0.1)">
+    <!-- 1.22 s -->
+    <g transform="translate(205.766083 68.460172) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
      <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="254.443359"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- 839 ms (x 1.48) -->
-    <g transform="translate(223.116554 168.024486) rotate(-90) scale(0.1 -0.1)">
+    <!-- 859 ms (x 1.41) -->
+    <g transform="translate(223.116554 158.615624) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 830 ms (x 1.46) -->
+    <g transform="translate(240.467024 165.991784) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
+     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
+     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
+     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
+     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- 821 ms (x 1.48) -->
+    <g transform="translate(257.817494 168.362063) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1573,63 +1609,23 @@ z
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- 773 ms (x 1.60) -->
-    <g transform="translate(240.467024 184.589383) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-36" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-30" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 760 ms (x 1.63) -->
-    <g transform="translate(257.817494 187.775358) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-     <use xlink:href="#DejaVuSans-20" x="372.167969"/>
-     <use xlink:href="#DejaVuSans-28" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-78" x="442.96875"/>
-     <use xlink:href="#DejaVuSans-20" x="502.148438"/>
-     <use xlink:href="#DejaVuSans-31" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-36" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
-     <use xlink:href="#DejaVuSans-29" x="756.591797"/>
-    </g>
-   </g>
    <g id="text_28">
-    <!-- 553 ms -->
-    <g transform="translate(309.868905 238.827768) rotate(-90) scale(0.1 -0.1)">
+    <!-- 535 ms -->
+    <g transform="translate(309.868905 240.66658) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-33" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- 282 ms (x 1.95) -->
-    <g transform="translate(327.219375 306.018731) rotate(-90) scale(0.1 -0.1)">
+    <!-- 286 ms (x 1.85) -->
+    <g transform="translate(327.219375 303.611195) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1639,17 +1635,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
      <use xlink:href="#DejaVuSans-35" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 160 ms (x 3.43) -->
-    <g transform="translate(344.569845 336.196392) rotate(-90) scale(0.1 -0.1)">
+    <!-- 162 ms (x 3.27) -->
+    <g transform="translate(344.569845 334.825481) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1659,14 +1655,14 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- 125 ms (x 4.39) -->
-    <g transform="translate(361.920315 344.879627) rotate(-90) scale(0.1 -0.1)">
+    <!-- 125 ms (x 4.22) -->
+    <g transform="translate(361.920315 344.089331) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-35" x="127.246094"/>
@@ -1679,28 +1675,28 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-34" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-33" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 536 ms -->
-    <g transform="translate(413.971726 243.152086) rotate(-90) scale(0.1 -0.1)">
+    <!-- 527 ms -->
+    <g transform="translate(413.971726 242.678667) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- 277 ms (x 1.93) -->
-    <g transform="translate(431.322196 307.212639) rotate(-90) scale(0.1 -0.1)">
+    <!-- 274 ms (x 1.92) -->
+    <g transform="translate(431.322196 306.646463) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1711,13 +1707,13 @@ z
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
      <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- 156 ms (x 3.41) -->
-    <g transform="translate(448.672667 337.110307) rotate(-90) scale(0.1 -0.1)">
+    <!-- 156 ms (x 3.37) -->
+    <g transform="translate(448.672667 336.459062) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" x="63.623047"/>
      <use xlink:href="#DejaVuSans-36" x="127.246094"/>
@@ -1730,17 +1726,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-33" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-37" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 122 ms (x 4.38) -->
-    <g transform="translate(466.023137 345.638271) rotate(-90) scale(0.1 -0.1)">
+    <!-- 116 ms (x 4.53) -->
+    <g transform="translate(466.023137 346.591892) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1750,28 +1746,28 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-34" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-33" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-38" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-35" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 551 ms -->
-    <g transform="translate(518.074547 239.495675) rotate(-90) scale(0.1 -0.1)">
+    <!-- 532 ms -->
+    <g transform="translate(518.074547 241.41166) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- 280 ms (x 1.96) -->
-    <g transform="translate(535.425018 306.614689) rotate(-90) scale(0.1 -0.1)">
+    <!-- 288 ms (x 1.84) -->
+    <g transform="translate(535.425018 303.021789) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1781,17 +1777,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-31" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-39" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-38" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- 157 ms (x 3.49) -->
-    <g transform="translate(552.775488 336.866603) rotate(-90) scale(0.1 -0.1)">
+    <!-- 162 ms (x 3.26) -->
+    <g transform="translate(552.775488 334.834925) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-37" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1801,17 +1797,17 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-33" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-36" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- 122 ms (x 4.49) -->
-    <g transform="translate(570.125958 345.544003) rotate(-90) scale(0.1 -0.1)">
+    <!-- 125 ms (x 4.23) -->
+    <g transform="translate(570.125958 344.198028) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
@@ -1821,8 +1817,8 @@ z
      <use xlink:href="#DejaVuSans-20" x="502.148438"/>
      <use xlink:href="#DejaVuSans-34" x="533.935547"/>
      <use xlink:href="#DejaVuSans-2e" x="597.558594"/>
-     <use xlink:href="#DejaVuSans-34" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-39" x="692.96875"/>
+     <use xlink:href="#DejaVuSans-32" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="692.96875"/>
      <use xlink:href="#DejaVuSans-29" x="756.591797"/>
     </g>
    </g>
@@ -2144,7 +2140,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pabcc9c31f3">
+  <clipPath id="pc28d0783bd">
    <rect x="47.72" y="26.88" width="553.48" height="353.912"/>
   </clipPath>
  </defs>

--- a/docs/_static/threaded_lines_simple_dark.svg
+++ b/docs/_static/threaded_lines_simple_dark.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:09.414346</dc:date>
+    <dc:date>2024-05-06T19:15:04.926866</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m80ec35309a" d="M 0 0 
+       <path id="m46d8918914" d="M 0 0 
 L 0 3.5 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m80ec35309a" x="121.853119" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m46d8918914" x="121.853119" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -223,7 +223,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m80ec35309a" x="224.75406" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m46d8918914" x="224.75406" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -320,7 +320,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m80ec35309a" x="327.655" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m46d8918914" x="327.655" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -502,7 +502,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m80ec35309a" x="430.55594" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m46d8918914" x="430.55594" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -614,7 +614,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m80ec35309a" x="533.456881" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m46d8918914" x="533.456881" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -666,16 +666,16 @@ z
      <g id="line2d_6">
       <path d="M 54.11 380.792 
 L 601.2 380.792 
-" clip-path="url(#pd53bf57171)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p77d5188fa9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="m006a6680b4" d="M 0 0 
+       <path id="mc22caa6b2b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m006a6680b4" x="54.11" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mc22caa6b2b" x="54.11" y="380.792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -720,18 +720,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_8">
-      <path d="M 54.11 341.410235 
-L 601.2 341.410235 
-" clip-path="url(#pd53bf57171)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 338.466884 
+L 601.2 338.466884 
+" clip-path="url(#p77d5188fa9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m006a6680b4" x="54.11" y="341.410235" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mc22caa6b2b" x="54.11" y="338.466884" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.02 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 345.209454) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.844375 342.266103) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -767,18 +767,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_10">
-      <path d="M 54.11 302.02847 
-L 601.2 302.02847 
-" clip-path="url(#pd53bf57171)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 296.141768 
+L 601.2 296.141768 
+" clip-path="url(#p77d5188fa9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m006a6680b4" x="54.11" y="302.02847" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mc22caa6b2b" x="54.11" y="296.141768" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.04 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 305.827689) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.844375 299.940986) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -809,18 +809,18 @@ z
     </g>
     <g id="ytick_4">
      <g id="line2d_12">
-      <path d="M 54.11 262.646705 
-L 601.2 262.646705 
-" clip-path="url(#pd53bf57171)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 253.816652 
+L 601.2 253.816652 
+" clip-path="url(#p77d5188fa9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m006a6680b4" x="54.11" y="262.646705" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mc22caa6b2b" x="54.11" y="253.816652" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.06 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 266.445924) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.844375 257.61587) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -862,18 +862,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_14">
-      <path d="M 54.11 223.26494 
-L 601.2 223.26494 
-" clip-path="url(#pd53bf57171)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 211.491535 
+L 601.2 211.491535 
+" clip-path="url(#p77d5188fa9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m006a6680b4" x="54.11" y="223.26494" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mc22caa6b2b" x="54.11" y="211.491535" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.08 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 227.064159) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.844375 215.290754) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -924,18 +924,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_16">
-      <path d="M 54.11 183.883175 
-L 601.2 183.883175 
-" clip-path="url(#pd53bf57171)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 169.166419 
+L 601.2 169.166419 
+" clip-path="url(#p77d5188fa9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m006a6680b4" x="54.11" y="183.883175" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mc22caa6b2b" x="54.11" y="169.166419" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.10 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 187.682394) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.844375 172.965638) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -961,18 +961,18 @@ z
     </g>
     <g id="ytick_7">
      <g id="line2d_18">
-      <path d="M 54.11 144.50141 
-L 601.2 144.50141 
-" clip-path="url(#pd53bf57171)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 126.841303 
+L 601.2 126.841303 
+" clip-path="url(#p77d5188fa9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m006a6680b4" x="54.11" y="144.50141" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mc22caa6b2b" x="54.11" y="126.841303" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.12 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 148.300629) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.844375 130.640522) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -982,18 +982,18 @@ L 601.2 144.50141
     </g>
     <g id="ytick_8">
      <g id="line2d_20">
-      <path d="M 54.11 105.119645 
-L 601.2 105.119645 
-" clip-path="url(#pd53bf57171)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 84.516187 
+L 601.2 84.516187 
+" clip-path="url(#p77d5188fa9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m006a6680b4" x="54.11" y="105.119645" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mc22caa6b2b" x="54.11" y="84.516187" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.14 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 108.918864) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.844375 88.315406) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1003,18 +1003,18 @@ L 601.2 105.119645
     </g>
     <g id="ytick_9">
      <g id="line2d_22">
-      <path d="M 54.11 65.737881 
-L 601.2 65.737881 
-" clip-path="url(#pd53bf57171)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 42.191071 
+L 601.2 42.191071 
+" clip-path="url(#p77d5188fa9)" style="fill: none; stroke: #ffffff; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m006a6680b4" x="54.11" y="65.737881" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mc22caa6b2b" x="54.11" y="42.191071" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.16 -->
-      <g style="fill: #ffffff" transform="translate(24.844375 69.537099) scale(0.1 -0.1)">
+      <g style="fill: #ffffff" transform="translate(24.844375 45.990289) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1126,288 +1126,68 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 78.977727 380.792 
 L 96.127884 380.792 
-L 96.127884 133.8019 
-L 78.977727 133.8019 
+L 96.127884 125.697893 
+L 78.977727 125.697893 
 z
-" clip-path="url(#pd53bf57171)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p77d5188fa9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 181.878668 380.792 
 L 199.028824 380.792 
-L 199.028824 133.286294 
-L 181.878668 133.286294 
+L 199.028824 127.381008 
+L 181.878668 127.381008 
 z
-" clip-path="url(#pd53bf57171)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p77d5188fa9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 284.779608 380.792 
 L 301.929765 380.792 
-L 301.929765 135.994164 
-L 284.779608 135.994164 
+L 301.929765 128.064588 
+L 284.779608 128.064588 
 z
-" clip-path="url(#pd53bf57171)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p77d5188fa9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 387.680549 380.792 
 L 404.830705 380.792 
-L 404.830705 135.206753 
-L 387.680549 135.206753 
+L 404.830705 127.635964 
+L 387.680549 127.635964 
 z
-" clip-path="url(#pd53bf57171)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p77d5188fa9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 490.581489 380.792 
 L 507.731646 380.792 
-L 507.731646 136.209894 
-L 490.581489 136.209894 
+L 507.731646 125.444237 
+L 490.581489 125.444237 
 z
-" clip-path="url(#pd53bf57171)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p77d5188fa9)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_16">
-    <!-- 125 ms -->
-    <g style="fill: #ffffff" transform="translate(90.312181 128.8019) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 121 ms -->
+    <g style="fill: #ffffff" transform="translate(90.312181 120.697893) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_17">
-    <!-- 126 ms -->
-    <g style="fill: #ffffff" transform="translate(193.213121 128.286294) rotate(-90) scale(0.1 -0.1)">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(193.213121 122.381008) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_18">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(296.114062 130.994164) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 125 ms -->
-    <g style="fill: #ffffff" transform="translate(399.015002 130.206753) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 124 ms -->
-    <g style="fill: #ffffff" transform="translate(501.915942 131.209894) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_12">
-    <path d="M 96.127884 380.792 
-L 113.278041 380.792 
-L 113.278041 126.565173 
-L 96.127884 126.565173 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 113.278041 380.792 
-L 130.428197 380.792 
-L 130.428197 209.635739 
-L 113.278041 209.635739 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 130.428197 380.792 
-L 147.578354 380.792 
-L 147.578354 263.132013 
-L 130.428197 263.132013 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 147.578354 380.792 
-L 164.728511 380.792 
-L 164.728511 282.420805 
-L 147.578354 282.420805 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 199.028824 380.792 
-L 216.178981 380.792 
-L 216.178981 126.15961 
-L 199.028824 126.15961 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 216.178981 380.792 
-L 233.329138 380.792 
-L 233.329138 210.238466 
-L 216.178981 210.238466 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 233.329138 380.792 
-L 250.479295 380.792 
-L 250.479295 263.37678 
-L 233.329138 263.37678 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 250.479295 380.792 
-L 267.629451 380.792 
-L 267.629451 279.309309 
-L 250.479295 279.309309 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 301.929765 380.792 
-L 319.079922 380.792 
-L 319.079922 127.128365 
-L 301.929765 127.128365 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 319.079922 380.792 
-L 336.230078 380.792 
-L 336.230078 208.54869 
-L 319.079922 208.54869 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_22">
-    <path d="M 336.230078 380.792 
-L 353.380235 380.792 
-L 353.380235 261.53016 
-L 336.230078 261.53016 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_23">
-    <path d="M 353.380235 380.792 
-L 370.530392 380.792 
-L 370.530392 277.695566 
-L 353.380235 277.695566 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 404.830705 380.792 
-L 421.980862 380.792 
-L 421.980862 125.444237 
-L 404.830705 125.444237 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 421.980862 380.792 
-L 439.131019 380.792 
-L 439.131019 208.373586 
-L 421.980862 208.373586 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 439.131019 380.792 
-L 456.281176 380.792 
-L 456.281176 262.599601 
-L 439.131019 262.599601 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 456.281176 380.792 
-L 473.431332 380.792 
-L 473.431332 277.908068 
-L 456.281176 277.908068 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 507.731646 380.792 
-L 524.881803 380.792 
-L 524.881803 127.043915 
-L 507.731646 127.043915 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_29">
-    <path d="M 524.881803 380.792 
-L 542.031959 380.792 
-L 542.031959 209.997806 
-L 524.881803 209.997806 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_30">
-    <path d="M 542.031959 380.792 
-L 559.182116 380.792 
-L 559.182116 262.530717 
-L 542.031959 262.530717 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_31">
-    <path d="M 559.182116 380.792 
-L 576.332273 380.792 
-L 576.332273 278.924494 
-L 559.182116 278.924494 
-z
-" clip-path="url(#pd53bf57171)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 129 ms -->
-    <g style="fill: #ffffff" transform="translate(107.462337 121.565173) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(296.114062 123.064588) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1441,17 +1221,220 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
+   <g id="text_19">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(399.015002 122.635964) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 121 ms -->
+    <g style="fill: #ffffff" transform="translate(501.915942 120.444237) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_12">
+    <path d="M 96.127884 380.792 
+L 113.278041 380.792 
+L 113.278041 126.687572 
+L 96.127884 126.687572 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 113.278041 380.792 
+L 130.428197 380.792 
+L 130.428197 207.791162 
+L 113.278041 207.791162 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 130.428197 380.792 
+L 147.578354 380.792 
+L 147.578354 262.075257 
+L 130.428197 262.075257 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 147.578354 380.792 
+L 164.728511 380.792 
+L 164.728511 280.067135 
+L 147.578354 280.067135 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 199.028824 380.792 
+L 216.178981 380.792 
+L 216.178981 125.980665 
+L 199.028824 125.980665 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 216.178981 380.792 
+L 233.329138 380.792 
+L 233.329138 206.886201 
+L 216.178981 206.886201 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 233.329138 380.792 
+L 250.479295 380.792 
+L 250.479295 262.712943 
+L 233.329138 262.712943 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 250.479295 380.792 
+L 267.629451 380.792 
+L 267.629451 279.701634 
+L 250.479295 279.701634 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 301.929765 380.792 
+L 319.079922 380.792 
+L 319.079922 127.320945 
+L 301.929765 127.320945 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 319.079922 380.792 
+L 336.230078 380.792 
+L 336.230078 206.508188 
+L 319.079922 206.508188 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 336.230078 380.792 
+L 353.380235 380.792 
+L 353.380235 259.924245 
+L 336.230078 259.924245 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 353.380235 380.792 
+L 370.530392 380.792 
+L 370.530392 273.357134 
+L 353.380235 273.357134 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 404.830705 380.792 
+L 421.980862 380.792 
+L 421.980862 126.885864 
+L 404.830705 126.885864 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 421.980862 380.792 
+L 439.131019 380.792 
+L 439.131019 205.073954 
+L 421.980862 205.073954 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 439.131019 380.792 
+L 456.281176 380.792 
+L 456.281176 261.156471 
+L 439.131019 261.156471 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 456.281176 380.792 
+L 473.431332 380.792 
+L 473.431332 277.868227 
+L 456.281176 277.868227 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 507.731646 380.792 
+L 524.881803 380.792 
+L 524.881803 128.330891 
+L 507.731646 128.330891 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 524.881803 380.792 
+L 542.031959 380.792 
+L 542.031959 206.671364 
+L 524.881803 206.671364 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 542.031959 380.792 
+L 559.182116 380.792 
+L 559.182116 261.190518 
+L 542.031959 261.190518 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 559.182116 380.792 
+L 576.332273 380.792 
+L 576.332273 274.644667 
+L 559.182116 274.644667 
+z
+" clip-path="url(#p77d5188fa9)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(107.462337 121.687572) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
    <g id="text_22">
-    <!-- 86.9 ms (x 1.44) -->
-    <g style="fill: #ffffff" transform="translate(124.612494 204.635739) rotate(-90) scale(0.1 -0.1)">
+    <!-- 81.7 ms (x 1.47) -->
+    <g style="fill: #ffffff" transform="translate(124.612494 202.791162) rotate(-90) scale(0.1 -0.1)">
      <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
 L 3578 0 
@@ -1469,9 +1452,9 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1482,17 +1465,44 @@ z
      <use xlink:href="#DejaVuSans-31" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- 59.8 ms (x 2.10) -->
-    <g style="fill: #ffffff" transform="translate(141.762651 258.132013) rotate(-90) scale(0.1 -0.1)">
+    <!-- 56.1 ms (x 2.15) -->
+    <g style="fill: #ffffff" transform="translate(141.762651 257.075257) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1503,173 +1513,13 @@ z
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 50.0 ms (x 2.51) -->
-    <g style="fill: #ffffff" transform="translate(158.912808 277.420805) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 129 ms -->
-    <g style="fill: #ffffff" transform="translate(210.363278 121.15961) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 86.6 ms (x 1.45) -->
-    <g style="fill: #ffffff" transform="translate(227.513435 205.238466) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 59.6 ms (x 2.11) -->
-    <g style="fill: #ffffff" transform="translate(244.663591 258.37678) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 51.5 ms (x 2.44) -->
-    <g style="fill: #ffffff" transform="translate(261.813748 274.309309) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 129 ms -->
-    <g style="fill: #ffffff" transform="translate(313.264218 122.128365) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 87.5 ms (x 1.42) -->
-    <g style="fill: #ffffff" transform="translate(330.414375 203.54869) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 60.6 ms (x 2.05) -->
-    <g style="fill: #ffffff" transform="translate(347.564532 256.53016) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-30" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 52.4 ms (x 2.37) -->
-    <g style="fill: #ffffff" transform="translate(364.714688 272.695566) rotate(-90) scale(0.1 -0.1)">
+    <!-- 47.6 ms (x 2.53) -->
+    <g style="fill: #ffffff" transform="translate(158.912808 275.067135) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1704,39 +1554,7 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- 130 ms -->
-    <g style="fill: #ffffff" transform="translate(416.165159 120.444237) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- 87.6 ms (x 1.42) -->
-    <g style="fill: #ffffff" transform="translate(433.315315 203.373586) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-37" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-36" x="159.033203"/>
@@ -1747,38 +1565,28 @@ z
      <use xlink:href="#DejaVuSans-28" x="435.742188"/>
      <use xlink:href="#DejaVuSans-78" x="474.755859"/>
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 60.0 ms (x 2.08) -->
-    <g style="fill: #ffffff" transform="translate(450.465472 257.599601) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-30" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_36">
-    <!-- 52.2 ms (x 2.39) -->
-    <g style="fill: #ffffff" transform="translate(467.615629 272.908068) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
+   <g id="text_25">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(210.363278 120.980665) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 82.2 ms (x 1.46) -->
+    <g style="fill: #ffffff" transform="translate(227.513435 201.886201) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-32" x="159.033203"/>
@@ -1789,31 +1597,73 @@ z
      <use xlink:href="#DejaVuSans-28" x="435.742188"/>
      <use xlink:href="#DejaVuSans-78" x="474.755859"/>
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-39" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_37">
-    <!-- 129 ms -->
-    <g style="fill: #ffffff" transform="translate(519.066099 122.043915) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_27">
+    <!-- 55.8 ms (x 2.15) -->
+    <g style="fill: #ffffff" transform="translate(244.663591 257.712943) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 47.8 ms (x 2.51) -->
+    <g style="fill: #ffffff" transform="translate(261.813748 274.701634) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(313.264218 122.320945) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_38">
-    <!-- 86.7 ms (x 1.43) -->
-    <g style="fill: #ffffff" transform="translate(536.216256 204.997806) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_30">
+    <!-- 82.4 ms (x 1.45) -->
+    <g style="fill: #ffffff" transform="translate(330.414375 201.508188) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1824,15 +1674,15 @@ z
      <use xlink:href="#DejaVuSans-31" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_39">
-    <!-- 60.1 ms (x 2.07) -->
-    <g style="fill: #ffffff" transform="translate(553.366413 257.530717) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+   <g id="text_31">
+    <!-- 57.1 ms (x 2.09) -->
+    <g style="fill: #ffffff" transform="translate(347.564532 254.924245) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1845,17 +1695,91 @@ z
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-30" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-39" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_40">
-    <!-- 51.7 ms (x 2.40) -->
-    <g style="fill: #ffffff" transform="translate(570.516569 273.924494) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_32">
+    <!-- 50.8 ms (x 2.35) -->
+    <g style="fill: #ffffff" transform="translate(364.714688 268.357134) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- 120 ms -->
+    <g style="fill: #ffffff" transform="translate(416.165159 121.885864) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 83.0 ms (x 1.44) -->
+    <g style="fill: #ffffff" transform="translate(433.315315 200.073954) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 56.5 ms (x 2.12) -->
+    <g style="fill: #ffffff" transform="translate(450.465472 256.156471) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 48.6 ms (x 2.46) -->
+    <g style="fill: #ffffff" transform="translate(467.615629 272.868227) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1866,7 +1790,81 @@ z
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- 119 ms -->
+    <g style="fill: #ffffff" transform="translate(519.066099 123.330891) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- 82.3 ms (x 1.47) -->
+    <g style="fill: #ffffff" transform="translate(536.216256 201.671364) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- 56.5 ms (x 2.13) -->
+    <g style="fill: #ffffff" transform="translate(553.366413 256.190518) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- 50.2 ms (x 2.41) -->
+    <g style="fill: #ffffff" transform="translate(570.516569 269.644667) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
@@ -2188,7 +2186,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pd53bf57171">
+  <clipPath id="p77d5188fa9">
    <rect x="54.11" y="26.88" width="547.09" height="353.912"/>
   </clipPath>
  </defs>

--- a/docs/_static/threaded_lines_simple_light.svg
+++ b/docs/_static/threaded_lines_simple_light.svg
@@ -6,11 +6,11 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-10-24T11:22:09.166717</dc:date>
+    <dc:date>2024-05-06T19:15:04.734022</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.8.0, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mdc9f6d527c" d="M 0 0 
+       <path id="m897a35e247" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdc9f6d527c" x="121.853119" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m897a35e247" x="121.853119" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -223,7 +223,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mdc9f6d527c" x="224.75406" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m897a35e247" x="224.75406" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -320,7 +320,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mdc9f6d527c" x="327.655" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m897a35e247" x="327.655" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -502,7 +502,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mdc9f6d527c" x="430.55594" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m897a35e247" x="430.55594" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -614,7 +614,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mdc9f6d527c" x="533.456881" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m897a35e247" x="533.456881" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -666,16 +666,16 @@ z
      <g id="line2d_6">
       <path d="M 54.11 380.792 
 L 601.2 380.792 
-" clip-path="url(#pc9f0ebcc2e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p809bfcf258)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <defs>
-       <path id="m659817c749" d="M 0 0 
+       <path id="m3fec5d2a5c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m659817c749" x="54.11" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fec5d2a5c" x="54.11" y="380.792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -720,18 +720,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_8">
-      <path d="M 54.11 341.410235 
-L 601.2 341.410235 
-" clip-path="url(#pc9f0ebcc2e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 338.466884 
+L 601.2 338.466884 
+" clip-path="url(#p809bfcf258)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m659817c749" x="54.11" y="341.410235" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fec5d2a5c" x="54.11" y="338.466884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0.02 -->
-      <g transform="translate(24.844375 345.209454) scale(0.1 -0.1)">
+      <g transform="translate(24.844375 342.266103) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -767,18 +767,18 @@ z
     </g>
     <g id="ytick_3">
      <g id="line2d_10">
-      <path d="M 54.11 302.02847 
-L 601.2 302.02847 
-" clip-path="url(#pc9f0ebcc2e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 296.141768 
+L 601.2 296.141768 
+" clip-path="url(#p809bfcf258)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m659817c749" x="54.11" y="302.02847" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fec5d2a5c" x="54.11" y="296.141768" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0.04 -->
-      <g transform="translate(24.844375 305.827689) scale(0.1 -0.1)">
+      <g transform="translate(24.844375 299.940986) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -809,18 +809,18 @@ z
     </g>
     <g id="ytick_4">
      <g id="line2d_12">
-      <path d="M 54.11 262.646705 
-L 601.2 262.646705 
-" clip-path="url(#pc9f0ebcc2e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 253.816652 
+L 601.2 253.816652 
+" clip-path="url(#p809bfcf258)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m659817c749" x="54.11" y="262.646705" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fec5d2a5c" x="54.11" y="253.816652" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 0.06 -->
-      <g transform="translate(24.844375 266.445924) scale(0.1 -0.1)">
+      <g transform="translate(24.844375 257.61587) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -862,18 +862,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_14">
-      <path d="M 54.11 223.26494 
-L 601.2 223.26494 
-" clip-path="url(#pc9f0ebcc2e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 211.491535 
+L 601.2 211.491535 
+" clip-path="url(#p809bfcf258)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m659817c749" x="54.11" y="223.26494" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fec5d2a5c" x="54.11" y="211.491535" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.08 -->
-      <g transform="translate(24.844375 227.064159) scale(0.1 -0.1)">
+      <g transform="translate(24.844375 215.290754) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -924,18 +924,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_16">
-      <path d="M 54.11 183.883175 
-L 601.2 183.883175 
-" clip-path="url(#pc9f0ebcc2e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 169.166419 
+L 601.2 169.166419 
+" clip-path="url(#p809bfcf258)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m659817c749" x="54.11" y="183.883175" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fec5d2a5c" x="54.11" y="169.166419" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.10 -->
-      <g transform="translate(24.844375 187.682394) scale(0.1 -0.1)">
+      <g transform="translate(24.844375 172.965638) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -961,18 +961,18 @@ z
     </g>
     <g id="ytick_7">
      <g id="line2d_18">
-      <path d="M 54.11 144.50141 
-L 601.2 144.50141 
-" clip-path="url(#pc9f0ebcc2e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 126.841303 
+L 601.2 126.841303 
+" clip-path="url(#p809bfcf258)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m659817c749" x="54.11" y="144.50141" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fec5d2a5c" x="54.11" y="126.841303" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 0.12 -->
-      <g transform="translate(24.844375 148.300629) scale(0.1 -0.1)">
+      <g transform="translate(24.844375 130.640522) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -982,18 +982,18 @@ L 601.2 144.50141
     </g>
     <g id="ytick_8">
      <g id="line2d_20">
-      <path d="M 54.11 105.119645 
-L 601.2 105.119645 
-" clip-path="url(#pc9f0ebcc2e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 84.516187 
+L 601.2 84.516187 
+" clip-path="url(#p809bfcf258)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m659817c749" x="54.11" y="105.119645" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fec5d2a5c" x="54.11" y="84.516187" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 0.14 -->
-      <g transform="translate(24.844375 108.918864) scale(0.1 -0.1)">
+      <g transform="translate(24.844375 88.315406) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1003,18 +1003,18 @@ L 601.2 105.119645
     </g>
     <g id="ytick_9">
      <g id="line2d_22">
-      <path d="M 54.11 65.737881 
-L 601.2 65.737881 
-" clip-path="url(#pc9f0ebcc2e)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 54.11 42.191071 
+L 601.2 42.191071 
+" clip-path="url(#p809bfcf258)" style="fill: none; stroke: #000000; stroke-opacity: 0.2; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m659817c749" x="54.11" y="65.737881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fec5d2a5c" x="54.11" y="42.191071" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 0.16 -->
-      <g transform="translate(24.844375 69.537099) scale(0.1 -0.1)">
+      <g transform="translate(24.844375 45.990289) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-31" x="95.410156"/>
@@ -1126,288 +1126,68 @@ L 601.2 26.88
    <g id="patch_7">
     <path d="M 78.977727 380.792 
 L 96.127884 380.792 
-L 96.127884 133.8019 
-L 78.977727 133.8019 
+L 96.127884 125.697893 
+L 78.977727 125.697893 
 z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p809bfcf258)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 181.878668 380.792 
 L 199.028824 380.792 
-L 199.028824 133.286294 
-L 181.878668 133.286294 
+L 199.028824 127.381008 
+L 181.878668 127.381008 
 z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p809bfcf258)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 284.779608 380.792 
 L 301.929765 380.792 
-L 301.929765 135.994164 
-L 284.779608 135.994164 
+L 301.929765 128.064588 
+L 284.779608 128.064588 
 z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p809bfcf258)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 387.680549 380.792 
 L 404.830705 380.792 
-L 404.830705 135.206753 
-L 387.680549 135.206753 
+L 404.830705 127.635964 
+L 387.680549 127.635964 
 z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p809bfcf258)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 490.581489 380.792 
 L 507.731646 380.792 
-L 507.731646 136.209894 
-L 490.581489 136.209894 
+L 507.731646 125.444237 
+L 490.581489 125.444237 
 z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+" clip-path="url(#p809bfcf258)" style="fill: #77aadd; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_16">
-    <!-- 125 ms -->
-    <g transform="translate(90.312181 128.8019) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 121 ms -->
+    <g transform="translate(90.312181 120.697893) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_17">
-    <!-- 126 ms -->
-    <g transform="translate(193.213121 128.286294) rotate(-90) scale(0.1 -0.1)">
+    <!-- 120 ms -->
+    <g transform="translate(193.213121 122.381008) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
    <g id="text_18">
-    <!-- 124 ms -->
-    <g transform="translate(296.114062 130.994164) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 125 ms -->
-    <g transform="translate(399.015002 130.206753) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-35" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 124 ms -->
-    <g transform="translate(501.915942 131.209894) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-34" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="patch_12">
-    <path d="M 96.127884 380.792 
-L 113.278041 380.792 
-L 113.278041 126.565173 
-L 96.127884 126.565173 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_13">
-    <path d="M 113.278041 380.792 
-L 130.428197 380.792 
-L 130.428197 209.635739 
-L 113.278041 209.635739 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_14">
-    <path d="M 130.428197 380.792 
-L 147.578354 380.792 
-L 147.578354 263.132013 
-L 130.428197 263.132013 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_15">
-    <path d="M 147.578354 380.792 
-L 164.728511 380.792 
-L 164.728511 282.420805 
-L 147.578354 282.420805 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_16">
-    <path d="M 199.028824 380.792 
-L 216.178981 380.792 
-L 216.178981 126.15961 
-L 199.028824 126.15961 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_17">
-    <path d="M 216.178981 380.792 
-L 233.329138 380.792 
-L 233.329138 210.238466 
-L 216.178981 210.238466 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_18">
-    <path d="M 233.329138 380.792 
-L 250.479295 380.792 
-L 250.479295 263.37678 
-L 233.329138 263.37678 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_19">
-    <path d="M 250.479295 380.792 
-L 267.629451 380.792 
-L 267.629451 279.309309 
-L 250.479295 279.309309 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_20">
-    <path d="M 301.929765 380.792 
-L 319.079922 380.792 
-L 319.079922 127.128365 
-L 301.929765 127.128365 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_21">
-    <path d="M 319.079922 380.792 
-L 336.230078 380.792 
-L 336.230078 208.54869 
-L 319.079922 208.54869 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_22">
-    <path d="M 336.230078 380.792 
-L 353.380235 380.792 
-L 353.380235 261.53016 
-L 336.230078 261.53016 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_23">
-    <path d="M 353.380235 380.792 
-L 370.530392 380.792 
-L 370.530392 277.695566 
-L 353.380235 277.695566 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_24">
-    <path d="M 404.830705 380.792 
-L 421.980862 380.792 
-L 421.980862 125.444237 
-L 404.830705 125.444237 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_25">
-    <path d="M 421.980862 380.792 
-L 439.131019 380.792 
-L 439.131019 208.373586 
-L 421.980862 208.373586 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 439.131019 380.792 
-L 456.281176 380.792 
-L 456.281176 262.599601 
-L 439.131019 262.599601 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 456.281176 380.792 
-L 473.431332 380.792 
-L 473.431332 277.908068 
-L 456.281176 277.908068 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 507.731646 380.792 
-L 524.881803 380.792 
-L 524.881803 127.043915 
-L 507.731646 127.043915 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_29">
-    <path d="M 524.881803 380.792 
-L 542.031959 380.792 
-L 542.031959 209.997806 
-L 524.881803 209.997806 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_30">
-    <path d="M 542.031959 380.792 
-L 559.182116 380.792 
-L 559.182116 262.530717 
-L 542.031959 262.530717 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_31">
-    <path d="M 559.182116 380.792 
-L 576.332273 380.792 
-L 576.332273 278.924494 
-L 559.182116 278.924494 
-z
-" clip-path="url(#pc9f0ebcc2e)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_21">
-    <!-- 129 ms -->
-    <g transform="translate(107.462337 121.565173) rotate(-90) scale(0.1 -0.1)">
+    <!-- 119 ms -->
+    <g transform="translate(296.114062 123.064588) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1441,17 +1221,220 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-39" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
+   <g id="text_19">
+    <!-- 120 ms -->
+    <g transform="translate(399.015002 122.635964) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 121 ms -->
+    <g transform="translate(501.915942 120.444237) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="patch_12">
+    <path d="M 96.127884 380.792 
+L 113.278041 380.792 
+L 113.278041 126.687572 
+L 96.127884 126.687572 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 113.278041 380.792 
+L 130.428197 380.792 
+L 130.428197 207.791162 
+L 113.278041 207.791162 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 130.428197 380.792 
+L 147.578354 380.792 
+L 147.578354 262.075257 
+L 130.428197 262.075257 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 147.578354 380.792 
+L 164.728511 380.792 
+L 164.728511 280.067135 
+L 147.578354 280.067135 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 199.028824 380.792 
+L 216.178981 380.792 
+L 216.178981 125.980665 
+L 199.028824 125.980665 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 216.178981 380.792 
+L 233.329138 380.792 
+L 233.329138 206.886201 
+L 216.178981 206.886201 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 233.329138 380.792 
+L 250.479295 380.792 
+L 250.479295 262.712943 
+L 233.329138 262.712943 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 250.479295 380.792 
+L 267.629451 380.792 
+L 267.629451 279.701634 
+L 250.479295 279.701634 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 301.929765 380.792 
+L 319.079922 380.792 
+L 319.079922 127.320945 
+L 301.929765 127.320945 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 319.079922 380.792 
+L 336.230078 380.792 
+L 336.230078 206.508188 
+L 319.079922 206.508188 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 336.230078 380.792 
+L 353.380235 380.792 
+L 353.380235 259.924245 
+L 336.230078 259.924245 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 353.380235 380.792 
+L 370.530392 380.792 
+L 370.530392 273.357134 
+L 353.380235 273.357134 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 404.830705 380.792 
+L 421.980862 380.792 
+L 421.980862 126.885864 
+L 404.830705 126.885864 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 421.980862 380.792 
+L 439.131019 380.792 
+L 439.131019 205.073954 
+L 421.980862 205.073954 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 439.131019 380.792 
+L 456.281176 380.792 
+L 456.281176 261.156471 
+L 439.131019 261.156471 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 456.281176 380.792 
+L 473.431332 380.792 
+L 473.431332 277.868227 
+L 456.281176 277.868227 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 507.731646 380.792 
+L 524.881803 380.792 
+L 524.881803 128.330891 
+L 507.731646 128.330891 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 524.881803 380.792 
+L 542.031959 380.792 
+L 542.031959 206.671364 
+L 524.881803 206.671364 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 542.031959 380.792 
+L 559.182116 380.792 
+L 559.182116 261.190518 
+L 542.031959 261.190518 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 559.182116 380.792 
+L 576.332273 380.792 
+L 576.332273 274.644667 
+L 559.182116 274.644667 
+z
+" clip-path="url(#p809bfcf258)" style="fill: #99ddff; stroke: #222222; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 120 ms -->
+    <g transform="translate(107.462337 121.687572) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
    <g id="text_22">
-    <!-- 86.9 ms (x 1.44) -->
-    <g transform="translate(124.612494 204.635739) rotate(-90) scale(0.1 -0.1)">
+    <!-- 81.7 ms (x 1.47) -->
+    <g transform="translate(124.612494 202.791162) rotate(-90) scale(0.1 -0.1)">
      <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
 L 3578 0 
@@ -1469,9 +1452,9 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-39" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1482,17 +1465,44 @@ z
      <use xlink:href="#DejaVuSans-31" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- 59.8 ms (x 2.10) -->
-    <g transform="translate(141.762651 258.132013) rotate(-90) scale(0.1 -0.1)">
+    <!-- 56.1 ms (x 2.15) -->
+    <g transform="translate(141.762651 257.075257) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1503,173 +1513,13 @@ z
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 50.0 ms (x 2.51) -->
-    <g transform="translate(158.912808 277.420805) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 129 ms -->
-    <g transform="translate(210.363278 121.15961) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 86.6 ms (x 1.45) -->
-    <g transform="translate(227.513435 205.238466) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 59.6 ms (x 2.11) -->
-    <g transform="translate(244.663591 258.37678) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-39" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 51.5 ms (x 2.44) -->
-    <g transform="translate(261.813748 274.309309) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- 129 ms -->
-    <g transform="translate(313.264218 122.128365) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 87.5 ms (x 1.42) -->
-    <g transform="translate(330.414375 203.54869) rotate(-90) scale(0.1 -0.1)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 60.6 ms (x 2.05) -->
-    <g transform="translate(347.564532 256.53016) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-30" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 52.4 ms (x 2.37) -->
-    <g transform="translate(364.714688 272.695566) rotate(-90) scale(0.1 -0.1)">
+    <!-- 47.6 ms (x 2.53) -->
+    <g transform="translate(158.912808 275.067135) rotate(-90) scale(0.1 -0.1)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1704,39 +1554,7 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- 130 ms -->
-    <g transform="translate(416.165159 120.444237) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
-     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- 87.6 ms (x 1.42) -->
-    <g transform="translate(433.315315 203.373586) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-37" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-36" x="159.033203"/>
@@ -1747,38 +1565,28 @@ z
      <use xlink:href="#DejaVuSans-28" x="435.742188"/>
      <use xlink:href="#DejaVuSans-78" x="474.755859"/>
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
-     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
-     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 60.0 ms (x 2.08) -->
-    <g transform="translate(450.465472 257.599601) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
-     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
-     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
-     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
-     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
-     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
-     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
-     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-30" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-38" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_36">
-    <!-- 52.2 ms (x 2.39) -->
-    <g transform="translate(467.615629 272.908068) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
+   <g id="text_25">
+    <!-- 120 ms -->
+    <g transform="translate(210.363278 120.980665) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 82.2 ms (x 1.46) -->
+    <g transform="translate(227.513435 201.886201) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-32" x="159.033203"/>
@@ -1789,31 +1597,73 @@ z
      <use xlink:href="#DejaVuSans-28" x="435.742188"/>
      <use xlink:href="#DejaVuSans-78" x="474.755859"/>
      <use xlink:href="#DejaVuSans-20" x="533.935547"/>
-     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
-     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-39" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_37">
-    <!-- 129 ms -->
-    <g transform="translate(519.066099 122.043915) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_27">
+    <!-- 55.8 ms (x 2.15) -->
+    <g transform="translate(244.663591 257.712943) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 47.8 ms (x 2.51) -->
+    <g transform="translate(261.813748 274.701634) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-35" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 120 ms -->
+    <g transform="translate(313.264218 122.320945) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" x="63.623047"/>
-     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
      <use xlink:href="#DejaVuSans-20" x="190.869141"/>
      <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
      <use xlink:href="#DejaVuSans-73" x="320.068359"/>
     </g>
    </g>
-   <g id="text_38">
-    <!-- 86.7 ms (x 1.43) -->
-    <g transform="translate(536.216256 204.997806) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_30">
+    <!-- 82.4 ms (x 1.45) -->
+    <g transform="translate(330.414375 201.508188) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-34" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1824,15 +1674,15 @@ z
      <use xlink:href="#DejaVuSans-31" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_39">
-    <!-- 60.1 ms (x 2.07) -->
-    <g transform="translate(553.366413 257.530717) rotate(-90) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+   <g id="text_31">
+    <!-- 57.1 ms (x 2.09) -->
+    <g transform="translate(347.564532 254.924245) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-37" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
      <use xlink:href="#DejaVuSans-31" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
@@ -1845,17 +1695,91 @@ z
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-30" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-39" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
-   <g id="text_40">
-    <!-- 51.7 ms (x 2.40) -->
-    <g transform="translate(570.516569 273.924494) rotate(-90) scale(0.1 -0.1)">
+   <g id="text_32">
+    <!-- 50.8 ms (x 2.35) -->
+    <g transform="translate(364.714688 268.357134) rotate(-90) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
      <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
-     <use xlink:href="#DejaVuSans-37" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-38" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-33" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-35" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- 120 ms -->
+    <g transform="translate(416.165159 121.885864) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 83.0 ms (x 1.44) -->
+    <g transform="translate(433.315315 200.073954) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-34" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 56.5 ms (x 2.12) -->
+    <g transform="translate(450.465472 256.156471) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-32" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 48.6 ms (x 2.46) -->
+    <g transform="translate(467.615629 272.868227) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-36" x="159.033203"/>
      <use xlink:href="#DejaVuSans-20" x="222.65625"/>
      <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
      <use xlink:href="#DejaVuSans-73" x="351.855469"/>
@@ -1866,7 +1790,81 @@ z
      <use xlink:href="#DejaVuSans-32" x="565.722656"/>
      <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
      <use xlink:href="#DejaVuSans-34" x="661.132812"/>
-     <use xlink:href="#DejaVuSans-30" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-36" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- 119 ms -->
+    <g transform="translate(519.066099 123.330891) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-39" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+     <use xlink:href="#DejaVuSans-6d" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-73" x="320.068359"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- 82.3 ms (x 1.47) -->
+    <g transform="translate(536.216256 201.671364) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-33" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-31" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-37" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- 56.5 ms (x 2.13) -->
+    <g transform="translate(553.366413 256.190518) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-31" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-33" x="724.755859"/>
+     <use xlink:href="#DejaVuSans-29" x="788.378906"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- 50.2 ms (x 2.41) -->
+    <g transform="translate(570.516569 269.644667) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+     <use xlink:href="#DejaVuSans-32" x="159.033203"/>
+     <use xlink:href="#DejaVuSans-20" x="222.65625"/>
+     <use xlink:href="#DejaVuSans-6d" x="254.443359"/>
+     <use xlink:href="#DejaVuSans-73" x="351.855469"/>
+     <use xlink:href="#DejaVuSans-20" x="403.955078"/>
+     <use xlink:href="#DejaVuSans-28" x="435.742188"/>
+     <use xlink:href="#DejaVuSans-78" x="474.755859"/>
+     <use xlink:href="#DejaVuSans-20" x="533.935547"/>
+     <use xlink:href="#DejaVuSans-32" x="565.722656"/>
+     <use xlink:href="#DejaVuSans-2e" x="629.345703"/>
+     <use xlink:href="#DejaVuSans-34" x="661.132812"/>
+     <use xlink:href="#DejaVuSans-31" x="724.755859"/>
      <use xlink:href="#DejaVuSans-29" x="788.378906"/>
     </g>
    </g>
@@ -2188,7 +2186,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pc9f0ebcc2e">
+  <clipPath id="p809bfcf258">
    <rect x="54.11" y="26.88" width="547.09" height="353.912"/>
   </clipPath>
  </defs>

--- a/docs/benchmarks/calculation.rst
+++ b/docs/benchmarks/calculation.rst
@@ -30,8 +30,8 @@ Contour lines
    :class: only-dark
 
 For the ``simple`` dataset above the performance of :ref:`serial` for contour lines is the same
-regardless of :class:`~.LineType`. It is about 20% faster than :ref:`mpl2005` and significantly faster
-than :ref:`mpl2014` with a speedup of 1.7-1.8.
+regardless of :class:`~.LineType`. It is about the same as :ref:`mpl2005` and significantly faster
+than :ref:`mpl2014` with a speedup of 1.8-1.9.
 
 .. image:: ../_static/lines_random_1000_light.svg
    :class: only-light
@@ -49,7 +49,7 @@ thousand `NumPy`_ arrays (one per line) and a small amount is the time taken to 
 `Matplotlib`_ kind codes to put in them.
 
 The chunked line types (``LineType.ChunkCombinedCode``, ``LineType.ChunkCombinedOffset`` and
-``LineType.ChunkCombinedNan``) have similar timings with a speedup of 2.3-2.6 compared to
+``LineType.ChunkCombinedNan``) have similar timings with a speedup of 2.4-2.7 compared to
 ``LineType.SeparateCode``.  The big difference here again is in array allocation, for a single chunk
 these two ``LineType`` allocate just two large arrays whereas ``LineType.SeparateCode`` allocates
 1.7 million `NumPy`_ arrays, i.e. two per each line returned.
@@ -63,8 +63,8 @@ Filled contours
    :class: only-dark
 
 For the ``simple`` dataset above the performance of :ref:`serial` for filled contours is the same
-regardless of :class:`~.FillType`.  It it 10-20% faster than :ref:`mpl2005` and significantly
-faster than :ref:`mpl2014` with a speedup of 1.7-1.8.
+regardless of :class:`~.FillType`.  It is about the same as :ref:`mpl2005` and significantly
+faster than :ref:`mpl2014` with a speedup of 1.9-2.0.
 
 .. image:: ../_static/filled_random_1000_light.svg
    :class: only-light
@@ -73,9 +73,9 @@ faster than :ref:`mpl2014` with a speedup of 1.7-1.8.
    :class: only-dark
 
 For the ``random`` dataset above the performance of :ref:`serial` varies significantly by :class:`~.FillType`.
-For ``FillType.OuterCode`` it is faster than :ref:`mpl2014` with a speedup of 1.2-1.3.  It is also
+For ``FillType.OuterCode`` it is faster than :ref:`mpl2014` with a speedup of 1.5-1.7.  It is also
 faster than :ref:`mpl2005` but only the ``corner_mask=False`` option is shown in full as the unmasked
-benchmark here is off the scale at 11.2 seconds.  The :ref:`mpl2005` algorithm calculates points for
+benchmark here is off the scale at 11.7 seconds.  The :ref:`mpl2005` algorithm calculates points for
 outer and hole boundaries in an interleaved format which need to be reordered, and this approach
 scales badly for a large outer boundary containing many holes as occurs here for unmasked ``z``.
 
@@ -83,9 +83,9 @@ Other :class:`~.FillType` are faster, although ``FillType.OuterOffset`` is only 
 creates the same number of `NumPy`_ arrays as ``FillType.OuterCode`` but the arrays are shorter.
 
 The other four :class:`~.FillType` can be grouped in pairs: ``FillType.ChunkCombinedCodeOffset`` and
-``FillType.ChunkCombinedOffsetOffset`` have a speedup of 1.8-2 compared to
+``FillType.ChunkCombinedOffsetOffset`` have a speedup of 1.8-2.0 compared to
 ``FillType.OuterCode``; whereas ``FillType.ChunkCombinedCode`` and
-``FillType.ChunkCombinedOffset`` are marginally faster with a speedup of 1.9-2.  The speed
+``FillType.ChunkCombinedOffset`` are marginally faster with a speedup of 1.9-2.1.  The speed
 improvement has the usual explanation that they only allocate a small number of arrays whereas
 ``FillType.OuterCode`` allocates 1.7 million arrays.  ``FillType.ChunkCombinedCode`` and
 ``FillType.ChunkCombinedOffset`` are slightly faster than the other two because they do not

--- a/docs/benchmarks/index.rst
+++ b/docs/benchmarks/index.rst
@@ -24,7 +24,7 @@ the results in a web browser using:
 For further information see the ``README.md`` document in the ``benchmarks`` directory.
 
 There follows a summary of key benchmark results taken on a 6-core Intel Core i7-10750H processor
-using Python 3.10.12 and g++ 11.4.0 on Ubuntu 22.04 for commit ``75e78a87``.
+using Python 3.12.3 and g++ 13.2.0 on Ubuntu 24.04 for commit ``3064ab24``.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/benchmarks/rendering.rst
+++ b/docs/benchmarks/rendering.rst
@@ -16,7 +16,7 @@ Contour lines
 For the ``simple`` dataset above the performance of :ref:`serial` for contour lines is the same
 regardless of :class:`~.LineType`. It is slightly faster than :ref:`mpl2005` and significantly faster
 than :ref:`mpl2014` with a speedup of 1.3-1.4.  Comparing these times with the calculation-only times
-of the previous section shows that the rendering time here is only about 125 ms so there is a fairly
+of the previous section shows that the rendering time here is only about 120 ms so there is a fairly
 even split between calculation and rendering time for :ref:`serial`.
 
 .. image:: ../_static/lines_random_1000_render_light.svg
@@ -35,7 +35,7 @@ codes yourself or allow `Matplotlib`_ to generate them for you, either way is sl
 ``contourpy`` to generate them for you in C++.
 
 ``LineType.ChunkCombinedCode`` is significantly faster than ``LineType.SeparateCode`` with a speedup
-of 2-2.4.  This means that use of the :ref:`serial` algorithm with ``LineType.ChunkCombinedCode``
+of 1.9-2.2.  This means that use of the :ref:`serial` algorithm with ``LineType.ChunkCombinedCode``
 could halve the calculation and rendering time in `Matplotlib`_ for such complicated datasets.
 The benefit here is in just having two `NumPy`_ arrays per chunk, one for points and one for codes,
 which are ultimately used by `Matplotlib`_'s Agg renderer.  Compare this with
@@ -52,9 +52,9 @@ Filled contours
    :class: only-dark
 
 As usual, for the ``simple`` dataset above the performance of :ref:`serial` for filled contours is the
-same regardless of :class:`~.FillType`.  It is 10% faster than :ref:`mpl2005` and significantly faster
-than :ref:`mpl2014` with a speedup of 1.3-1.4.  As with ``lines`` the rendering time here is only
-about 125 ms so there is a fairly even split between calculation and rendering time for :ref:`serial`.
+same regardless of :class:`~.FillType`.  It is about the same as :ref:`mpl2005` and significantly faster
+than :ref:`mpl2014` with a speedup of 1.5.  As with ``lines`` the rendering time here is only
+about 110 ms so there is a fairly even split between calculation and rendering time for :ref:`serial`.
 
 .. image:: ../_static/filled_random_1000_render_light.svg
    :class: only-light
@@ -63,8 +63,8 @@ about 125 ms so there is a fairly even split between calculation and rendering t
    :class: only-dark
 
 For the ``random`` dataset above the performance of :ref:`serial` varies significantly by
-:class:`~.FillType`.  For ``FillType.OuterCode`` it is faster than :ref:`mpl2014` by about 10-15%.
-The calculation for :ref:`serial` here was about 1.8 s so the rendering takes about four times as
+:class:`~.FillType`.  For ``FillType.OuterCode`` it is faster than :ref:`mpl2014` by about 10%.
+The calculation for :ref:`serial` here was about 1.7 s so the rendering takes about four times as
 long as the calculation.
 
 Three of the other :ref:`serial` :class:`~.FillType` take longer because they either have to create
@@ -73,7 +73,7 @@ C++, or in the case of ``FillType.ChunkCombinedCodeOffset`` by breaking up the l
 codes arrays into many smaller arrays, one per polygon (outer plus holes).
 
 ``FillType.ChunkCombinedCode`` and ``FillType.ChunkCombinedOffset`` are significantly faster than
-``FillType.OuterCode`` with a speedup of 2.8-3.2 compared to :ref:`serial` and 3-3.4 compared to
+``FillType.OuterCode`` with a speedup of 2.6-3.0 compared to :ref:`serial` and 3.0-3.2 compared to
 :ref:`mpl2014`.  Again this only has to send two `NumPy`_ arrays to `Matplotlib`_ for rendering rather
 than 850 thousand pairs of them.
 

--- a/docs/benchmarks/threads.rst
+++ b/docs/benchmarks/threads.rst
@@ -17,8 +17,8 @@ of 1000 and a ``total_chunk_count`` of 40 for up to 6 threads.
    :class: only-dark
 
 For the ``simple`` dataset contour calculations are faster with more threads but it does not scale
-particularly well.  The speedup with 6 threads is 2.4-2.5 for :meth:`~.ContourGenerator.lines`
-and 2.5-2.6 for :meth:`~.ContourGenerator.filled`.  This problem dataset is perhaps not
+particularly well.  The speedup with 6 threads is 2.4-2.5 for both :meth:`~.ContourGenerator.lines`
+and :meth:`~.ContourGenerator.filled`.  This problem dataset is perhaps not
 computationally expensive enough to justify the use of multiple threads.
 
 .. image:: ../_static/threaded_lines_random_light.svg
@@ -35,7 +35,7 @@ computationally expensive enough to justify the use of multiple threads.
 
 For the ``random`` dataset contour calculations scale much better with increasing number of threads
 as long as one of the ``ChunkCombined...`` line or fill types is being used.
-Using 6 threads the speedup is 4.4 for :meth:`~.ContourGenerator.lines` and 5.1-5.2 for
+Using 6 threads the speedup is 4.2-4.5 for :meth:`~.ContourGenerator.lines` and 4.6-5.2 for
 :meth:`~.ContourGenerator.filled`.
 
 The :class:`~.LineType` and :class:`~.FillType` options that do not scale well are those that return individual


### PR DESCRIPTION
Update benchmarks for Python 3.12.3 and g++ 13.2.0 on Ubuntu 24.04, commit 3064ab24. These are the first benchmarks to use `multi_lines` and `multi_filled` but this should have negligible effect.