### PR TITLE
Don't need to use NumPy nightlies when building wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CIBW_PRERELEASE_PYTHONS: True
-      CIBW_FREE_THREADED_SUPPORT: True
 
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,15 +99,7 @@ test-command = [
 ]
 # Only test combinations for which a numpy wheel exists to avoid compiling numpy from source.
 test-skip = "*_{ppc64le,s390x} cp313-*_aarch64"
-
-#[tool.cibuildwheel.windows]
-#before-all = "pip install delvewheel"
-#repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
-
-[[tool.cibuildwheel.overrides]]
-# For Python 3.13 install numpy from nightly wheels as not yet on PyPI.
-select = "{cp313,cp313t,pp310}-*"
-before-test = "pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
+free-threaded-support = true
 
 
 [tool.codespell]


### PR DESCRIPTION
With the release of NumPy 2.1.0 which includes PyPy 3.10 and CPython 3.13 and 3.13t wheels we no longer need to install NumPy nightlies to test against when building ContourPy wheels.

Also moved `CIBW_FREE_THREADED_SUPPORT` env var from cibuildwheel github action to `pyproject.toml` setting.