### PR TITLE
tell meson to get correct pybind11 version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,7 @@ endif
 
 py_mod = import('python')
 py3 = py_mod.find_installation(pure: false)
-pybind11_dep = dependency('pybind11')
+pybind11_dep = dependency('pybind11', version : '>= 2.13.2, != 2.13.3')
 
 subdir('lib/contourpy')
 subdir('src')


### PR DESCRIPTION
With multiple versions of pybind11 on the system, meson picks up the one reported by `pkg-config`, and ignores constraints in `pyproject.toml` and `build-requirements.txt` (certainly if the build is started by `pip install .`, I didn't try `python -m build`), which might be too old. 

E.g. this happens is the source build with `pip` is tried on a recent Ubuntu, which still ships `pybind11` version 2.10.

We get user reports complaining of such an error while building [sagemath](https://sagemath.org) from source, see e.g. https://groups.google.com/g/sage-devel/c/H8M3mK_nM2w/m/U1ly-tdYBwAJ