### PR TITLE
Use ubuntu-24.04-arm runners

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,13 +28,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             arch: aarch64
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             arch: ppc64le
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             arch: s390x
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             arch: x86_64
 
           - os: macOS-14
@@ -42,9 +42,9 @@ jobs:
           - os: macOS-13
             arch: x86_64
 
-          - os: windows-latest
+          - os: windows-24.04
             arch: AMD64
-          - os: windows-latest
+          - os: windows-24.04
             arch: x86
 
     steps:
@@ -84,7 +84,7 @@ jobs:
   build_sdist:
     name: Build sdist
     if: github.repository_owner == 'contourpy'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -111,7 +111,7 @@ jobs:
 
   merge_wheels:
     name: Merge wheel build artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build_wheels
     steps:
       - name: Merge artifacts
@@ -124,7 +124,7 @@ jobs:
   upload_nightlies:
     name: Upload nightly wheels
     if: github.repository_owner == 'contourpy' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: merge_wheels
     steps:
       - name: Download merged wheel artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,7 @@ jobs:
             python-version: "3.13"
             name: "Test"
             short-name: "test"
+            test-no-codebase: true
           # Debug build including Python and C++ coverage.
           - os: ubuntu-24.04
             python-version: "3.12"
@@ -311,6 +312,10 @@ jobs:
           then
             echo "Run all tests except big ones"
             ${PYTEST} tests/ -k "not big"
+          elif [[ "${{ matrix.test-no-codebase }}" != "" ]]
+          then
+            echo "Run all tests except codebase"
+            ${PYTEST} tests/ --ignore tests/test_codebase.py
           else
             echo "Run all tests"
             ${PYTEST} tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
   pre-commit:
     name: pre-commit
     if: github.event_name != 'schedule' || github.repository_owner == 'contourpy'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
   codebase:
     name: codebase
     if: github.event_name != 'schedule' || github.repository_owner == 'contourpy'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -96,59 +96,64 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]  # macos-14 is ARM
+        os: [ubuntu-24.04, macos-13, macos-14, windows-latest]  # macos-14 is ARM
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         name: ["Test"]
         short-name: ["test"]
         include:
+          # Single run on ubuntu arm
+          - os: ubuntu-24.04-arm
+            python-version: "3.13"
+            name: "Test"
+            short-name: "test"
           # Debug build including Python and C++ coverage.
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             python-version: "3.12"
             name: "Test debug with coverage"
             short-name: "test-debug"
             coverage-files: "coverage.lcov,coverage.cpp"
             debug: true
           # Bokeh and text tests with Python (not C++) coverage.
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             python-version: "3.12"
             name: "Test bokeh and text tests with coverage"
             short-name: "test-bokeh"
             coverage-files: "coverage.lcov"
             test-text: true
           # Test against numpy debug build.
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             python-version: "3.12"
             name: "Test numpy debug"
             short-name: "test-numpy-debug"
             build-numpy-debug: true
           # Test against earliest supported numpy
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             python-version: "3.10"
             name: "Test earliest numpy"
             short-name: "test-earliest-numpy"
             extra-install-args: "numpy==1.23"
           # Compile using C++11.
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             python-version: "3.12"
             name: "Test C++11"
             short-name: "test-c++11"
             extra-install-args: "-Csetup-args=-Dcpp_std=c++11"
           # PyPy 3.10 only tested on ubuntu for speed, exclude big tests.
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             python-version: "pypy3.10"
             name: "Test"
             short-name: "test"
             test-no-images: true
             numpy-nightly: true
           # Win32 test.
-          - os: windows-latest
+          - os: windows-24.04
             python-version: "3.12"
             name: "Win32"
             short-name: "test-win32"
             win32: true
             test-no-images: true
           # Test against matplotlib and numpy nightly wheels.
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             python-version: "3.12"
             name: "Nightly wheels"
             short-name: "test-nightlies"
@@ -164,7 +169,7 @@ jobs:
             short-name: "test-nightlies"
             nightly-wheels: true
           # Python 3.13 free-threading test.
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             python-version: "3.13t"
             name: "Test"
             short-name: "test"
@@ -336,7 +341,7 @@ jobs:
     # In-docker tests are either emulated hardware or musllinux
     name: In docker ${{ matrix.arch }} ${{ matrix.manylinux_version }}
     if: github.event_name != 'schedule' || github.repository_owner == 'contourpy'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -449,7 +454,7 @@ jobs:
   merge:
     name: Merge test artifacts
     if: github.event_name != 'schedule' || github.repository_owner == 'contourpy'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [test, test-in-docker]
     steps:
       - name: Merge Artifacts

--- a/.github/workflows/test_own_nightlies.yml
+++ b/.github/workflows/test_own_nightlies.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-24.04, macos-14, windows-latest]
         python-version: ["3.12"]
         dependencies: ["released", "nightlies"]
 


### PR DESCRIPTION
Linux ARM github runners are now available https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/. Here adding a single linux arm CI test run, and more importantly switching the `aarch64` wheel builds across to use an arm runner so that they are no longer emulated.