### PR TITLE
Remove 3.13.3 pin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-13, macos-14, windows-latest]  # macos-14 is ARM
-        python-version: ["3.11", "3.12", "3.13.3"]
+        python-version: ["3.11", "3.12", "3.13"]
         name: ["Test"]
         short-name: ["test"]
         include:

--- a/lib/contourpy/array.py
+++ b/lib/contourpy/array.py
@@ -190,7 +190,7 @@ def outer_offsets_from_list_of_codes(list_of_codes: list[cpy.CodeArray]) -> cpy.
     if not list_of_codes:
         raise ValueError("Empty list passed to outer_offsets_from_list_of_codes")
 
-    return np.cumsum([0] + [np.count_nonzero(codes == MOVETO) for codes in list_of_codes],  # type: ignore[misc]
+    return np.cumsum([0] + [np.count_nonzero(codes == MOVETO) for codes in list_of_codes],
                      dtype=offset_dtype)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ mypy = [
     "contourpy[bokeh,docs]",
     "bokeh",
     "docutils-stubs",
-    "mypy == 1.15.0",
+    "mypy == 1.17.0",
     "types-Pillow",
 ]
 test = [


### PR DESCRIPTION
Previously pinning python 3.13 CI runs to 3.13.3 as there was a problem with 3.13.4 on Windows. This is no longer necessary as 3.13.5 is reliably available in github runners.