### PR TITLE
Remove unused `ntotal` argument in mpl2005 `build_cntr_list_v2`

### DIFF
--- a/src/mpl2005_original.cpp
+++ b/src/mpl2005_original.cpp
@@ -1397,7 +1397,7 @@ reorder(double *xpp, double *ypp, short *kpp, double *xy, unsigned char *c, int 
 */
 static py::tuple
 build_cntr_list_v2(long *np, double *xp, double *yp, short *kp,
-                   int nparts, long ntotal, int nlevels)
+                   int nparts, int nlevels)
 {
     int i;
     long k;
@@ -1520,7 +1520,7 @@ cntr_trace(Csite *site, double levels[], int nlevels)
     site->kcp = nullptr;
 
     return build_cntr_list_v2(
-        nseg0.data(), xp0.data(), yp0.data(), kp0.data(), nparts, ntotal, nlevels);
+        nseg0.data(), xp0.data(), yp0.data(), kp0.data(), nparts, nlevels);
 }
 
 } // namespace contourpy


### PR DESCRIPTION
Remove argument `ntotal` passed to `build_cntr_list_v2` in `mpl2005` algorithm as it is unused. The policy is to not make changes to the historic algorithms unless really necessary, but this self-evidently makes no difference at runtime.