### PR TITLE
Label flaky test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ test-no-images = [
     # Dependencies to run tests excluding image-generating tests.
     "pytest",
     "pytest-cov",
+    "pytest-rerunfailures",
     "pytest-xdist",
     "wurlitzer",
 ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,6 +35,7 @@ def test_config_filled(show_text: bool, name: str) -> None:
 
 @pytest.mark.image
 @pytest.mark.text
+@pytest.mark.flaky(reruns=1, condition=platform.python_implementation().startswith("PyPy"))
 @pytest.mark.parametrize("show_text", [False, True])
 @pytest.mark.parametrize("name", util_test.quad_as_tri_names())
 def test_config_filled_quad_as_tri(show_text: bool, name: str) -> None:


### PR DESCRIPTION
`test_config_filled_quad_as_tri` is occasionally flaky when run using PyPy in CI. AFAIR is has always passed when subsequently rerun manually. Here marking this particular as flaky for PyPy with just a single rerun allowed.