### PR TITLE
Revert MSVC runtime workaround in PR #391

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -2,11 +2,6 @@ cpp_args = [
   '-DCONTOURPY_VERSION=' + version
 ]
 
-cpp = meson.get_compiler('cpp')
-if cpp.get_id() == 'msvc'
-  cpp_args += '-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR'
-endif
-
 ext = py3.extension_module(
   '_contourpy',
   [


### PR DESCRIPTION
Revert the MSVC workaround in PR #391 as it has been fixed upstream.