### PR TITLE
Include macos-14 python 3.9 CI run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,11 +96,6 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         name: ["Test"]
         short-name: ["test"]
-        exclude:
-          # M1 mac setup-python doesn't yet have python 3.9
-          # https://github.com/actions/setup-python/issues/808
-          - os: macos-14
-            python-version: "3.9"
         include:
           # Debug build including Python and C++ coverage.
           - os: ubuntu-latest


### PR DESCRIPTION
Python 3.9 is now available via the `setup-python` action on `macos-14` runners, so here completing the CI matrix.