### PR TITLE
Use matplotlib images tests for python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,13 +199,28 @@ jobs:
             python-version: "3.14-dev"
             name: "Test"
             short-name: "test"
-            test-no-images: true
+            nightly-wheels: true
+          - os: macos-13
+            python-version: "3.14-dev"
+            name: "Test"
+            short-name: "test"
+            nightly-wheels: true
+          - os: macos-14
+            python-version: "3.14-dev"
+            name: "Test"
+            short-name: "test"
+            nightly-wheels: true
+          - os: windows-latest
+            python-version: "3.14-dev"
+            name: "Test"
+            short-name: "test"
+            nightly-wheels: true
           # Python 3.14 free-threading test.
           - os: ubuntu-24.04
             python-version: "3.14t-dev"
             name: "Test"
             short-name: "test"
-            test-no-images: true
+            nightly-wheels: true
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
There are now Matplotlib as well as NumPy nightly wheels available, so use image tests for python 3.14 and on a wider variety of platforms.