### PR TITLE
Update minimum pybind11 to 2.13.2

### DIFF
--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,4 +1,4 @@
 # These are the requirements from the build-system section of pyproject.toml
 meson >= 1.2.0
 meson-python >= 0.13.1
-pybind11 >= 2.13.1, != 2.13.3
+pybind11 >= 2.13.2, != 2.13.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "mesonpy"
 requires = [
     "meson >= 1.2.0",
     "meson-python >= 0.13.1",
-    "pybind11 >= 2.13.1, != 2.13.3",
+    "pybind11 >= 2.13.2, != 2.13.3",
 ]
 
 [project]


### PR DESCRIPTION
Update minimum pybind11 to 2.13.2 as use of 2.13.1 can cause mutex problems in free-threaded builds. This is not an issue with the latest contourpy release 1.3.0 (the only release to support python 3.13) was built using pybind11 2.13.5 on PyPI and 2.13.6 on conda-forge, confirmed using:

```bash
python -c "import contourpy.util as u; print(u.build_config()['pybind11_version'])"
```