### PR TITLE
Use image tests on windows with mpl nightly wheels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,6 @@ jobs:
             name: "Nightly wheels"
             short-name: "test-nightlies"
             nightly-wheels: true
-            test-no-images: true
           # Python 3.13-dev: use numpy nightlies but no matplotlib or pillow.
           - os: ubuntu-latest
             python-version: "3.13-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ test = [
     # Standard test dependencies.
     "contourpy[test-no-images]",
     "matplotlib",
-    "matplotlib < 3.9.1; platform_system == 'Windows'",
+    #"matplotlib < 3.9.1; platform_system == 'Windows'",
     "Pillow",
 ]
 test-no-images = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ mypy = [
 test = [
     # Standard test dependencies.
     "contourpy[test-no-images]",
-    "matplotlib",
-    #"matplotlib < 3.9.1; platform_system == 'Windows'",
+    "matplotlib; platform_system != 'Windows'",
+    "matplotlib != 3.9.1; platform_system == 'Windows'",
     "Pillow",
 ]
 test-no-images = [


### PR DESCRIPTION
As part of the ongoing issue of crashes caused by matplotlib 3.9.1 (matplotlib/matplotlib#28551) here trying some experiments:

1. Re-enable Windows tests against Matplotlib 3.9.1, expecting these to fail.
2. Re-enable image tests when using Matplotlib nightly wheels. Up until yesterday these failed for me locally, today they pass so need to try to reproduce in GHA. 