### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, macos-14, windows-latest]  # macos-14 is ARM
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: ["3.10", "3.11", "3.12", "3.13-dev"]
         name: ["Test"]
         short-name: ["test"]
         include:
@@ -123,7 +123,7 @@ jobs:
             build-numpy-debug: true
           # Test against earliest supported numpy
           - os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.10"
             name: "Test earliest numpy"
             short-name: "test-earliest-numpy"
             extra-install-args: "numpy==1.23"
@@ -133,13 +133,7 @@ jobs:
             name: "Test C++11"
             short-name: "test-c++11"
             extra-install-args: "-Csetup-args=-Dcpp_std=c++11"
-          # PyPy 3.9 only tested on ubuntu for speed, exclude big tests.
-          - os: ubuntu-latest
-            python-version: "pypy3.9"
-            name: "Test"
-            short-name: "test"
-            test-no-big: true
-          # PyPy 3.10.
+          # PyPy 3.10 only tested on ubuntu for speed, exclude big tests.
           - os: ubuntu-latest
             python-version: "pypy3.10"
             name: "Test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,8 +164,13 @@ line-length = 100
 
 [tool.ruff.lint]
 ignore = [
+    "B905",
     "PLW1510",
     "PLW2901",
+    "RUF007",
+    "TCH003",
+    "UP035",
+    "UP038",
 ]
 select = [
     "B",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -34,7 +33,7 @@ dynamic = ["version"]
 license = {file = "LICENSE"}
 name = "contourpy"
 readme = "README_simple.md"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 
 [project.optional-dependencies]
 docs = [
@@ -90,7 +89,7 @@ setup = [
 
 [tool.cibuildwheel]
 build-frontend = "build"
-build = "cp{39,310,311,312,313,313t}-* pp{39,310}-*_{amd64,x86_64}"
+build = "cp{310,311,312,313,313t}-* pp310-*_{amd64,x86_64}"
 skip = "*-musllinux_{ppc64le,s390x} cp313t-win*"
 test-requires = "pytest"
 test-command = [


### PR DESCRIPTION
Drop support for Python 3.9 following a delayed [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table).