### PR TITLE
Switch from macos-13 to macos-15-intel github runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14, windows-2022]  # macos-14 is ARM
+        os: [ubuntu-24.04, macos-14, macos-15-intel, windows-2022]
         python-version: ["3.11", "3.12", "3.13"]
         name: ["Test"]
         short-name: ["test"]
@@ -176,7 +176,7 @@ jobs:
             short-name: "test-nightlies"
             matplotlib-nightly: true
             numpy-nightly: true
-          - os: macos-13
+          - os: macos-14
             python-version: "3.13"
             name: "Nightly wheels"
             short-name: "test-nightlies"
@@ -199,12 +199,12 @@ jobs:
             name: "Test"
             short-name: "test"
             matplotlib-nightly: true
-          - os: macos-13
+          - os: macos-14
             python-version: "3.14-dev"
             name: "Test"
             short-name: "test"
             matplotlib-nightly: true
-          - os: macos-14
+          - os: macos-15-intel
             python-version: "3.14-dev"
             name: "Test"
             short-name: "test"


### PR DESCRIPTION
Switch from `macos-13` to `macos-15-intel` github runners as the former are deprecated.