### PR TITLE
Increase pyodide test coverage

### DIFF
--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -41,6 +41,7 @@ jobs:
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           CIBW_PLATFORM: pyodide
+          CIBW_TEST_REQUIRES: pytest pytest-rerunfailures<16
           CIBW_TEST_SOURCES: tests
           CIBW_TEST_COMMAND: pytest -v ./tests --ignore=./tests/test_codebase.py -k "not image and not big"
 

--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Build and test pyodide wheels
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
-          CIBW_PLATFORM: "pyodide"
+          CIBW_PLATFORM: pyodide
+          CIBW_TEST_SOURCES: tests
+          CIBW_TEST_COMMAND: pytest -v ./tests --ignore=./tests/test_codebase.py -k "not image and not big"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
The pyodide testing in CI uses `cibuildwheel` for convenience and it hence picks up the default testing config from `pyproject.toml` which is to just use `test_minimal.py`. This PR increases the test coverage to include all tests that are not image tests (so no Matplotlib or Bokeh), are not labelled "big", and are not codebase tests.