### PR TITLE
Add build configurations for iOS wheels.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,7 +22,6 @@ permissions:
 jobs:
   build_wheels:
     name: ${{ matrix.platform }} ${{ matrix.arch }} wheels
-    if: github.repository_owner == 'contourpy'
     runs-on: ${{ matrix.os }}
     env:
       CIBW_PRERELEASE_PYTHONS: True

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -53,13 +53,24 @@ jobs:
             arch: wasm32
             platform: pyodide
 
-          # Macos
+          # macOS
           - os: macOS-14
             arch: arm64
             platform: macos
           - os: macOS-15-intel
             arch: x86_64
             platform: macos
+
+          # iOS
+          - os: macOS-latest
+            arch: arm64_iphoneos
+            platform: ios
+          - os: macOS-latest
+            arch: arm64_iphonesimulator
+            platform: ios
+          - os: macOS-15-intel
+            arch: x86_64_iphonesimulator
+            platform: ios
 
           # Windows
           - os: windows-2022

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -67,7 +67,7 @@ jobs:
           # However, the ARM64 simulator and device are sufficiently similar
           # that explicit on-device testing is not generally necessary. This
           # matches the approach taken by PEP 730, and the services offered by
-          # XCode Cloud. See https://peps.python.org/pep-0730/#on-device-testing
+          # Xcode Cloud. See https://peps.python.org/pep-0730/#on-device-testing
           - os: macOS-latest
             arch: arm64_iphoneos
             platform: ios

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   build_wheels:
     name: ${{ matrix.platform }} ${{ matrix.arch }} wheels
+    if: github.repository_owner == 'contourpy'
     runs-on: ${{ matrix.os }}
     env:
       CIBW_PRERELEASE_PYTHONS: True

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -62,6 +62,12 @@ jobs:
             platform: macos
 
           # iOS
+          # This builds iOS device wheels, but there's not way to test "on
+          # device", as there's no CI environment with physical wheels attached.
+          # However, the ARM64 simulator and device are sufficiently similar
+          # that explicit on-device testing is not generally necessary. This
+          # matches the approach taken by PEP 730, and the services offered by
+          # XCode Cloud. See https://peps.python.org/pep-0730/#on-device-testing
           - os: macOS-latest
             arch: arm64_iphoneos
             platform: ios

--- a/.github/workflows/test_with_cibuildwheel.yml
+++ b/.github/workflows/test_with_cibuildwheel.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           python-version: 3.13
 
-      - name: Build and test pyodide wheels
+      - name: Build and test wheels
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           CIBW_PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/test_with_cibuildwheel.yml
+++ b/.github/workflows/test_with_cibuildwheel.yml
@@ -1,4 +1,4 @@
-name: Build and test pyodide
+name: Test (cibuildwheel)
 
 on:
   pull_request:
@@ -21,9 +21,25 @@ permissions:
   contents: read
 
 jobs:
-  build_pyodide:
-    name: Build pyodide wheel
+  cibuildwheel_test:
+    name: Test (${{ matrix.name }})
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: pyodide
+            os: ubuntu-24.04
+            arch: auto
+            platform: pyodide
+          - name: iOS-x86_64
+            os: macos-latest
+            arch: arm64_iphonesimulator
+            platform: ios
+          - name: iOS-x86_64
+            os: macos-15-intel
+            arch: x86_64_iphonesimulator
+            platform: ios
 
     steps:
       - name: Checkout source
@@ -40,7 +56,8 @@ jobs:
       - name: Build and test pyodide wheels
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
-          CIBW_PLATFORM: pyodide
+          CIBW_PLATFORM: ${{ matrix.platform }}
+          CIBW_ARCHES: ${{ matrix.arch }}
           CIBW_TEST_REQUIRES: pytest pytest-rerunfailures<16
           CIBW_TEST_SOURCES: tests
           CIBW_TEST_COMMAND: pytest -v ./tests --ignore=./tests/test_codebase.py -k "not image and not big"
@@ -48,5 +65,5 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: pyodide-wheels
+          name: ${{ matrix.name }}-wheels
           path: ./wheelhouse/*.whl

--- a/.github/workflows/test_with_cibuildwheel.yml
+++ b/.github/workflows/test_with_cibuildwheel.yml
@@ -60,7 +60,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_TEST_REQUIRES: pytest pytest-rerunfailures<16
           CIBW_TEST_SOURCES: tests
-          CIBW_TEST_COMMAND: pytest -v ./tests --ignore=./tests/test_codebase.py -k "not image and not big"
+          CIBW_TEST_COMMAND: python -m pytest -v ./tests --ignore=./tests/test_codebase.py -k "not image and not big"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/test_with_cibuildwheel.yml
+++ b/.github/workflows/test_with_cibuildwheel.yml
@@ -32,7 +32,7 @@ jobs:
             os: ubuntu-24.04
             arch: auto
             platform: pyodide
-          - name: iOS-x86_64
+          - name: iOS-arm64
             os: macos-latest
             arch: arm64_iphonesimulator
             platform: ios
@@ -57,7 +57,7 @@ jobs:
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           CIBW_PLATFORM: ${{ matrix.platform }}
-          CIBW_ARCHES: ${{ matrix.arch }}
+          CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_TEST_REQUIRES: pytest pytest-rerunfailures<16
           CIBW_TEST_SOURCES: tests
           CIBW_TEST_COMMAND: pytest -v ./tests --ignore=./tests/test_codebase.py -k "not image and not big"

--- a/.github/workflows/test_with_cibuildwheel.yml
+++ b/.github/workflows/test_with_cibuildwheel.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   cibuildwheel_test:
     name: Test (${{ matrix.name }})
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ test-command = [
     'python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"',
     'pytest -v {project}/tests/test_minimal.py',
 ]
+# Only test combinations for which a numpy wheel exists to avoid compiling numpy from source.
+test-skip = "*_{ppc64le,s390x}"
 
 [tool.cibuildwheel.ios]
 xbuild-tools = ["ninja"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,8 +100,14 @@ test-command = [
     'python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"',
     'pytest -v {project}/tests/test_minimal.py',
 ]
-# Only test combinations for which a numpy wheel exists to avoid compiling numpy from source.
-test-skip = "*_{ppc64le,s390x}"
+
+[tool.cibuildwheel.ios]
+xbuild-tools = ["ninja"]
+# numpy iOS wheels are not on PyPI yet; see https://github.com/numpy/numpy/pull/28759
+# Use the BeeWare independent repository in the meantime.
+environment = { PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/beeware/simple" }
+test-sources = ["tests"]
+test-command = "python -m pytest -vv tests/test_minimal.py"
 
 [[tool.cibuildwheel.overrides]]
 # See https://github.com/contourpy/contourpy/issues/424
@@ -124,6 +130,13 @@ select = "*riscv64*"
 # Let's install from rise project for now: https://riseproject.gitlab.io/python/wheel_builder/packages/numpy
 # Note: only manylinux wheel available (no musllinux)
 before-test = "python -m pip install -v --only-binary=:all: --extra-index-url https://gitlab.com/api/v4/projects/riseproject%2Fpython%2Fwheel_builder/packages/pypi/simple numpy "
+
+[[tool.cibuildwheel.overrides]]
+# Reassert the BeeWare NumPy index for iOS. This must come after the cp315* override
+# above, which would otherwise replace PIP_EXTRA_INDEX_URL with the scientific-python
+# nightly index for cp315 iOS builds (NumPy iOS wheels are only on BeeWare).
+select = "*-ios_*"
+environment = { PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/beeware/simple" }
 
 [tool.codespell]
 ignore-words-list = "nd,socio-economic"


### PR DESCRIPTION
iOS is a Tier 3 supported platform on CPython 3.13+ (as a result of PEP 730). This adds the cibuildwheel configuration to build iOS wheels.

This will produce 3 wheels per CPython version:

* ARM64 device
* ARM64 simulator
* x86_64 simulator

It will run the test suite using the ARM64 simulator.

NumPy doesn't yet officially publish iOS wheels; a [PR adding iOS support has been submitted](https://github.com/numpy/numpy/pull/28759), and is awaiting review of an upstream dependency. In the meantime, this PR points at the BeeWare anaconda.org repository, which has unofficial NumPy wheels.