### PR TITLE
Support python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,11 +101,6 @@ jobs:
         name: ["Test"]
         short-name: ["test"]
         include:
-          - os: ubuntu-24.04
-            python-version: "3.14.0-alpha.7"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
           # Single run on ubuntu arm
           - os: ubuntu-24.04-arm
             python-version: "3.13"
@@ -199,6 +194,18 @@ jobs:
             python-version: "3.13t"
             name: "Test"
             short-name: "test"
+          # Python 3.14 test.
+          - os: ubuntu-24.04
+            python-version: "3.14-dev"
+            name: "Test"
+            short-name: "test"
+            test-no-images: true
+          # Python 3.14 free-threading test.
+          - os: ubuntu-24.04
+            python-version: "3.14t-dev"
+            name: "Test"
+            short-name: "test"
+            test-no-images: true
 
     steps:
       - name: Checkout source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Scientific/Engineering :: Visualization",
@@ -89,7 +90,7 @@ setup = [
 
 [tool.cibuildwheel]
 build-frontend = "build"
-build = "cp{311,312,313,313t}-* pp311-*_{amd64,x86_64}"
+build = "cp{311,312,313,313t,314,314t}-* pp311-*_{amd64,x86_64}"
 skip = "*-musllinux_{ppc64le,s390x}"
 test-requires = "pytest"
 test-command = [
@@ -97,7 +98,7 @@ test-command = [
     'pytest -v {project}/tests/test_minimal.py',
 ]
 # Only test combinations for which a numpy wheel exists to avoid compiling numpy from source.
-test-skip = "*_{ppc64le,s390x} cp313-*_aarch64"
+test-skip = "*_{ppc64le,s390x}"
 free-threaded-support = true
 
 [[tool.cibuildwheel.overrides]]
@@ -110,12 +111,8 @@ config-settings.setup-args = [
 ]
 
 [[tool.cibuildwheel.overrides]]
-# For PyPy 3.11 install numpy from nightly wheels as not yet on PyPI.
-select = "pp311-*"
-before-test = "pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
-
-[[tool.cibuildwheel.overrides]]
-select = "*-win_arm64"
+# Install numpy from nightly wheels as not yet on PyPI.
+select = "pp311-* *-win_arm64 cp314*"
 before-test = "pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
 
 


### PR DESCRIPTION
Support python 3.14 with a couple of CI runs to test upstream, and build nightly wheels for 3.14 so that downstream can test against them.