### PR TITLE
Remove download numbers for conda packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It contains the 2005 and 2014 algorithms used in Matplotlib as well as a newer a
 
 | | |
 | --- | --- |
-| Latest release | [![PyPI version](https://img.shields.io/pypi/v/contourpy.svg?label=pypi&color=fdae61)](https://pypi.python.org/pypi/contourpy) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/contourpy.svg?label=conda-forge&color=a6d96a)](https://anaconda.org/conda-forge/contourpy) [![anaconda version](https://img.shields.io/conda/v/anaconda/contourpy.svg?label=anaconda&color=1a9641)](https://anaconda.org/anaconda/contourpy) |
-| Downloads | [![PyPi downloads](https://img.shields.io/pypi/dm/contourpy?label=pypi&style=flat&color=fdae61)](https://pepy.tech/project/contourpy) [![conda-forge downloads](https://raw.githubusercontent.com/contourpy/condabadges/main/cache/contourpy_conda-forge_monthly.svg)](https://anaconda.org/conda-forge/contourpy) [![anaconda downloads](https://raw.githubusercontent.com/contourpy/condabadges/main/cache/contourpy_anaconda_monthly.svg)](https://anaconda.org/anaconda/contourpy) |
+| Latest release | [![PyPI version](https://img.shields.io/pypi/v/contourpy.svg?label=pypi&color=fdae61)](https://pypi.python.org/pypi/contourpy) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/contourpy.svg?label=conda-forge&color=a6d96a)](https://anaconda.org/conda-forge/contourpy) |
+| Downloads | [![PyPi downloads](https://img.shields.io/pypi/dm/contourpy?label=pypi&style=flat&color=fdae61)](https://pepy.tech/project/contourpy) |
 | Python version | [![Platforms](https://img.shields.io/pypi/pyversions/contourpy?color=fdae61)](https://pypi.org/project/contourpy/) |
 | Coverage | [![Codecov](https://img.shields.io/codecov/c/gh/contourpy/contourpy?color=fdae61&label=codecov)](https://app.codecov.io/gh/contourpy/contourpy) |

--- a/README_simple.md
+++ b/README_simple.md
@@ -9,7 +9,7 @@ It contains the 2005 and 2014 algorithms used in Matplotlib as well as a newer a
 
 | | |
 | --- | --- |
-| Latest release | [![PyPI version](https://img.shields.io/pypi/v/contourpy.svg?label=pypi&color=fdae61)](https://pypi.python.org/pypi/contourpy) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/contourpy.svg?label=conda-forge&color=a6d96a)](https://anaconda.org/conda-forge/contourpy) [![anaconda version](https://img.shields.io/conda/v/anaconda/contourpy.svg?label=anaconda&color=1a9641)](https://anaconda.org/anaconda/contourpy) |
-| Downloads | [![PyPi downloads](https://img.shields.io/pypi/dm/contourpy?label=pypi&style=flat&color=fdae61)](https://pepy.tech/project/contourpy) [![conda-forge downloads](https://raw.githubusercontent.com/contourpy/condabadges/main/cache/contourpy_conda-forge_monthly.svg)](https://anaconda.org/conda-forge/contourpy) [![anaconda downloads](https://raw.githubusercontent.com/contourpy/condabadges/main/cache/contourpy_anaconda_monthly.svg)](https://anaconda.org/anaconda/contourpy) |
+| Latest release | [![PyPI version](https://img.shields.io/pypi/v/contourpy.svg?label=pypi&color=fdae61)](https://pypi.python.org/pypi/contourpy) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/contourpy.svg?label=conda-forge&color=a6d96a)](https://anaconda.org/conda-forge/contourpy) |
+| Downloads | [![PyPi downloads](https://img.shields.io/pypi/dm/contourpy?label=pypi&style=flat&color=fdae61)](https://pepy.tech/project/contourpy) |
 | Python version | [![Platforms](https://img.shields.io/pypi/pyversions/contourpy?color=fdae61)](https://pypi.org/project/contourpy/) |
 | Coverage | [![Codecov](https://img.shields.io/codecov/c/gh/contourpy/contourpy?color=fdae61&label=codecov)](https://app.codecov.io/gh/contourpy/contourpy) |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,6 @@ rst_epilog = """
 .. _Shapely: https://shapely.readthedocs.io/
 .. _conda: https://conda.io/
 .. _conda-forge: https://anaconda.org/conda-forge/contourpy/
-.. _default: https://anaconda.org/anaconda/contourpy/
 .. _github: https://www.github.com/contourpy/contourpy/
 .. _meson: https://mesonbuild.com/
 .. _meson-python: https://meson-python.readthedocs.io/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,8 +4,7 @@ Installation
 Installing from prepackaged binaries
 ------------------------------------
 
-Stable releases of ContourPy are available from `PyPI`_, `conda-forge`_, and Anaconda
-`default`_ channels for Linux, macOS and Windows.
+Stable releases of ContourPy are available from `PyPI`_ and `conda-forge`_ for Linux, macOS and Windows.
 
 #. To install from `PyPI`_:
 
@@ -18,12 +17,6 @@ Stable releases of ContourPy are available from `PyPI`_, `conda-forge`_, and Ana
    .. code-block:: bash
 
       $ conda install -c conda-forge contourpy
-
-#. To install from Anaconda `default`_ channel:
-
-   .. code-block:: bash
-
-      $ conda install contourpy
 
 The only compulsory runtime dependency is `NumPy`_.
 


### PR DESCRIPTION
Remove download numbers for conda packages as Anaconda haven't made the package data available for the past 2 months. Also remove instructions for installing from Anaconda default channel as that isn't kept up to date either.