### PR TITLE
Bump minimum supported numpy to 1.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
             python-version: "3.9"
             name: "Test earliest numpy"
             short-name: "test-earliest-numpy"
-            extra-install-args: "numpy==1.20"
+            extra-install-args: "numpy==1.23"
           # Compile using C++11.
           - os: ubuntu-latest
             python-version: "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "numpy >= 1.20",
+    "numpy >= 1.23",
 ]
 description = "Python library for calculating contours of 2D quadrilateral grids"
 dynamic = ["version"]


### PR DESCRIPTION
Bump minimum supported NumPy to 1.23, not quite following [SPEC0](https://scientific-python.org/specs/spec-0000/) but heading in that direction.