### PR TITLE
Remove Windows matplotlib==3.9.1 pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,7 @@ mypy = [
 test = [
     # Standard test dependencies.
     "contourpy[test-no-images]",
-    "matplotlib; platform_system != 'Windows'",
-    "matplotlib != 3.9.1; platform_system == 'Windows'",
+    "matplotlib",
     "Pillow",
 ]
 test-no-images = [


### PR DESCRIPTION
With the release of Matplotlib 3.9.1.post1 the underlying problem has been fixed (matplotlib/matplotlib#28551) and the pin is no longer necessary.