### PR TITLE
Bump minimum supported Python to 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-13, macos-14, windows-latest]  # macos-14 is ARM
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
         name: ["Test"]
         short-name: ["test"]
         include:
@@ -134,32 +134,16 @@ jobs:
             build-numpy-debug: true
           # Test against earliest supported numpy
           - os: ubuntu-24.04
-            python-version: "3.10"
+            python-version: "3.11"
             name: "Test earliest numpy"
             short-name: "test-earliest-numpy"
-            extra-install-args: "numpy==1.23"
+            extra-install-args: "numpy==1.25"
           # Compile using C++11.
           - os: ubuntu-24.04
             python-version: "3.12"
             name: "Test C++11"
             short-name: "test-c++11"
             extra-install-args: "-Csetup-args=-Dcpp_std=c++11"
-          # PyPy 3.10 only tested on ubuntu for speed, exclude big tests.
-          - os: ubuntu-24.04
-            python-version: "pypy3.10"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
-          - os: macos-14
-            python-version: "pypy3.10"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
-          - os: windows-latest
-            python-version: "pypy3.10"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
           # PyPy 3.11
           - os: ubuntu-24.04
             python-version: "pypy3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -26,14 +25,14 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "numpy >= 1.23",
+    "numpy >= 1.25",
 ]
 description = "Python library for calculating contours of 2D quadrilateral grids"
 dynamic = ["version"]
 license = {file = "LICENSE"}
 name = "contourpy"
 readme = "README_simple.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 
 [project.optional-dependencies]
 docs = [
@@ -90,8 +89,8 @@ setup = [
 
 [tool.cibuildwheel]
 build-frontend = "build"
-build = "cp{310,311,312,313,313t}-* pp{310,311}-*_{amd64,x86_64}"
-skip = "*-musllinux_{ppc64le,s390x} cp310-win_arm64"
+build = "cp{311,312,313,313t}-* pp311-*_{amd64,x86_64}"
+skip = "*-musllinux_{ppc64le,s390x}"
 test-requires = "pytest"
 test-command = [
     'python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"',


### PR DESCRIPTION
Bump minimum supported Python to 3.11 and NumPy to 1.25 following delayed [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table).