### PR TITLE
Fix type annotations for bokeh >= 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ bokeh = [
 mypy = [
     # Requirements to run mypy to check type annotations.
     "contourpy[bokeh,docs]",
-    "bokeh < 3.7",
+    "bokeh",
     "docutils-stubs",
     "mypy == 1.15.0",
     "types-Pillow",


### PR DESCRIPTION
Fix type annotations for bokeh >= 3.7, closes #466.