### PR TITLE
Pin numpy<2.2 when type checking using mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ mypy = [
     "contourpy[bokeh,docs]",
     "docutils-stubs",
     "mypy == 1.11.1",
+    "numpy < 2.2",
     "types-Pillow",
 ]
 test = [


### PR DESCRIPTION
There are `mypy` CI failures when using `numpy 2.2.0`. Some are genuine, some are bugs that will be fixed in the next numpy release e.g. numpy/numpy#27967. Temporarily pin `numpy` used for type checking until then.