### PR TITLE
Ignore some coverage errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -324,7 +324,11 @@ jobs:
       - name: Collect C++ coverage
         if: matrix.debug
         run: |
-          lcov --output-file coverage.cpp --capture --directory build
+          which lcov
+          lcov --version
+          which gcov
+          gcov --version
+          lcov --output-file coverage.cpp --capture --directory build --ignore-errors mismatch,negative
           lcov --output-file coverage.cpp --extract coverage.cpp $PWD/src/"*"
 
       - name: Upload coverage


### PR DESCRIPTION
Coverage CI runs have started failing with some errors reported that are neither correct nor important. Here ignoring those errors.