### PR TITLE
Temporary workaround for qemu segfault

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -58,6 +58,8 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+          # Temporary workaround
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Setup MSVC (32-bit)
         if: ${{ matrix.arch == 'x86' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -391,6 +391,8 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+          # Temporary workaround
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Run inside docker
         uses: addnab/docker-run-action@v3


### PR DESCRIPTION
Temporary workaround for seg faults occurring in CI when emulating `ppc64le` or `s390x` using qemu. Workaround from pypa/cibuildwheel#2256.