### PR TITLE
Build Python 3.13t wheels on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ setup = [
 [tool.cibuildwheel]
 build-frontend = "build"
 build = "cp{310,311,312,313,313t}-* pp310-*_{amd64,x86_64}"
-skip = "*-musllinux_{ppc64le,s390x} cp313t-win*"
+skip = "*-musllinux_{ppc64le,s390x}"
 test-requires = "pytest"
 test-command = [
     'python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"',
@@ -108,6 +108,11 @@ config-settings.setup-args = [
     "-Db_vscrt=mt",
     "-Dcpp_link_args=['ucrt.lib','vcruntime.lib','/nodefaultlib:libucrt.lib','/nodefaultlib:libvcruntime.lib']"
 ]
+
+[[tool.cibuildwheel.overrides]]
+# For Python 3.13t on windows install numpy from nightly wheels as not yet on PyPI.
+select = "cp313t-win*"
+before-test = "pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
 
 
 [tool.codespell]


### PR DESCRIPTION
Now that Python 3.13 free-threaded Windows wheels are available for NumPy (numpy/numpy#26157) we can build and test ContourPy nightly wheels for the same to help downstream libraries such as Matplotlib do the same (matplotlib/matplotlib#28819).