### PR TITLE
Disable nightly wheels test on Windows on ARM

### DIFF
--- a/.github/workflows/test_own_nightlies.yml
+++ b/.github/workflows/test_own_nightlies.yml
@@ -25,7 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-latest, windows-11-arm]
+        #os: [ubuntu-24.04, macos-14, windows-latest, windows-11-arm]
+        os: [ubuntu-24.04, macos-14, windows-latest]
         python-version: ["3.12"]
         dependencies: ["released", "nightlies"]
 


### PR DESCRIPTION
Disable nightly wheels test on Windows on ARM, waiting for Matplotlib wheels (matplotlib/matplotlib#28554).