### PR TITLE
Use delvewheel when building windows wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,10 @@ test-command = [
 # Only test combinations for which a numpy wheel exists to avoid compiling numpy from source.
 test-skip = "*_{ppc64le,s390x} cp313-*_aarch64"
 
+[tool.cibuildwheel.windows]
+before-all = "pip install delvewheel"
+repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
+
 [[tool.cibuildwheel.overrides]]
 # For Python 3.13 install numpy from nightly wheels as not yet on PyPI.
 select = "{cp313,cp313t,pp310}-*"

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,11 @@ cpp_args = [
   '-DCONTOURPY_VERSION=' + version
 ]
 
+cpp = meson.get_compiler('cpp')
+if cpp.get_id() == 'msvc'
+  cpp_args += '-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR'
+endif
+
 ext = py3.extension_module(
   '_contourpy',
   [


### PR DESCRIPTION
Use `delvewheel` when building wheels on Windows, as requested in matplotlib/matplotlib#28551. Also reinstated the MSCV `std::mutex` workaround of #391 as without it the test of the 64-bit wheel fails, presumably because we're packaging an 'old' version of the MSVC DLL.