### PR TITLE
Pin matplotlib < 3.9.1 on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ test = [
     # Standard test dependencies.
     "contourpy[test-no-images]",
     "matplotlib",
+    "matplotlib < 3.9.1; platform_system == 'Windows'",
     "Pillow",
 ]
 test-no-images = [


### PR DESCRIPTION
CI on Windows is failing with access violations when using Matplotlib 3.9.1 for testing, but with 3.9.0 it seems to be OK. This PR therefore pins Matplotlib to < 3.9.1 on Windows to confirm this.