### PR TITLE
Read meson-python in recommended way

### DIFF
--- a/lib/contourpy/util/meson.build
+++ b/lib/contourpy/util/meson.build
@@ -28,7 +28,7 @@ conf_data.set('meson_version', meson.version())
 conf_data.set('mesonpy_version',
   run_command(
     py3,
-    ['-c', 'import mesonpy; print(mesonpy.__version__)'],
+    ['-c', 'import importlib.metadata as im; print(im.version("meson-python"))'],
     check: true
   ).stdout().strip()
 )


### PR DESCRIPTION
`meson-python` is removing `__version__` so change reading of this for `build_config` to use the recommended `importlib.metadata.version('meson-python')` instead. See mesonbuild/meson-python#691.

Tested locally using `meson-python` `main` branch (commit `9faca831`) and the build fails before this fix and passes afterwards with
```bash
$ python -c "import contourpy.util as cu; print(cu.build_config()['mesonpy_version'])"
0.18.0.dev0
```