### PR TITLE
Docs for multi_lines and multi_filled

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,9 @@ rst_epilog = """
 .. _MSVC: https://visualstudio.microsoft.com/
 .. _NumPy: https://numpy.org/
 .. _PyPI: https://pypi.org/project/contourpy/
+.. _Scientific Python: https://scientific-python.org/
 .. _Shapely: https://shapely.readthedocs.io/
+.. _SPEC 4: https://scientific-python.org/specs/spec-0004/
 .. _conda: https://conda.io/
 .. _conda-forge: https://anaconda.org/conda-forge/contourpy/
 .. _github: https://www.github.com/contourpy/contourpy/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,11 @@ Installation
 Installing from prepackaged binaries
 ------------------------------------
 
-Stable releases of ContourPy are available from `PyPI`_ and `conda-forge`_ for Linux, macOS and Windows.
+Official releases
+^^^^^^^^^^^^^^^^^
+
+Official releases of ContourPy are available from `PyPI`_ and `conda-forge`_ for Linux, macOS and
+Windows.
 
 #. To install from `PyPI`_:
 
@@ -22,6 +26,14 @@ The only compulsory runtime dependency is `NumPy`_.
 
 If you want to make use of one of ContourPy's utility renderers in the :mod:`contourpy.util` module
 you will also have to install either `Matplotlib`_ or `Bokeh`_.
+
+Pre-releases
+^^^^^^^^^^^^
+
+Prepackaged wheels of the latest pre-release ContourPy code, at most a week old, are available as
+part of the `Scientific Python`_ nightly wheels service. These are intended to be used for testing
+and are not necessarily stable. See `SPEC 4`_ for more details.
+
 
 Installing from source
 ----------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -23,7 +23,7 @@ The hexadecimal number will be different, it is the address of the `pybind11`_-w
 Contour lines
 -------------
 
-Create some contour lines at a z-level of ``0.25``:
+Calculate some contour lines at a z-level of ``0.25``:
 
   >>> lines = cont_gen.lines(0.25)
   >>> lines
@@ -38,10 +38,25 @@ consisting of two ``(x, y)`` points from ``(0.5, 1)`` to ``(1, 0.75)``.
    The format of data returned by :meth:`~.ContourGenerator.lines` is controlled by
    the ``line_type`` argument passed to :func:`~.contour_generator`.
 
+To calculate contour lines at two different z-levels you can either call
+:meth:`~.ContourGenerator.lines` twice, once for each z-level, or call
+:meth:`~.ContourGenerator.multi_lines` once passing it a list of the z-levels:
+
+  >>> multi_lines = cont_gen.multi_lines([0.15, 0.25])
+  >>> multi_lines
+  [[array([[0.  , 0.75],
+           [1.  , 0.25]])],
+   [array([[0.5 , 1.  ],
+           [1.  , 0.75]])]]
+
+This returns a list of the lines calculated for each z-level and is equivalent to:
+
+  >>> multi_lines = [cont_gen.lines(0.15), cont_gen.lines(0.25)]
+
 Filled contours
 ---------------
 
-Create some filled contours between the z-levels of ``0.15`` and ``0.25``:
+Calculate some filled contours between the z-levels of ``0.15`` and ``0.25``:
 
   >>> filled = cont_gen.filled(0.15, 0.25)
   >>> filled
@@ -53,7 +68,7 @@ Create some filled contours between the z-levels of ``0.15`` and ``0.25``:
            [0. , 1.  ]])],
    [array([0, 6], dtype=uint32)])
 
-The output data is more complicated, it is a tuple of two lists each of which has a length of one
+The output is more complicated, it is a tuple of two lists each of which has a length of one
 corresponding to a single polygon. The first `NumPy`_ array has shape ``(6, 2)`` and is the
 ``(x, y)`` coordinates of the 6 points that make up the polygon; the first and last points are the
 same. The second `NumPy`_ array is an integer array of offsets into the points array; here the
@@ -64,6 +79,30 @@ explained further in :ref:`fill_type`.
 
    The format of data returned by :meth:`~.ContourGenerator.filled` is controlled by
    the ``filled_type`` argument passed to :func:`~.contour_generator`.
+
+To calculate multiple sets of filled contours between pairs of adjacent z-levels you can either call
+:meth:`~.ContourGenerator.filled` multiple times, once for each pair of z-levels, or call
+:meth:`~.ContourGenerator.multi_filled` once passing it a list of the z-levels:
+
+   >>> multi_filled = cont_gen.multi_filled([0.15, 0.25, 0.35])
+   >>> multi_filled
+   [([array([[0.  , 1.  ],
+             [0.  , 0.75],
+             [1.  , 0.25],
+             [1.  , 0.75],
+             [0.5 , 1.  ],
+             [0.  , 1.  ]])],
+     [array([0, 6], dtype=uint32)]),
+    ([array([[0.5 , 1.  ],
+             [1.  , 0.75],
+             [1.  , 1.  ],
+             [0.5 , 1.  ]])],
+     [array([0, 4], dtype=uint32)])]
+
+This returns a list of the filled contours calculated for each pair of adjacent z-levels and is
+equivalent to:
+
+   >>> multi_filled = [cont_gen.filled(0.15, 0.25), cont_gen.filled(0.25, 0.35)]
 
 Graphical output
 ----------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,18 +5,18 @@ The standard approach to use ContourPy is to:
 
 #. Call :func:`~.contour_generator` passing your 2D ``z`` array and optional ``x`` and ``y``
    arrays as arguments to return a :class:`~.ContourGenerator` object, such as the default
-   :class:`.SerialContourGenerator`.
+   :class:`.SerialContourGenerator`. There are many arguments for :func:`~.contour_generator` but
+   only ``z`` is compulsory and there are sensible defaults for the others.
 
-#. Call :class:`~.ContourGenerator` member functions
-   :meth:`~.ContourGenerator.lines` and/or :meth:`~.ContourGenerator.filled`
-   repeatedly to calculate and return contours for that (x, y, z) grid:
+#. To calculate contour lines at a particular z-level call :class:`~.ContourGenerator` member
+   function :meth:`~.ContourGenerator.lines`. To calculate contour lines at multiple levels either
+   repeatedly call :meth:`~.ContourGenerator.lines` or use
+   :meth:`~.ContourGenerator.multi_lines` instead.
 
-   - :meth:`~.ContourGenerator.lines` calculates contour lines at a particular z-level.
-   - :meth:`~.ContourGenerator.filled` calculates filled contours (polygons) between two
-     z-levels.
-
-There are many arguments for :func:`~.contour_generator` but only ``z`` is compulsory and
-there are sensible defaults for the others.
+#. To calculate filled contours (polygons) between two z-levels call :class:`~.ContourGenerator`
+   member function :meth:`~.ContourGenerator.filled`. To calculate filled contours between multiple
+   pairs of z-levels either repeatedly call  :meth:`~.ContourGenerator.filled` or use
+   :meth:`~.ContourGenerator.multi_filled` instead.
 
 .. note::
 

--- a/docs/user_guide/calculate/index.rst
+++ b/docs/user_guide/calculate/index.rst
@@ -1,8 +1,9 @@
 Calculate contours
 ==================
 
-Contours are calculated using the :meth:`~.ContourGenerator.lines` and
-:meth:`~.ContourGenerator.filled` methods of a :class:`~.ContourGenerator` object
+Contours are calculated using the :meth:`~.ContourGenerator.lines`,
+:meth:`~.ContourGenerator.filled`, :meth:`~.ContourGenerator.multi_lines` and
+:meth:`~.ContourGenerator.multi_filled` methods of a :class:`~.ContourGenerator` object
 that is obtained by calling the :func:`~.contour_generator` function.
 There are many options available for contouring that equate to keyword arguments passed to
 the :func:`~.contour_generator` function, these are described in turn below.

--- a/docs/user_guide/manipulate/convert.rst
+++ b/docs/user_guide/manipulate/convert.rst
@@ -4,8 +4,8 @@ Convert line and fill types
 Convert contour lines to a different line type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:func:`~.convert_lines` is used to convert contour lines to a different
-:class:`~.LineType`.
+:func:`~.convert_lines` and :func:`~.convert_multi_lines` are used to convert contour lines to a
+different :class:`~.LineType`.
 
 The following example creates two contour lines in ``LineType.Separate`` format where each line's 2D
 points are in separate NumPy arrays:
@@ -35,8 +35,8 @@ the other direction, all chunk information is discarded as all lines are appende
 Convert filled contours to a different fill type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:func:`~.convert_filled` is used to convert filled contours to a different
-:class:`~.FillType`.
+:func:`~.convert_filled` and :func:`~.convert_multi_filled` are used to convert filled contours to a
+different :class:`~.FillType`.
 
 The following example creates two filled polygons in ``FillType.OuterCode`` format where each of the
 polygons points and codes are in separate NumPy arrays:
@@ -67,7 +67,8 @@ Two of the :class:`~.FillType` (``FillType.ChunkCombinedCode`` and
 ``FillType.ChunkCombinedOffset``) do not include information about the relationship between outer
 and inner boundaries so they cannot be converted to any of the :class:`~.FillType` that
 need this information (``FillType.OuterCode``, ``FillType.OuterOffset``,
-``FillType.ChunkCombinedCodeOffset`` and ``FillType.ChunkCombinedOffsetOffset``).
+``FillType.ChunkCombinedCodeOffset`` and ``FillType.ChunkCombinedOffsetOffset``);
+a ``ValueError`` will be raised instead.
 
 Also, when converting from a non-chunked fill type (``FillType.OuterCode`` or
 ``FillType.OuterOffset``) to a chunked one (any of the others), all polygons are placed together in

--- a/docs/user_guide/manipulate/dechunk.rst
+++ b/docs/user_guide/manipulate/dechunk.rst
@@ -2,7 +2,8 @@ Dechunking
 ----------
 
 Contour lines and filled contours that are split into multiple chunks can have their chunks combined
-using the functions :func:`~.dechunk_lines` and :func:`~.dechunk_filled`. Line and
+using the functions :func:`~.dechunk_lines`, :func:`~.dechunk_filled`,
+:func:`~.dechunk_multi_lines` and :func:`~.dechunk_multi_filled`. Line and
 fill types that are not split into chunks (``LineType.Separate``, ``LineType.SeparateCode``,
 ``FillType.OuterCode`` and ``FillType.OuterOffset``) and those that are but only have a single chunk
 are returned unmodified by the dechunk functions.

--- a/docs/user_guide/manipulate/index.rst
+++ b/docs/user_guide/manipulate/index.rst
@@ -1,8 +1,9 @@
 Manipulate contours
 ===================
 
-The format of contour data returned by :meth:`~.ContourGenerator.lines` and
-:meth:`~.ContourGenerator.filled` is controlled by the ``line_type``, ``fill_type`` and
+The format of contour data returned by :meth:`~.ContourGenerator.lines`,
+:meth:`~.ContourGenerator.filled`, :meth:`~.ContourGenerator.multi_lines` and
+:meth:`~.ContourGenerator.multi_filled` is controlled by the ``line_type``, ``fill_type`` and
 chunking keyword arguments passed to :func:`~.contour_generator`. Usually this is fully
 within your control but there may be occasions when it is not, such as when your contour data is
 obtained via a third-party library that limits some of the available options. ContourPy includes

--- a/lib/contourpy/convert.py
+++ b/lib/contourpy/convert.py
@@ -257,10 +257,11 @@ def convert_filled(
     fill_type_from: FillType | str,
     fill_type_to:  FillType | str,
 ) -> cpy.FillReturn:
-    """Return the specified filled contours converted to a different :class:`~.FillType`.
+    """Convert filled contours from one :class:`~.FillType` to another.
 
     Args:
-        filled (sequence of arrays): Filled contour polygons to convert.
+        filled (sequence of arrays): Filled contour polygons to convert, such as those returned by
+            :meth:`.ContourGenerator.filled`.
         fill_type_from (FillType or str): :class:`~.FillType` to convert from as enum or
             string equivalent.
         fill_type_to (FillType or str): :class:`~.FillType` to convert to as enum or string
@@ -272,7 +273,7 @@ def convert_filled(
     When converting non-chunked fill types (``FillType.OuterCode`` or ``FillType.OuterOffset``) to
     chunked ones, all polygons are placed in the first chunk. When converting in the other
     direction, all chunk information is discarded. Converting a fill type that is not aware of the
-    relationship between outer boundaries and contained holes (``FillType.ChunkCombinedCode`` or)
+    relationship between outer boundaries and contained holes (``FillType.ChunkCombinedCode`` or
     ``FillType.ChunkCombinedOffset``) to one that is will raise a ``ValueError``.
 
     .. versionadded:: 1.2.0
@@ -507,10 +508,11 @@ def convert_lines(
     line_type_from: LineType | str,
     line_type_to:  LineType | str,
 ) -> cpy.LineReturn:
-    """Return the specified contour lines converted to a different :class:`~.LineType`.
+    """Convert contour lines from one :class:`~.LineType` to another.
 
     Args:
-        lines (sequence of arrays): Contour lines to convert.
+        lines (sequence of arrays): Contour lines to convert, such as those returned by
+            :meth:`.ContourGenerator.lines`.
         line_type_from (LineType or str): :class:`~.LineType` to convert from as enum or
             string equivalent.
         line_type_to (LineType or str): :class:`~.LineType` to convert to as enum or string
@@ -560,7 +562,24 @@ def convert_multi_filled(
     fill_type_from: FillType | str,
     fill_type_to:  FillType | str,
 ) -> list[cpy.FillReturn]:
-    """
+    """Convert multiple sets of filled contours from one :class:`~.FillType` to another.
+
+    Args:
+        multi_filled (nested sequence of arrays): Filled contour polygons to convert, such as those
+            returned by :meth:`.ContourGenerator.multi_filled`.
+        fill_type_from (FillType or str): :class:`~.FillType` to convert from as enum or
+            string equivalent.
+        fill_type_to (FillType or str): :class:`~.FillType` to convert to as enum or string
+            equivalent.
+
+    Return:
+        Converted sets filled contour polygons.
+
+    When converting non-chunked fill types (``FillType.OuterCode`` or ``FillType.OuterOffset``) to
+    chunked ones, all polygons are placed in the first chunk. When converting in the other
+    direction, all chunk information is discarded. Converting a fill type that is not aware of the
+    relationship between outer boundaries and contained holes (``FillType.ChunkCombinedCode`` or
+    ``FillType.ChunkCombinedOffset``) to one that is will raise a ``ValueError``.
 
     .. versionadded:: 1.3.0
     """
@@ -575,7 +594,23 @@ def convert_multi_lines(
     line_type_from: LineType | str,
     line_type_to:  LineType | str,
 ) -> list[cpy.LineReturn]:
-    """
+    """Convert multiple sets of contour lines from one :class:`~.LineType` to another.
+
+    Args:
+        multi_lines (nested sequence of arrays): Contour lines to convert, such as those returned by
+            :meth:`.ContourGenerator.multi_lines`.
+        line_type_from (LineType or str): :class:`~.LineType` to convert from as enum or
+            string equivalent.
+        line_type_to (LineType or str): :class:`~.LineType` to convert to as enum or string
+            equivalent.
+
+    Return:
+        Converted set of contour lines.
+
+    When converting non-chunked line types (``LineType.Separate`` or ``LineType.SeparateCode``) to
+    chunked ones (``LineType.ChunkCombinedCode``, ``LineType.ChunkCombinedOffset`` or
+    ``LineType.ChunkCombinedNan``), all lines are placed in the first chunk. When converting in the
+    other direction, all chunk information is discarded.
 
     .. versionadded:: 1.3.0
     """

--- a/lib/contourpy/dechunk.py
+++ b/lib/contourpy/dechunk.py
@@ -17,15 +17,15 @@ if TYPE_CHECKING:
 
 
 def dechunk_filled(filled: cpy.FillReturn, fill_type: FillType | str) -> cpy.FillReturn:
-    """Return the specified filled contours with all chunked data moved into the first chunk.
+    """Return the specified filled contours with chunked data moved into the first chunk.
 
     Filled contours that are not chunked (``FillType.OuterCode`` and ``FillType.OuterOffset``) and
     those that are but only contain a single chunk are returned unmodified. Individual polygons are
     unchanged, they are not geometrically combined.
 
     Args:
-        filled (sequence of arrays): Filled contour data as returned by
-            :meth:`~.ContourGenerator.filled`.
+        filled (sequence of arrays): Filled contour data, such as returned by
+            :meth:`.ContourGenerator.filled`.
         fill_type (FillType or str): Type of :meth:`~.ContourGenerator.filled` as enum or string
             equivalent.
 
@@ -88,15 +88,15 @@ def dechunk_filled(filled: cpy.FillReturn, fill_type: FillType | str) -> cpy.Fil
 
 
 def dechunk_lines(lines: cpy.LineReturn, line_type: LineType | str) -> cpy.LineReturn:
-    """Return the specified contour lines with all chunked data moved into the first chunk.
+    """Return the specified contour lines with chunked data moved into the first chunk.
 
     Contour lines that are not chunked (``LineType.Separate`` and ``LineType.SeparateCode``) and
     those that are but only contain a single chunk are returned unmodified. Individual lines are
     unchanged, they are not geometrically combined.
 
     Args:
-        lines (sequence of arrays): Contour line data as returned by
-            :meth:`~.ContourGenerator.lines`.
+        lines (sequence of arrays): Contour line data, such as returned by
+            :meth:`.ContourGenerator.lines`.
         line_type (LineType or str): Type of :meth:`~.ContourGenerator.lines` as enum or string
             equivalent.
 
@@ -151,7 +151,20 @@ def dechunk_multi_filled(
     multi_filled: list[cpy.FillReturn],
     fill_type: FillType | str,
 ) -> list[cpy.FillReturn]:
-    """
+    """Return multiple sets of filled contours with chunked data moved into the first chunks.
+
+    Filled contours that are not chunked (``FillType.OuterCode`` and ``FillType.OuterOffset``) and
+    those that are but only contain a single chunk are returned unmodified. Individual polygons are
+    unchanged, they are not geometrically combined.
+
+    Args:
+        multi_filled (nested sequence of arrays): Filled contour data, such as returned by
+            :meth:`.ContourGenerator.multi_filled`.
+        fill_type (FillType or str): Type of :meth:`~.ContourGenerator.filled` as enum or string
+            equivalent.
+
+    Return:
+        Multiple sets of filled contours in a single chunk.
 
     .. versionadded:: 1.3.0
     """
@@ -168,7 +181,20 @@ def dechunk_multi_lines(
     multi_lines: list[cpy.LineReturn],
     line_type: LineType | str,
 ) -> list[cpy.LineReturn]:
-    """
+    """Return multiple sets of contour lines with all chunked data moved into the first chunks.
+
+    Contour lines that are not chunked (``LineType.Separate`` and ``LineType.SeparateCode``) and
+    those that are but only contain a single chunk are returned unmodified. Individual lines are
+    unchanged, they are not geometrically combined.
+
+    Args:
+        multi_lines (nested sequence of arrays): Contour line data, such as returned by
+            :meth:`.ContourGenerator.multi_lines`.
+        line_type (LineType or str): Type of :meth:`~.ContourGenerator.lines` as enum or string
+            equivalent.
+
+    Return:
+        Multiple sets of contour lines in a single chunk.
 
     .. versionadded:: 1.3.0
     """

--- a/lib/contourpy/util/renderer.py
+++ b/lib/contourpy/util/renderer.py
@@ -93,6 +93,8 @@ class Renderer(ABC):
                 10 sets of filled contours are rendered.
             kwargs: All other keyword argument are passed on to
                 :meth:`.Renderer.filled` unchanged.
+
+        .. versionadded:: 1.3.0
         """
         if color is not None:
             kwargs["color"] = color
@@ -124,6 +126,8 @@ class Renderer(ABC):
                 are rendered.
             kwargs: All other keyword argument are passed on to
                 :meth:`Renderer.lines` unchanged.
+
+        .. versionadded:: 1.3.0
         """
         if color is not None:
             kwargs["color"] = color

--- a/src/wrap.cpp
+++ b/src/wrap.cpp
@@ -115,7 +115,7 @@ PYBIND11_MODULE(_contourpy, m, py::mod_gil_not_used()) {
         "``level`` may be ``np.nan``, ``np.inf`` or ``-np.inf``; they all return the same result "
         "which is an empty line set.";
     const char* multi_filled_doc =
-        "Calculate and return filled contours between multiple levels.\n\n"
+        "Calculate and return filled contours between multiple pairs of adjacent levels.\n\n"
         "Args:\n"
         "    levels (array-like of floats): z-levels to calculate filled contours between. "
         "There must be at least 2 levels, they cannot be NaN, and each level must be larger than "
@@ -123,15 +123,16 @@ PYBIND11_MODULE(_contourpy, m, py::mod_gil_not_used()) {
         "Return:\n"
         "    List of filled contours, one per pair of levels. The length of the returned list is "
         "one less than ``len(levels)``. The format of returned contours is determined by the "
-        "``fill_type`` used by the ``ContourGenerator``.\n\n"
+        "``fill_type`` used by the ``ContourGenerator`` and the options are explained at "
+        ":ref:`fill_type`.\n\n"
         "Raises a ``ValueError`` if ``levels`` are not increasing, or contain a NaN, or there are "
         "fewer than 2 ``levels``.\n\n"
         "Calling:\n\n"
         ".. code-block:: python\n\n"
-        "    ret = obj.multi_filled(levels)\n\n"
+        "    ret = cont_gen.multi_filled(levels)\n\n"
         "is equivalent to:\n\n"
         ".. code-block:: python\n\n"
-        "    ret = [obj.filled(lower, upper) for lower, upper in zip(levels[:-1], levels[1:])]\n\n"
+        "    ret = [cont_gen.filled(lower, upper) for lower, upper in zip(levels[:-1], levels[1:])]\n\n"
         ".. versionadded:: 1.3.0";
     const char* multi_lines_doc =
         "Calculate and return contour lines at multiple levels.\n\n"
@@ -139,13 +140,14 @@ PYBIND11_MODULE(_contourpy, m, py::mod_gil_not_used()) {
         "    levels (array-like of floats): z-levels to calculate contours at.\n\n"
         "Return:\n"
         "    List of contour lines, one per level. The format of returned lines is determined by "
-        "the ``line_type`` used by the ``ContourGenerator``.\n\n"
+        "the ``line_type`` used by the ``ContourGenerator`` and the options are explained at "
+        ":ref:`line_type`.\n\n"
         "Calling:\n\n"
         ".. code-block:: python\n\n"
-        "    ret = obj.multi_lines(levels)\n\n"
+        "    ret = cont_gen.multi_lines(levels)\n\n"
         "is equivalent to:\n\n"
         ".. code-block:: python\n\n"
-        "    ret = [obj.lines(level) for level in levels]\n\n"
+        "    ret = [cont_gen.lines(level) for level in levels]\n\n"
         ".. versionadded:: 1.3.0";
     const char* quad_as_tri_doc = "Return whether ``quad_as_tri`` is set or not.";
     const char* supports_corner_mask_doc =


### PR DESCRIPTION
Add documentation for `multi_lines` and `multi_filled`, including for renderers and the various `convert_*` and `dechunk_*` possibilities. Also documented availability of nightly wheels.