### PR TITLE
Use multi_lines/filled in examples in docs

### DIFF
--- a/docs/user_guide/calculate/quad_as_tri.rst
+++ b/docs/user_guide/calculate/quad_as_tri.rst
@@ -46,9 +46,8 @@ semicircular.
       renderer.title(f"quad_as_tri={quad_as_tri}", ax=ax)
 
       cont_gen = contour_generator(x, y, z, quad_as_tri=quad_as_tri)
-      for i, level in enumerate(np.arange(0.5, 2.51, 0.5)):
-         lines = cont_gen.lines(level)
-         renderer.lines(lines, cont_gen.line_type, ax=ax, color=f"C{i}", linewidth=2)
+      multi_lines = cont_gen.multi_lines(np.arange(0.5, 2.51, 0.5))
+      renderer.multi_lines(multi_lines, cont_gen.line_type, ax=ax, linewidth=2)
 
       renderer.z_values(x, y, z, ax=ax, quad_as_tri=quad_as_tri, fmt="0.2f")
 
@@ -75,9 +74,8 @@ at the same ``z`` level so without ``quad_as_tri`` contour lines cut across diag
       renderer.title(f"quad_as_tri={quad_as_tri}", ax=ax)
 
       cont_gen = contour_generator(x, y, z, quad_as_tri=quad_as_tri)
-      for i, level in enumerate(np.arange(0.0, 4.0, 0.4)):
-         lines = cont_gen.lines(level)
-         renderer.lines(lines, cont_gen.line_type, ax=ax, color=f"C{i}", linewidth=2)
+      multi_lines = cont_gen.multi_lines(np.arange(0.0, 4.0, 0.4))
+      renderer.multi_lines(multi_lines, cont_gen.line_type, ax=ax, linewidth=2)
 
       renderer.z_values(x, y, z, ax=ax, quad_as_tri=quad_as_tri)
 

--- a/docs/user_guide/calculate/z_corner_mask.rst
+++ b/docs/user_guide/calculate/z_corner_mask.rst
@@ -96,11 +96,9 @@ Here is an example of the difference, the red circles indicate masked out points
 
    for ax, corner_mask in enumerate([False, True]):
        cont_gen = contour_generator(x, y, z, corner_mask=corner_mask)
-
-       for i in range(len(levels)-1):
-           filled = cont_gen.filled(levels[i], levels[i+1])
-           renderer.filled(filled, cont_gen.fill_type, ax=ax, color=f"C{i}")
-
+       multi_filled = cont_gen.multi_filled(levels)
+       renderer.multi_filled(multi_filled, cont_gen.fill_type, ax=ax)
+       
        renderer.grid(x, y, ax=ax, color="gray", alpha=0.2)
        renderer.mask(x, y, z, ax=ax, color="red")
        renderer.title(f"corner_mask = {corner_mask}", ax=ax)

--- a/docs/user_guide/calculate/z_corner_mask.rst
+++ b/docs/user_guide/calculate/z_corner_mask.rst
@@ -98,7 +98,7 @@ Here is an example of the difference, the red circles indicate masked out points
        cont_gen = contour_generator(x, y, z, corner_mask=corner_mask)
        multi_filled = cont_gen.multi_filled(levels)
        renderer.multi_filled(multi_filled, cont_gen.fill_type, ax=ax)
-       
+
        renderer.grid(x, y, ax=ax, color="gray", alpha=0.2)
        renderer.mask(x, y, z, ax=ax, color="red")
        renderer.title(f"corner_mask = {corner_mask}", ax=ax)

--- a/docs/user_guide/calculate/z_interp.rst
+++ b/docs/user_guide/calculate/z_interp.rst
@@ -66,10 +66,11 @@ as expected.
 
    for ax, z_interp in enumerate([ZInterp.Linear, ZInterp.Log]):
       renderer.grid(x, y, ax=ax, color="gray", alpha=0.2)
+
       cont_gen = contour_generator(x, y, z, z_interp=z_interp)
-      for i, level in enumerate(levels):
-          lines = cont_gen.lines(level)
-          renderer.lines(lines, cont_gen.line_type, ax=ax, color=f"C{i}", linewidth=2)
+      multi_lines = cont_gen.multi_lines(levels)
+      renderer.multi_lines(multi_lines, cont_gen.line_type, ax=ax, linewidth=2)
+
       renderer.z_values(x, y, z, ax=ax)
       renderer.title(z_interp, ax=ax)
 


### PR DESCRIPTION
Use `multi_lines` and `multi_filled` in examples in the docs in preference to loops of `lines` and `filled`.