### PR TITLE
Avoid use of pybind11 2.13.3 due to Windows quoting bug

### DIFF
--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,4 +1,4 @@
 # These are the requirements from the build-system section of pyproject.toml
 meson >= 1.2.0
 meson-python >= 0.13.1
-pybind11 >= 2.13.1
+pybind11 >= 2.13.1, != 2.13.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "mesonpy"
 requires = [
     "meson >= 1.2.0",
     "meson-python >= 0.13.1",
-    "pybind11 >= 2.13.1",
+    "pybind11 >= 2.13.1, != 2.13.3",
 ]
 
 [project]


### PR DESCRIPTION
Avoid use of pybind11 2.13.3 which introduced erroneous quoting of compiler arguments on Windows such as:
```
"'-IC:\hostedtoolcache\windows\Python\3.12.4\x64\Include'"
```

Ref https://github.com/pybind/pybind11/issues/5300#issuecomment-2287698500.