### PR TITLE
Bump minimum python to 3.12 and minimum numpy to 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-14, macos-15-intel, windows-2022]
-        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.12", "3.13", "3.14", "3.14t"]
         name: ["Test"]
         short-name: ["test"]
         include:
@@ -128,32 +128,16 @@ jobs:
             build-numpy-debug: true
           # Test against earliest supported numpy
           - os: ubuntu-24.04
-            python-version: "3.11"
+            python-version: "3.12"
             name: "Test earliest numpy"
             short-name: "test-earliest-numpy"
-            extra-install-args: "numpy==1.25"
+            extra-install-args: "numpy==2.0"
           # Compile using C++11.
           - os: ubuntu-24.04
             python-version: "3.13"
             name: "Test C++11"
             short-name: "test-c++11"
             extra-install-args: "-Csetup-args=-Dcpp_std=c++11"
-          # PyPy 3.11
-          - os: ubuntu-24.04
-            python-version: "pypy3.11"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
-          - os: macos-14
-            python-version: "pypy3.11"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
-          - os: windows-2022
-            python-version: "pypy3.11"
-            name: "Test"
-            short-name: "test"
-            test-no-images: true
           # Win32 test.
           - os: windows-2022
             python-version: "3.13"

--- a/lib/contourpy/_contourpy.pyi
+++ b/lib/contourpy/_contourpy.pyi
@@ -1,4 +1,4 @@
-from typing import ClassVar, NoReturn, TypeAlias
+from typing import ClassVar, NoReturn
 
 import numpy as np
 import numpy.typing as npt
@@ -6,33 +6,33 @@ import numpy.typing as npt
 import contourpy._contourpy as cpy
 
 # Input numpy array types, the same as in common.h
-CoordinateArray: TypeAlias = npt.NDArray[np.float64]
-MaskArray: TypeAlias = npt.NDArray[np.bool_]
-LevelArray: TypeAlias = npt.ArrayLike
+type CoordinateArray = npt.NDArray[np.float64]
+type MaskArray = npt.NDArray[np.bool_]
+type LevelArray = npt.ArrayLike
 
 # Output numpy array types, the same as in common.h
-PointArray: TypeAlias = npt.NDArray[np.float64]
-CodeArray: TypeAlias = npt.NDArray[np.uint8]
-OffsetArray: TypeAlias = npt.NDArray[np.uint32]
+type PointArray = npt.NDArray[np.float64]
+type CodeArray = npt.NDArray[np.uint8]
+type OffsetArray = npt.NDArray[np.uint32]
 
 # Types returned from filled()
-FillReturn_OuterCode: TypeAlias = tuple[list[PointArray], list[CodeArray]]
-FillReturn_OuterOffset: TypeAlias = tuple[list[PointArray], list[OffsetArray]]
-FillReturn_ChunkCombinedCode: TypeAlias = tuple[list[PointArray | None], list[CodeArray | None]]
-FillReturn_ChunkCombinedOffset: TypeAlias = tuple[list[PointArray | None], list[OffsetArray | None]]
-FillReturn_ChunkCombinedCodeOffset: TypeAlias = tuple[list[PointArray | None], list[CodeArray | None], list[OffsetArray | None]]
-FillReturn_ChunkCombinedOffsetOffset: TypeAlias = tuple[list[PointArray | None], list[OffsetArray | None], list[OffsetArray | None]]
-FillReturn_Chunk: TypeAlias = FillReturn_ChunkCombinedCode | FillReturn_ChunkCombinedOffset | FillReturn_ChunkCombinedCodeOffset | FillReturn_ChunkCombinedOffsetOffset
-FillReturn: TypeAlias = FillReturn_OuterCode | FillReturn_OuterOffset | FillReturn_Chunk
+type FillReturn_OuterCode = tuple[list[PointArray], list[CodeArray]]
+type FillReturn_OuterOffset = tuple[list[PointArray], list[OffsetArray]]
+type FillReturn_ChunkCombinedCode = tuple[list[PointArray | None], list[CodeArray | None]]
+type FillReturn_ChunkCombinedOffset = tuple[list[PointArray | None], list[OffsetArray | None]]
+type FillReturn_ChunkCombinedCodeOffset = tuple[list[PointArray | None], list[CodeArray | None], list[OffsetArray | None]]
+type FillReturn_ChunkCombinedOffsetOffset = tuple[list[PointArray | None], list[OffsetArray | None], list[OffsetArray | None]]
+type FillReturn_Chunk = FillReturn_ChunkCombinedCode | FillReturn_ChunkCombinedOffset | FillReturn_ChunkCombinedCodeOffset | FillReturn_ChunkCombinedOffsetOffset
+type FillReturn = FillReturn_OuterCode | FillReturn_OuterOffset | FillReturn_Chunk
 
 # Types returned from lines()
-LineReturn_Separate: TypeAlias = list[PointArray]
-LineReturn_SeparateCode: TypeAlias = tuple[list[PointArray], list[CodeArray]]
-LineReturn_ChunkCombinedCode: TypeAlias = tuple[list[PointArray | None], list[CodeArray | None]]
-LineReturn_ChunkCombinedOffset: TypeAlias = tuple[list[PointArray | None], list[OffsetArray | None]]
-LineReturn_ChunkCombinedNan: TypeAlias = tuple[list[PointArray | None]]
-LineReturn_Chunk: TypeAlias = LineReturn_ChunkCombinedCode | LineReturn_ChunkCombinedOffset | LineReturn_ChunkCombinedNan
-LineReturn: TypeAlias = LineReturn_Separate | LineReturn_SeparateCode | LineReturn_Chunk
+type LineReturn_Separate = list[PointArray]
+type LineReturn_SeparateCode = tuple[list[PointArray], list[CodeArray]]
+type LineReturn_ChunkCombinedCode = tuple[list[PointArray | None], list[CodeArray | None]]
+type LineReturn_ChunkCombinedOffset = tuple[list[PointArray | None], list[OffsetArray | None]]
+type LineReturn_ChunkCombinedNan = tuple[list[PointArray | None]]
+type LineReturn_Chunk = LineReturn_ChunkCombinedCode | LineReturn_ChunkCombinedOffset | LineReturn_ChunkCombinedNan
+type LineReturn = LineReturn_Separate | LineReturn_SeparateCode | LineReturn_Chunk
 
 
 NDEBUG: int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -24,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "numpy >= 1.25",
+    "numpy >= 2.0",
 ]
 description = "Python library for calculating contours of 2D quadrilateral grids"
 dynamic = ["version"]
@@ -32,12 +31,12 @@ license = "BSD-3-Clause"
 license-files= ["LICENSE"]
 name = "contourpy"
 readme = "README_simple.md"
-requires-python = ">= 3.11"
+requires-python = ">= 3.12"
 
 [project.optional-dependencies]
 docs = [
     "furo",
-    "sphinx < 9.1.0",  # Remove pin when increase min python to 3.12
+    "sphinx",
     "sphinx-copybutton",
 ]
 bokeh = [
@@ -88,8 +87,8 @@ setup = [
 
 
 [tool.cibuildwheel]
-build = "cp{311,312,313,313t,314,314t}-* pp311-*"
-enable = ["pypy", "cpython-prerelease"]
+build = "cp{312,313,313t,314,314t}-*"
+enable = ["cpython-prerelease"]
 skip = "*-musllinux_{ppc64le,riscv64,s390x}"
 test-requires = "pytest"
 test-command = [
@@ -131,7 +130,7 @@ exclude_also = [
 
 [tool.mypy]
 files = ["lib/contourpy", "benchmarks", "docs", "tests"]
-python_version = "3.11"
+python_version = "3.12"
 
 allow_redefinition = true
 check_untyped_defs = true

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from io import StringIO
 import sys
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -21,8 +21,8 @@ from contourpy._contourpy import (
 )
 
 if TYPE_CHECKING:
-    KWArgs: TypeAlias = dict[str, int | bool | LineType | FillType | ZInterp]
-    XYZMask: TypeAlias = tuple[list[list[int]], list[list[int]], list[list[int]], None]
+    type KWArgs = dict[str, int | bool | LineType | FillType | ZInterp]
+    type XYZMask = tuple[list[list[int]], list[list[int]], list[list[int]], None]
 
 
 def all_classes() -> list[type[ContourGenerator]]:


### PR DESCRIPTION
Bump minimum python to 3.12 and minimum numpy to 2.0, lazily following [SPEC 0](https://scientific-python.org/specs/spec-0000/).

Numpy made the corresponding changes in December 2025 and Matplotlib last month.