### PR TITLE
Bump default python version in CI to 3.12

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,12 +8,12 @@ linux_aarch64_test_task:
 
   matrix:
     - env:
-        PYTHON_VERSION: "3.11"
+        PYTHON_VERSION: "3.12"
         IMAGE_SUFFIX: slim
         BUILD_NUMPY: 0
         TEST_NO_IMAGES: 0
     #- env:
-    #    PYTHON_VERSION: "3.11"
+    #    PYTHON_VERSION: "3.12"
     #    IMAGE_SUFFIX: alpine
     #    BUILD_NUMPY: 1
     #    TEST_NO_IMAGES: 1
@@ -66,51 +66,6 @@ linux_aarch64_test_task:
       if [[ -e result_images ]]
       then
         DIR="test-artifacts/cirrus_linux_aarch64_${IMAGE_SUFFIX}_${PYTHON_VERSION}";
-        mkdir -p "${DIR}";
-        mv result_images/* "${DIR}/";
-      fi
-
-    upload_test_artifacts:
-      path: test-artifacts/**
-
-
-macos_arm64_test_task:
-  name: "Cirrus macos arm64 ${PYTHON_VERSION}"
-  only_if: $CIRRUS_BRANCH != "main"
-
-  macos_instance:
-    # https://github.com/cirruslabs/macos-image-templates
-    image: ghcr.io/cirruslabs/macos-monterey-xcode:latest
-
-  matrix:
-    - env:
-        PYTHON_VERSION: "3.10"
-
-  os_dependencies_script: |
-    brew install python@${PYTHON_VERSION}
-    echo "PATH=/opt/homebrew/opt/python@${PYTHON_VERSION}/libexec/bin:$PATH" >> $CIRRUS_ENV
-
-  python_venv_script: |
-    env | grep PATH
-    which python
-    python --version
-    python -m pip install --upgrade pip
-    python -m venv venv
-    source venv/bin/activate
-
-  install_contourpy_script: |
-    python -m pip install -v .[test] -Cbuilddir=build
-    python -m pip list
-    python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"
-
-  run_tests_script: |
-    python -m pytest -v tests/ -n 4 --log-image-diffs
-
-  always:
-    collect_test_image_failures_script: |
-      if [[ -e result_images ]]
-      then
-        DIR="test-artifacts/cirrus_macos_arm64_${PYTHON_VERSION}";
         mkdir -p "${DIR}";
         mv result_images/* "${DIR}/";
       fi

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
       - name: Checkout source
@@ -103,21 +103,21 @@ jobs:
         include:
           # Debug build including Python and C++ coverage.
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             name: "Test debug with coverage"
             short-name: "test-debug"
             coverage-files: "coverage.lcov,coverage.cpp"
             debug: true
           # Bokeh and text tests with Python (not C++) coverage.
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             name: "Test bokeh and text tests with coverage"
             short-name: "test-bokeh"
             coverage-files: "coverage.lcov"
             test-text: true
           # Test against numpy debug build.
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             name: "Test numpy debug"
             short-name: "test-numpy-debug"
             build-numpy-debug: true
@@ -129,7 +129,7 @@ jobs:
             extra-install-args: "numpy==1.23"
           # Compile using C++11.
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             name: "Test C++11"
             short-name: "test-c++11"
             extra-install-args: "-Csetup-args=-Dcpp_std=c++11"
@@ -148,7 +148,7 @@ jobs:
             numpy-nightly: true
           # Win32 test.
           - os: windows-latest
-            python-version: "3.11"
+            python-version: "3.12"
             name: "Win32"
             short-name: "test-win32"
             win32: true
@@ -398,7 +398,7 @@ jobs:
             if [[ $VENV == "venv" ]]
             then
               echo "==> Create virtual environment"
-              /opt/python/cp311-cp311/bin/python -m venv venv
+              /opt/python/cp312-cp312/bin/python -m venv venv
               . venv/bin/activate
               which python
               python --version
@@ -414,7 +414,7 @@ jobs:
               . /work/venv/etc/profile.d/conda.sh
 
               echo "==> Create and activate conda environment"
-              conda create -n my_env -q python=3.11
+              conda create -n my_env -q python=3.12
               conda activate my_env
 
               echo "==> Install conda dependencies"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -418,7 +418,7 @@ jobs:
               conda activate my_env
 
               echo "==> Install conda dependencies"
-              conda install -q numpy matplotlib Pillow
+              conda install -q -c conda-forge -c nodefaults numpy matplotlib Pillow
               conda list
             fi
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 python:
   install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,7 @@ mypy = [
 test = [
     # Standard test dependencies.
     "contourpy[test-no-images]",
-    "matplotlib; platform_system != 'Windows'",
-    "matplotlib != 3.9.1; platform_system == 'Windows'",
+    "matplotlib",
     "Pillow",
 ]
 test-no-images = [


### PR DESCRIPTION
Bump default python version in CI to 3.12. Also removed the cirrus macos arm64 run as that has been reliably working in github actions for a while now.