### PR TITLE
Test python 313t on macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
         name: ["Test"]
         short-name: ["test"]
         exclude:
-          - os: macos-14
+          - os: macos-13
             python-version: "3.13t"
           - os: windows-latest
             python-version: "3.13t"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,9 +97,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, macos-14, windows-latest]  # macos-14 is ARM
-        python-version: ["3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t"]
         name: ["Test"]
         short-name: ["test"]
+        exclude:
+          - os: macos-14
+            python-version: "3.13t"
+          - os: windows-latest
+            python-version: "3.13t"
         include:
           # Debug build including Python and C++ coverage.
           - os: ubuntu-latest
@@ -163,10 +168,6 @@ jobs:
             name: "Nightly wheels"
             short-name: "test-nightlies"
             nightly-wheels: true
-          - os: ubuntu-latest
-            python-version: "3.13-dev-freethreading"
-            name: "Test"
-            short-name: "test"
 
     steps:
       - name: Checkout source
@@ -175,7 +176,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        if: ${{ !matrix.win32 && !endsWith(matrix.python-version, 'freethreading') }}
+        if: ${{ !matrix.win32 && matrix.python-version != '3.13t' }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -187,11 +188,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x86
 
-      - name: Setup Python ${{ matrix.python-version }}
-        if: ${{ endsWith(matrix.python-version, 'freethreading') }}
+      - name: Setup Python ${{ matrix.python-version }} using deadsnakes
+        if: matrix.python-version == '3.13t'
         uses: deadsnakes/action@v3.2.0
         with:
-          python-version: '3.13-dev'
+          python-version: '3.13'
           nogil: true
 
       - name: Setup MSVC (32-bit)


### PR DESCRIPTION
Add testing using Python 3.13t on macos, alongside the existing linux test. Also streamlined the 3.13 identification now that it has been officially released.