### PR TITLE
Test PyPy 3.10 on all 3 major OSes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,16 @@ jobs:
             name: "Test"
             short-name: "test"
             test-no-images: true
-            numpy-nightly: true
+          - os: macos-14
+            python-version: "pypy3.10"
+            name: "Test"
+            short-name: "test"
+            test-no-images: true
+          - os: windows-latest
+            python-version: "pypy3.10"
+            name: "Test"
+            short-name: "test"
+            test-no-images: true
           # Win32 test.
           - os: windows-latest
             python-version: "3.12"


### PR DESCRIPTION
Test PyPy 3.10 on all 3 major OSes rather than just ubuntu, and obtain `numpy` packages from PyPI rather than scientific python nightly wheels.