### PR TITLE
Remove setup-python when testing using cibuildwheel

### DIFF
--- a/.github/workflows/test_with_cibuildwheel.yml
+++ b/.github/workflows/test_with_cibuildwheel.yml
@@ -48,11 +48,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: 3.13
-
       - name: Build and test wheels
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:


### PR DESCRIPTION
Remove `setup-python` github action when testing using `cibuildwheel` as it is not needed.