### PR TITLE
Pin pytest-rerunfailures < 16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ test-no-images = [
     # Dependencies to run tests excluding image-generating tests.
     "pytest",
     "pytest-cov",
-    "pytest-rerunfailures",
+    "pytest-rerunfailures < 16",
     "pytest-xdist",
     "wurlitzer",
 ]


### PR DESCRIPTION
`pytest-rerunfailures 16.0` has broken the world's CI (pytest-dev/pytest-rerunfailures#302), so here pinning to `< 16` to avoid it.