### PR TITLE
Update to bokeh 3.6.0

### DIFF
--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -162,8 +162,9 @@ class BokehRenderer(Renderer):
                 list(np.stack((y[:-1, 1:].ravel(), ymid, y[1:, :-1].ravel()), axis=1)),
                 **kwargs)
         if point_color is not None:
-            fig.circle(
-                x=x.ravel(), y=y.ravel(), fill_color=color, line_color=None, alpha=alpha, size=8)
+            fig.scatter(
+                x=x.ravel(), y=y.ravel(), fill_color=color, line_color=None, alpha=alpha,
+                marker="circle", size=8)
 
     def lines(
         self,
@@ -221,7 +222,7 @@ class BokehRenderer(Renderer):
         fig = self._get_figure(ax)
         color = self._convert_color(color)
         x, y = self._grid_as_2d(x, y)
-        fig.circle(x[mask], y[mask], fill_color=color, size=10)
+        fig.scatter(x[mask], y[mask], fill_color=color, marker="circle", size=10)
 
     def save(
         self,

--- a/tests/test_bokeh_renderer.py
+++ b/tests/test_bokeh_renderer.py
@@ -179,19 +179,18 @@ def test_save_svg(
     transparent: bool, tmpdir: LocalPath, driver: WebDriver, caplog: LogCaptureFixture,
 ) -> None:
     renderer = bokeh_renderer.BokehRenderer(figsize=(4, 3), show_frame=False, want_svg=True)
+    renderer.grid(x=[0, 1, 2], y=[0, 1], alpha=0.5)
     filename = (tmpdir / "bokeh.svg").strpath
 
-    with caplog.at_level(logging.ERROR):  # Hide Bokeh warnings about no renderers.
-        renderer.save(filename, transparent, webdriver=driver)
+    renderer.save(filename, transparent, webdriver=driver)
 
     # Rather simplistic check of SVG file contents.
     with open(filename) as f:
         svg = f.read()
 
     assert svg[:5] == "<svg "
-    count0 = len(re.findall('fill-opacity="0"', svg))
-    count1 = len(re.findall('fill-opacity="1"', svg))
+    count = len(re.findall('path fill="#ffffff"', svg))
     if transparent:
-        assert count0 == 2 and count1 == 0
+        assert count == 0
     else:
-        assert count0 == 2 and count1 == 2
+        assert count == 2


### PR DESCRIPTION
Fixes test failures caused by upgrade to Bokeh 3.6.0, and improved the SVG test at the same time.