### PR TITLE
Revert PR #414, use of delvewheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,9 +100,9 @@ test-command = [
 # Only test combinations for which a numpy wheel exists to avoid compiling numpy from source.
 test-skip = "*_{ppc64le,s390x} cp313-*_aarch64"
 
-[tool.cibuildwheel.windows]
-before-all = "pip install delvewheel"
-repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
+#[tool.cibuildwheel.windows]
+#before-all = "pip install delvewheel"
+#repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
 
 [[tool.cibuildwheel.overrides]]
 # For Python 3.13 install numpy from nightly wheels as not yet on PyPI.

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,10 +2,10 @@ cpp_args = [
   '-DCONTOURPY_VERSION=' + version
 ]
 
-cpp = meson.get_compiler('cpp')
-if cpp.get_id() == 'msvc'
-  cpp_args += '-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR'
-endif
+#cpp = meson.get_compiler('cpp')
+#if cpp.get_id() == 'msvc'
+#  cpp_args += '-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR'
+#endif
 
 ext = py3.extension_module(
   '_contourpy',


### PR DESCRIPTION
Reverting (well, commenting out really) PR #414 which added use of `delvewheel` when building Windows wheels and sets `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR`. This simple use of `delvewheel` is not correct, there is a more complicated set of build options for Matplotlib on Windows being tried out. I want to go back to creating nightly wheels as they were a month ago, to see if they are compatible with the new Matplotlib options.