### PR TITLE
Do not build free-threaded wheels on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ setup = [
 [tool.cibuildwheel]
 build-frontend = "build"
 build = "cp{39,310,311,312,313,313t}-* pp{39,310}-*_{amd64,x86_64}"
-skip = "*-musllinux_{ppc64le,s390x}"
+skip = "*-musllinux_{ppc64le,s390x} cp313t-win*"
 test-requires = "pytest"
 test-command = [
     'python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"',


### PR DESCRIPTION
Do not build free-threaded wheels on Windows, see #411.