### PR TITLE
Workaround for MSVC runtime confusion on github actions

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,11 @@ cpp_args = [
   '-DCONTOURPY_VERSION=' + version
 ]
 
+cpp = meson.get_compiler('cpp')
+if cpp.get_id() == 'msvc'
+  cpp_args += '-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR'
+endif
+
 ext = py3.extension_module(
   '_contourpy',
   [


### PR DESCRIPTION
Workaround for MSVC dll version mismatch on Windows github runners causing use of `std::mutex` (so any use of `threaded` algorithm here) to cause an access violation. See actions/runner-images#10004.