### PR TITLE
Build Python 3.13 wheels and upload to nightly wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -21,8 +21,8 @@ jobs:
     name: ${{ matrix.arch }} wheels on ${{ matrix.os }}
     if: github.repository_owner == 'contourpy'
     runs-on: ${{ matrix.os }}
-    #env:
-      #MACOSX_DEPLOYMENT_TARGET: "10.9"
+    env:
+      CIBW_PRERELEASE_PYTHONS: True
 
     strategy:
       fail-fast: false
@@ -72,7 +72,7 @@ jobs:
           rm /c/Program\ Files/Git/usr/bin/link.EXE
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.18.1
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,14 +89,19 @@ setup = [
 
 [tool.cibuildwheel]
 build-frontend = "build"
-build = "cp39-* cp310-* cp311-* cp312-* pp39-*"
+build = "cp39-* cp310-* cp311-* cp312-* cp313-* pp39-*"
 skip = "*-musllinux_ppc64le *-musllinux_s390x pp*_aarch64 pp*_ppc64le pp*_s390x"
 test-command = [
     'python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"',
     'python -c "import contourpy as c; print(c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9))"',
 ]
 # Only test combinations for which a numpy wheel exists to avoid compiling numpy from source.
-test-skip = "*-musllinux_* *_ppc64le *_s390x"
+test-skip = "*_ppc64le *_s390x cp313-*-aarch64"
+
+[[tool.cibuildwheel.overrides]]
+# For Python 3.13 install numpy from nightly wheels as not yet on PyPI.
+select = "cp313-*"
+before-test = "pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
 
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ test-command = [
     'python -c "import contourpy as c; print(c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9))"',
 ]
 # Only test combinations for which a numpy wheel exists to avoid compiling numpy from source.
-test-skip = "*_ppc64le *_s390x cp313-*-aarch64"
+test-skip = "*_ppc64le *_s390x cp313-*_aarch64"
 
 [[tool.cibuildwheel.overrides]]
 # For Python 3.13 install numpy from nightly wheels as not yet on PyPI.


### PR DESCRIPTION
Add building of Python 3.13 wheels and uploading to [Scientific Python Nightly Wheels](https://anaconda.org/scientific-python-nightly-wheels).

Using `CIBW_PRERELEASE_PYTHONS` to pick up pre-release Python 3.13, and for testing using NumPy nightly wheels. Excluding linux `aarch64` wheels (`manylinux` and `musllinux`) from tests as there are no NumPy nightly wheels for them yet.