### PR TITLE
Statically link C++ runtime on Windows

### DIFF
--- a/lib/contourpy/util/meson.build
+++ b/lib/contourpy/util/meson.build
@@ -41,7 +41,7 @@ conf_data.set('source_dir', meson.current_source_dir().replace('\\', '/'))
 conf_data.set('cross_build', meson.is_cross_build())
 
 # Build options
-conf_data.set('build_options', meson.build_options().replace('\\', '/'))
+conf_data.set('build_options', meson.build_options().replace('\\', '/').replace('"', '').replace('\'\'', ''))
 options = [
   'b_ndebug',
   'b_vscrt',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,15 @@ test-command = [
 test-skip = "*_{ppc64le,s390x} cp313-*_aarch64"
 free-threaded-support = true
 
+[[tool.cibuildwheel.overrides]]
+# See https://github.com/contourpy/contourpy/issues/424
+select = "*-win_amd64"
+before-all = "pwd"
+config-settings.setup-args = [
+    "-Db_vscrt=mt",
+    "-Dcpp_link_args=['ucrt.lib','vcruntime.lib','/nodefaultlib:libucrt.lib','/nodefaultlib:libvcruntime.lib']"
+]
+
 
 [tool.codespell]
 ignore-words-list = "nd"

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,11 +2,6 @@ cpp_args = [
   '-DCONTOURPY_VERSION=' + version
 ]
 
-#cpp = meson.get_compiler('cpp')
-#if cpp.get_id() == 'msvc'
-#  cpp_args += '-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR'
-#endif
-
 ext = py3.extension_module(
   '_contourpy',
   [


### PR DESCRIPTION
Statically link C++ runtime on Windows when building wheels.

Fixes #424.