### PR TITLE
Support type annotation changes in numpy 2.3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,10 +102,11 @@ jobs:
         short-name: ["test"]
         include:
           - os: ubuntu-24.04
-            python-version: "3.14.0-alpha.7"
+            python-version: "3.14-dev"
             name: "Test"
             short-name: "test"
             test-no-images: true
+            numpy-nightly: true
           # Single run on ubuntu arm
           - os: ubuntu-24.04-arm
             python-version: "3.13"

--- a/benchmarks/plot_benchmarks.py
+++ b/benchmarks/plot_benchmarks.py
@@ -82,7 +82,7 @@ def by_name_and_type(loader: Loader, filled: bool, dataset: str, render: bool, n
             if name == "serial":
                 xs = 2 + np.arange(ntypes)
             else:
-                xs = np.array(0 if name == "mpl2005" else 1)  # type: ignore[assignment]
+                xs = np.array(0 if name == "mpl2005" else 1)
 
             i = 0
             for corner_mask in corner_masks:

--- a/lib/contourpy/__init__.py
+++ b/lib/contourpy/__init__.py
@@ -77,8 +77,8 @@ def _remove_z_mask(
     z_array = np.ma.asarray(z, dtype=np.float64)  # type: ignore[no-untyped-call]
     z_masked = np.ma.masked_invalid(z_array, copy=False)  # type: ignore[no-untyped-call]
 
-    if np.ma.is_masked(z_masked):  # type: ignore[no-untyped-call]
-        mask = np.ma.getmask(z_masked)  # type: ignore[no-untyped-call]
+    if np.ma.is_masked(z_masked):
+        mask = np.ma.getmask(z_masked)
     else:
         mask = None
 

--- a/lib/contourpy/array.py
+++ b/lib/contourpy/array.py
@@ -190,7 +190,7 @@ def outer_offsets_from_list_of_codes(list_of_codes: list[cpy.CodeArray]) -> cpy.
     if not list_of_codes:
         raise ValueError("Empty list passed to outer_offsets_from_list_of_codes")
 
-    return np.cumsum([0] + [np.count_nonzero(codes == MOVETO) for codes in list_of_codes],
+    return np.cumsum([0] + [np.count_nonzero(codes == MOVETO) for codes in list_of_codes],  # type: ignore[misc]
                      dtype=offset_dtype)
 
 

--- a/lib/contourpy/util/bokeh_renderer.py
+++ b/lib/contourpy/util/bokeh_renderer.py
@@ -218,7 +218,7 @@ class BokehRenderer(Renderer):
             ax (int or Bokeh Figure, optional): Which plot to use, default ``0``.
             color (str, optional): Circle color, default ``"black"``.
         """
-        mask = np.ma.getmask(z)  # type: ignore[no-untyped-call]
+        mask = np.ma.getmask(z)
         if mask is np.ma.nomask:
             return
         fig = self._get_figure(ax)

--- a/lib/contourpy/util/mpl_renderer.py
+++ b/lib/contourpy/util/mpl_renderer.py
@@ -213,7 +213,7 @@ class MplRenderer(Renderer):
             ax (int or Matplotlib Axes, optional): Which Axes to plot on, default ``0``.
             color (str, optional): Circle color, default ``"black"``.
         """
-        mask = np.ma.getmask(z)  # type: ignore[no-untyped-call]
+        mask = np.ma.getmask(z)
         if mask is np.ma.nomask:
             return
         ax = self._get_ax(ax)

--- a/tests/util_config.py
+++ b/tests/util_config.py
@@ -420,7 +420,7 @@ class ConfigFilled(ConfigFilledCommon):
                         self._next_quad(config, suffix="(1)", set_0=lookup_1[zsum])
                     elif zmin == 0 and zmax == 2:
                         count_1 = np.count_nonzero(all == 1)
-                        lookup_0 = {2: -0.3, 3: -1, 4: -2-count_1/2, 5: -5, 6: -6}
+                        lookup_0 = {2: -0.3, 3: -1, 4: -2-count_1/2, 5: -5, 6: -6}  # type: ignore[dict-item]
                         self._next_quad(config, suffix="(0)", set_0=lookup_0[zsum])
 
                         if zsum <= 3:
@@ -431,13 +431,13 @@ class ConfigFilled(ConfigFilledCommon):
                             self._next_quad(config, suffix="(1)", set_0=-1)
 
                         lookup_2 = {2: 8.01, 3: 7.01, 4: 4+count_1/2, 5: 3.5, 6: 2.5}
-                        self._next_quad(config, suffix="(2)", set_2=lookup_2[zsum])
+                        self._next_quad(config, suffix="(2)", set_2=lookup_2[zsum])  # type: ignore[arg-type]
                     elif zmin == 1 and zmax == 2:
                         lookup_1 = {5: 2, 6: 1.65, 7: 1.6}
                         self._next_quad(config, suffix="(1)", set_2=lookup_1[zsum])
 
                         lookup_2 = {5: 4, 6: 3, 7: 2}
-                        self._next_quad(config, suffix="(2)", set_2=lookup_2[zsum])
+                        self._next_quad(config, suffix="(2)", set_2=lookup_2[zsum])  # type: ignore[arg-type]
                     else:
                         raise RuntimeError(f"Invalid combination of zmin {zmin} and zmax {zmax}")
                 else:


### PR DESCRIPTION
Support type annotation changes in numpy 2.3.0. Also switch the python 3.14 test to use numpy nightly wheels.